### PR TITLE
Add nonce verification to admin GET action handlers (CSRF fix)

### DIFF
--- a/eme-actions.php
+++ b/eme-actions.php
@@ -134,6 +134,7 @@ function eme_actions_init() {
     }
 
     if ( isset( $_GET['eme_admin_action'] ) && $eme_is_admin_request ) {
+        check_admin_referer( 'eme_admin', 'eme_admin_nonce' );
         if ( $_GET['eme_admin_action'] == 'autocomplete_locations' ) {
             $no_wp_die = 1;
             eme_locations_search_ajax( $no_wp_die );

--- a/eme-events.php
+++ b/eme-events.php
@@ -2500,33 +2500,33 @@ function eme_replace_event_placeholders( $format, $event, $target = 'html', $lan
             } elseif ( preg_match( '/#_PRINTBOOKINGSLINK/', $result ) ) {
                 if ( current_user_can( get_option( 'eme_cap_edit_events' ) ) || 
                     ( current_user_can( get_option( 'eme_cap_list_events' ) ) && ($event['event_author'] == $current_userid || $event['event_contactperson_id'] == $current_userid) ) ) {
-                    $url = admin_url( 'admin.php?page=eme-people&eme_admin_action=booking_printable&event_id=' . $event['event_id'] );
+                    $url = wp_nonce_url( admin_url( 'admin.php?page=eme-people&eme_admin_action=booking_printable&event_id=' . $event['event_id'] ), 'eme_admin', 'eme_admin_nonce' );
                     if ( $target == 'html' ) {
                         $url = esc_url( $url );
                     }
                     $replacement = "<a href='$url'>" . __( 'Printable view of bookings', 'events-made-easy' ) . '</a>';
                 }
             } elseif ( preg_match( '/#_PRINTBOOKINGSURL/', $result ) ) {
-                if ( current_user_can( get_option( 'eme_cap_edit_events' ) ) || 
+                if ( current_user_can( get_option( 'eme_cap_edit_events' ) ) ||
                     ( current_user_can( get_option( 'eme_cap_list_events' ) ) && ($event['event_author'] == $current_userid || $event['event_contactperson_id'] == $current_userid) ) ) {
-                    $replacement = admin_url( 'admin.php?page=eme-people&eme_admin_action=booking_printable&event_id=' . $event['event_id'] );
+                    $replacement = wp_nonce_url( admin_url( 'admin.php?page=eme-people&eme_admin_action=booking_printable&event_id=' . $event['event_id'] ), 'eme_admin', 'eme_admin_nonce' );
                     if ( $target == 'html' ) {
                         $replacement = esc_url( $replacement );
                     }
                 }
             } elseif ( preg_match( '/#_CSVBOOKINGSLINK/', $result ) ) {
-                if ( current_user_can( get_option( 'eme_cap_edit_events' ) ) || 
+                if ( current_user_can( get_option( 'eme_cap_edit_events' ) ) ||
                     ( current_user_can( get_option( 'eme_cap_list_events' ) ) && ($event['event_author'] == $current_userid || $event['event_contactperson_id'] == $current_userid) ) ) {
-                    $url = admin_url( 'admin.php?page=eme-people&eme_admin_action=booking_csv&event_id=' . $event['event_id'] );
+                    $url = wp_nonce_url( admin_url( 'admin.php?page=eme-people&eme_admin_action=booking_csv&event_id=' . $event['event_id'] ), 'eme_admin', 'eme_admin_nonce' );
                     if ( $target == 'html' ) {
                         $url = esc_url( $url );
                     }
                     $replacement = "<a href='$url'>" . __( 'CSV view of bookings', 'events-made-easy' ) . '</a>';
                 }
             } elseif ( preg_match( '/#_CSVBOOKINGSURL/', $result ) ) {
-                if ( current_user_can( get_option( 'eme_cap_edit_events' ) ) || 
+                if ( current_user_can( get_option( 'eme_cap_edit_events' ) ) ||
                     ( current_user_can( get_option( 'eme_cap_list_events' ) ) && ($event['event_author'] == $current_userid || $event['event_contactperson_id'] == $current_userid) ) ) {
-                    $replacement = admin_url( 'admin.php?page=eme-people&eme_admin_action=booking_csv&event_id=' . $event['event_id'] );
+                    $replacement = wp_nonce_url( admin_url( 'admin.php?page=eme-people&eme_admin_action=booking_csv&event_id=' . $event['event_id'] ), 'eme_admin', 'eme_admin_nonce' );
                     if ( $target == 'html' ) {
                         $replacement = esc_url( $replacement );
                     }
@@ -6775,8 +6775,8 @@ function eme_event_form( $event, $info, $edit_recurrence = 0 ) {
                 $info_line .= ' ' . sprintf( __( '(%d waiting list seats included)', 'events-made-easy' ), $waitinglist_seats );
             }
             if ( $booked_seats > 0 || $pending_seats > 0 ) {
-                $printable_address     = admin_url( 'admin.php?page=eme-manager&amp;eme_admin_action=booking_printable&amp;event_id=' . $event['event_id'] );
-                $csv_address           = admin_url( 'admin.php?page=eme-manager&amp;eme_admin_action=booking_csv&amp;event_id=' . $event['event_id'] );
+                $printable_address     = wp_nonce_url( admin_url( 'admin.php?page=eme-manager&amp;eme_admin_action=booking_printable&amp;event_id=' . $event['event_id'] ), 'eme_admin', 'eme_admin_nonce' );
+                $csv_address           = wp_nonce_url( admin_url( 'admin.php?page=eme-manager&amp;eme_admin_action=booking_csv&amp;event_id=' . $event['event_id'] ), 'eme_admin', 'eme_admin_nonce' );
                 $info_line .= "<br>(<a id='booking_printable_" . $event['event_id'] . "' href='$printable_address'>" . __( 'Printable view', 'events-made-easy' ) . '</a>)';
                 $info_line .= " (<a id='booking_csv_" . $event['event_id'] . "' href='$csv_address'>" . __( 'CSV export', 'events-made-easy' ) . '</a>)';
             }
@@ -10380,8 +10380,8 @@ function eme_ajax_events_list() {
                 $record['event_name'] .= ' ' . sprintf( __( '(%d waiting list seats included)', 'events-made-easy' ), $waitinglist_seats );
             }
             if ( $booked_seats > 0 || $pending_seats > 0 ) {
-                $printable_address     = admin_url( 'admin.php?page=eme-manager&amp;eme_admin_action=booking_printable&amp;event_id=' . $event['event_id'] );
-                $csv_address           = admin_url( 'admin.php?page=eme-manager&amp;eme_admin_action=booking_csv&amp;event_id=' . $event['event_id'] );
+                $printable_address     = wp_nonce_url( admin_url( 'admin.php?page=eme-manager&amp;eme_admin_action=booking_printable&amp;event_id=' . $event['event_id'] ), 'eme_admin', 'eme_admin_nonce' );
+                $csv_address           = wp_nonce_url( admin_url( 'admin.php?page=eme-manager&amp;eme_admin_action=booking_csv&amp;event_id=' . $event['event_id'] ), 'eme_admin', 'eme_admin_nonce' );
                 $record['event_name'] .= "<br>(<a id='booking_printable_" . $event['event_id'] . "' href='$printable_address'>" . __( 'Printable view', 'events-made-easy' ) . '</a>)';
                 $record['event_name'] .= " (<a id='booking_csv_" . $event['event_id'] . "' href='$csv_address'>" . __( 'CSV export', 'events-made-easy' ) . '</a>)';
             }

--- a/eme-rsvp.php
+++ b/eme-rsvp.php
@@ -6007,8 +6007,8 @@ function eme_ajax_bookings_list() {
                 }
 
                 if ( $booked_seats > 0 || $pending_seats > 0 ) {
-                    $printable_address            = admin_url( 'admin.php?page=eme-people&amp;eme_admin_action=booking_printable&amp;event_id=' . $event['event_id'] );
-                    $csv_address                  = admin_url( 'admin.php?page=eme-people&amp;eme_admin_action=booking_csv&amp;event_id=' . $event['event_id'] );
+                    $printable_address            = wp_nonce_url( admin_url( 'admin.php?page=eme-people&amp;eme_admin_action=booking_printable&amp;event_id=' . $event['event_id'] ), 'eme_admin', 'eme_admin_nonce' );
+                    $csv_address                  = wp_nonce_url( admin_url( 'admin.php?page=eme-people&amp;eme_admin_action=booking_csv&amp;event_id=' . $event['event_id'] ), 'eme_admin', 'eme_admin_nonce' );
                     $event_name_info[ $event_id ] .= " <br>(<a id='booking_printable_" . $event['event_id'] . "' href='$printable_address'>" . __( 'Printable view', 'events-made-easy' ) . '</a>)';
                     $event_name_info[ $event_id ] .= " (<a id='booking_csv_" . $event['event_id'] . "' href='$csv_address'>" . __( 'CSV export', 'events-made-easy' ) . '</a>)';
                 }

--- a/eme-tasks.php
+++ b/eme-tasks.php
@@ -2139,7 +2139,7 @@ function eme_ajax_task_signups_list() {
             $localized_taskend_date      = eme_localized_datetime( $row['task_end'], EME_TIMEZONE, 1 );
             $localized_signup_date       = eme_localized_datetime( $row['signup_date'], EME_TIMEZONE, 1 );
             $row['event_name']  = "<strong><a href='" . admin_url( 'admin.php?page=eme-manager&amp;eme_admin_action=edit_event&amp;event_id=' . $row['event_id'] ) . "' title='" . __( 'Edit event', 'events-made-easy' ) . "'>" . eme_trans_esc_html( $row['event_name'] ) . '</a></strong><br>' . $localized_start_date . ' - ' . $localized_end_date;
-            $csv_address = admin_url( 'admin.php?page=eme-people&amp;eme_admin_action=tasksignups_csv&amp;event_id=' . $row['event_id'] );
+            $csv_address = wp_nonce_url( admin_url( 'admin.php?page=eme-people&amp;eme_admin_action=tasksignups_csv&amp;event_id=' . $row['event_id'] ), 'eme_admin', 'eme_admin_nonce' );
             $row['event_name'] .= " (<a id='tasksignups_csv_" . $row['event_id'] . "' href='$csv_address'>" . __( 'CSV export', 'events-made-easy' ) . '</a>)';
             $row['task_name']   = eme_esc_html( $row['task_name'] );
             $row['comment']     = nl2br(eme_esc_html( $row['comment'] ));


### PR DESCRIPTION
## WordPress.org Plugin Directory Compliance (1/5)

Related: #919

### Why this change?

The admin GET action handlers in `eme_actions_init()` — specifically `booking_printable`, `booking_csv`, `tasksignups_csv`, and `autocomplete_locations` — only check `$eme_is_admin_request` but do not verify a nonce. This makes them vulnerable to **CSRF (Cross-Site Request Forgery)** attacks, where an attacker could trick an authenticated admin into triggering these actions via a crafted link.

This is also flagged by the [WordPress.org Plugin Check (PCP)](https://wordpress.org/plugins/plugin-check/) security checks, which require nonce verification on all admin actions.

Interestingly, the JavaScript for `autocomplete_locations` already sends the nonce (`eme_admin_nonce` in `js/eme_admin_events.js:563`), but the PHP handler never verified it — this change fixes that gap.

### What changed?

**`eme-actions.php`** (handler side):
- Added `check_admin_referer( 'eme_admin', 'eme_admin_nonce' )` to the `$_GET['eme_admin_action']` handler block

**`eme-events.php`**, **`eme-rsvp.php`**, **`eme-tasks.php`** (link generation side):
- Wrapped all `booking_printable`, `booking_csv`, and `tasksignups_csv` admin URLs with `wp_nonce_url()` so the nonce parameter is included in generated links

### Files changed

| File | Lines | Change |
|------|-------|--------|
| `eme-actions.php` | 137 | Added `check_admin_referer()` |
| `eme-events.php` | 2503, 2512, 2520, 2529, 6778, 6779, 10383, 10384 | `admin_url()` → `wp_nonce_url( admin_url() )` |
| `eme-rsvp.php` | 6010, 6011 | `admin_url()` → `wp_nonce_url( admin_url() )` |
| `eme-tasks.php` | 2142 | `admin_url()` → `wp_nonce_url( admin_url() )` |

### How to test

- [ ] Open an event with bookings in the admin → "Printable view" and "CSV export" links still work
- [ ] Task signups CSV export still works
- [ ] Location autocomplete still works when editing an event
- [ ] Directly accessing a booking_printable URL without a valid nonce shows an error (CSRF protection works)
- [ ] Run Plugin Check (PCP) — nonce verification warnings for these handlers should be resolved