### PR TITLE
Add per-action nonce verification to admin GET handlers (CSRF fix)

### DIFF
--- a/eme-actions.php
+++ b/eme-actions.php
@@ -135,19 +135,23 @@ function eme_actions_init() {
 
     if ( isset( $_GET['eme_admin_action'] ) && $eme_is_admin_request ) {
         if ( $_GET['eme_admin_action'] == 'autocomplete_locations' ) {
+            check_admin_referer( 'eme_admin', 'eme_admin_nonce' );
             $no_wp_die = 1;
             eme_locations_search_ajax( $no_wp_die );
             exit;
         }
         if ( $_GET['eme_admin_action'] == 'booking_printable' && isset( $_GET['event_id'] ) ) {
+            check_admin_referer( 'eme_admin', 'eme_admin_nonce' );
             eme_printable_booking_report( intval( $_GET['event_id'] ) );
             exit();
         }
         if ( $_GET['eme_admin_action'] == 'booking_csv' && isset( $_GET['event_id'] ) ) {
+            check_admin_referer( 'eme_admin', 'eme_admin_nonce' );
             eme_csv_booking_report( intval( $_GET['event_id'] ) );
             exit();
         }
         if ( $_GET['eme_admin_action'] == 'tasksignups_csv' && isset( $_GET['event_id'] ) ) {
+            check_admin_referer( 'eme_admin', 'eme_admin_nonce' );
             eme_csv_tasksignups_report( intval( $_GET['event_id'] ) );
             exit();
         }

--- a/eme-events.php
+++ b/eme-events.php
@@ -2500,7 +2500,7 @@ function eme_replace_event_placeholders( $format, $event, $target = 'html', $lan
             } elseif ( preg_match( '/#_PRINTBOOKINGSLINK/', $result ) ) {
                 if ( current_user_can( get_option( 'eme_cap_edit_events' ) ) || 
                     ( current_user_can( get_option( 'eme_cap_list_events' ) ) && ($event['event_author'] == $current_userid || $event['event_contactperson_id'] == $current_userid) ) ) {
-                    $url = admin_url( 'admin.php?page=eme-people&eme_admin_action=booking_printable&event_id=' . $event['event_id'] );
+                    $url = wp_nonce_url( admin_url( 'admin.php?page=eme-people&eme_admin_action=booking_printable&event_id=' . $event['event_id'] ), 'eme_admin', 'eme_admin_nonce' );
                     if ( $target == 'html' ) {
                         $url = esc_url( $url );
                     }
@@ -2509,7 +2509,7 @@ function eme_replace_event_placeholders( $format, $event, $target = 'html', $lan
             } elseif ( preg_match( '/#_PRINTBOOKINGSURL/', $result ) ) {
                 if ( current_user_can( get_option( 'eme_cap_edit_events' ) ) || 
                     ( current_user_can( get_option( 'eme_cap_list_events' ) ) && ($event['event_author'] == $current_userid || $event['event_contactperson_id'] == $current_userid) ) ) {
-                    $replacement = admin_url( 'admin.php?page=eme-people&eme_admin_action=booking_printable&event_id=' . $event['event_id'] );
+                    $replacement = wp_nonce_url( admin_url( 'admin.php?page=eme-people&eme_admin_action=booking_printable&event_id=' . $event['event_id'] ), 'eme_admin', 'eme_admin_nonce' );
                     if ( $target == 'html' ) {
                         $replacement = esc_url( $replacement );
                     }
@@ -2517,7 +2517,7 @@ function eme_replace_event_placeholders( $format, $event, $target = 'html', $lan
             } elseif ( preg_match( '/#_CSVBOOKINGSLINK/', $result ) ) {
                 if ( current_user_can( get_option( 'eme_cap_edit_events' ) ) || 
                     ( current_user_can( get_option( 'eme_cap_list_events' ) ) && ($event['event_author'] == $current_userid || $event['event_contactperson_id'] == $current_userid) ) ) {
-                    $url = admin_url( 'admin.php?page=eme-people&eme_admin_action=booking_csv&event_id=' . $event['event_id'] );
+                    $url = wp_nonce_url( admin_url( 'admin.php?page=eme-people&eme_admin_action=booking_csv&event_id=' . $event['event_id'] ), 'eme_admin', 'eme_admin_nonce' );
                     if ( $target == 'html' ) {
                         $url = esc_url( $url );
                     }
@@ -2526,7 +2526,7 @@ function eme_replace_event_placeholders( $format, $event, $target = 'html', $lan
             } elseif ( preg_match( '/#_CSVBOOKINGSURL/', $result ) ) {
                 if ( current_user_can( get_option( 'eme_cap_edit_events' ) ) || 
                     ( current_user_can( get_option( 'eme_cap_list_events' ) ) && ($event['event_author'] == $current_userid || $event['event_contactperson_id'] == $current_userid) ) ) {
-                    $replacement = admin_url( 'admin.php?page=eme-people&eme_admin_action=booking_csv&event_id=' . $event['event_id'] );
+                    $replacement = wp_nonce_url( admin_url( 'admin.php?page=eme-people&eme_admin_action=booking_csv&event_id=' . $event['event_id'] ), 'eme_admin', 'eme_admin_nonce' );
                     if ( $target == 'html' ) {
                         $replacement = esc_url( $replacement );
                     }
@@ -6775,8 +6775,8 @@ function eme_event_form( $event, $info, $edit_recurrence = 0 ) {
                 $info_line .= ' ' . sprintf( __( '(%d waiting list seats included)', 'events-made-easy' ), $waitinglist_seats );
             }
             if ( $booked_seats > 0 || $pending_seats > 0 ) {
-                $printable_address     = admin_url( 'admin.php?page=eme-manager&amp;eme_admin_action=booking_printable&amp;event_id=' . $event['event_id'] );
-                $csv_address           = admin_url( 'admin.php?page=eme-manager&amp;eme_admin_action=booking_csv&amp;event_id=' . $event['event_id'] );
+                $printable_address     = wp_nonce_url( admin_url( 'admin.php?page=eme-manager&amp;eme_admin_action=booking_printable&amp;event_id=' . $event['event_id'] ), 'eme_admin', 'eme_admin_nonce' );
+                $csv_address           = wp_nonce_url( admin_url( 'admin.php?page=eme-manager&amp;eme_admin_action=booking_csv&amp;event_id=' . $event['event_id'] ), 'eme_admin', 'eme_admin_nonce' );
                 $info_line .= "<br>(<a id='booking_printable_" . $event['event_id'] . "' href='$printable_address'>" . __( 'Printable view', 'events-made-easy' ) . '</a>)';
                 $info_line .= " (<a id='booking_csv_" . $event['event_id'] . "' href='$csv_address'>" . __( 'CSV export', 'events-made-easy' ) . '</a>)';
             }
@@ -10380,8 +10380,8 @@ function eme_ajax_events_list() {
                 $record['event_name'] .= ' ' . sprintf( __( '(%d waiting list seats included)', 'events-made-easy' ), $waitinglist_seats );
             }
             if ( $booked_seats > 0 || $pending_seats > 0 ) {
-                $printable_address     = admin_url( 'admin.php?page=eme-manager&amp;eme_admin_action=booking_printable&amp;event_id=' . $event['event_id'] );
-                $csv_address           = admin_url( 'admin.php?page=eme-manager&amp;eme_admin_action=booking_csv&amp;event_id=' . $event['event_id'] );
+                $printable_address     = wp_nonce_url( admin_url( 'admin.php?page=eme-manager&amp;eme_admin_action=booking_printable&amp;event_id=' . $event['event_id'] ), 'eme_admin', 'eme_admin_nonce' );
+                $csv_address           = wp_nonce_url( admin_url( 'admin.php?page=eme-manager&amp;eme_admin_action=booking_csv&amp;event_id=' . $event['event_id'] ), 'eme_admin', 'eme_admin_nonce' );
                 $record['event_name'] .= "<br>(<a id='booking_printable_" . $event['event_id'] . "' href='$printable_address'>" . __( 'Printable view', 'events-made-easy' ) . '</a>)';
                 $record['event_name'] .= " (<a id='booking_csv_" . $event['event_id'] . "' href='$csv_address'>" . __( 'CSV export', 'events-made-easy' ) . '</a>)';
             }

--- a/eme-rsvp.php
+++ b/eme-rsvp.php
@@ -6007,8 +6007,8 @@ function eme_ajax_bookings_list() {
                 }
 
                 if ( $booked_seats > 0 || $pending_seats > 0 ) {
-                    $printable_address            = admin_url( 'admin.php?page=eme-people&amp;eme_admin_action=booking_printable&amp;event_id=' . $event['event_id'] );
-                    $csv_address                  = admin_url( 'admin.php?page=eme-people&amp;eme_admin_action=booking_csv&amp;event_id=' . $event['event_id'] );
+                    $printable_address            = wp_nonce_url( admin_url( 'admin.php?page=eme-people&amp;eme_admin_action=booking_printable&amp;event_id=' . $event['event_id'] ), 'eme_admin', 'eme_admin_nonce' );
+                    $csv_address                  = wp_nonce_url( admin_url( 'admin.php?page=eme-people&amp;eme_admin_action=booking_csv&amp;event_id=' . $event['event_id'] ), 'eme_admin', 'eme_admin_nonce' );
                     $event_name_info[ $event_id ] .= " <br>(<a id='booking_printable_" . $event['event_id'] . "' href='$printable_address'>" . __( 'Printable view', 'events-made-easy' ) . '</a>)';
                     $event_name_info[ $event_id ] .= " (<a id='booking_csv_" . $event['event_id'] . "' href='$csv_address'>" . __( 'CSV export', 'events-made-easy' ) . '</a>)';
                 }

--- a/eme-tasks.php
+++ b/eme-tasks.php
@@ -2139,7 +2139,7 @@ function eme_ajax_task_signups_list() {
             $localized_taskend_date      = eme_localized_datetime( $row['task_end'], EME_TIMEZONE, 1 );
             $localized_signup_date       = eme_localized_datetime( $row['signup_date'], EME_TIMEZONE, 1 );
             $row['event_name']  = "<strong><a href='" . admin_url( 'admin.php?page=eme-manager&amp;eme_admin_action=edit_event&amp;event_id=' . $row['event_id'] ) . "' title='" . __( 'Edit event', 'events-made-easy' ) . "'>" . eme_trans_esc_html( $row['event_name'] ) . '</a></strong><br>' . $localized_start_date . ' - ' . $localized_end_date;
-            $csv_address = admin_url( 'admin.php?page=eme-people&amp;eme_admin_action=tasksignups_csv&amp;event_id=' . $row['event_id'] );
+            $csv_address = wp_nonce_url( admin_url( 'admin.php?page=eme-people&amp;eme_admin_action=tasksignups_csv&amp;event_id=' . $row['event_id'] ), 'eme_admin', 'eme_admin_nonce' );
             $row['event_name'] .= " (<a id='tasksignups_csv_" . $row['event_id'] . "' href='$csv_address'>" . __( 'CSV export', 'events-made-easy' ) . '</a>)';
             $row['task_name']   = eme_esc_html( $row['task_name'] );
             $row['comment']     = nl2br(eme_esc_html( $row['comment'] ));


### PR DESCRIPTION
## Context

This PR supersedes #920, which was reverted because it broke discount management and other menu navigation links.

After the revert we invested in a dedicated test setup (static code analysis + containerized runtime tests against a live WordPress instance) to catch these issues before submitting. The test suite specifically checks nonce consistency: it detects whether `eme_actions_init()` uses a blanket or per-action `check_admin_referer()`, then verifies that all affected URLs have matching `wp_nonce_url()` wrapping. Running this against the original #920 approach immediately flagged 54+ navigation URLs that would break — exactly the issue you encountered.

## Root cause of #920

The `eme_admin_action` GET parameter serves a dual purpose:
1. **Navigation** — switching tabs/views (discounts, dgroups, edit_event, states, etc.) — ~54 URLs
2. **Data processing** — actions that process data and `exit()` early in `eme_actions_init()` — exactly 4 actions

PR #920 placed `check_admin_referer()` at the **top** of the `if (isset($_GET['eme_admin_action']))` block, requiring a nonce for *all* URLs — including the ~54 navigation links that never had one. This broke menu navigation.

## What this PR does

Adds `check_admin_referer('eme_admin', 'eme_admin_nonce')` **per-action**, only inside the 4 handlers that actually process data and exit:

| Action | Handler |
|--------|---------|
| `autocomplete_locations` | `eme_locations_search_ajax()` |
| `booking_printable` | `eme_printable_booking_report()` |
| `booking_csv` | `eme_csv_booking_report()` |
| `tasksignups_csv` | `eme_csv_tasksignups_report()` |

All 11 corresponding `admin_url()` calls that generate links to these actions are wrapped with `wp_nonce_url()`.

Navigation-only `eme_admin_action` values are **unaffected** — no nonce required, no links broken.

## Files changed

| File | Change |
|------|--------|
| `eme-actions.php` | `check_admin_referer()` added inside each of the 4 action handlers |
| `eme-events.php` | 8 `admin_url()` calls wrapped with `wp_nonce_url()` |
| `eme-rsvp.php` | 2 `admin_url()` calls wrapped with `wp_nonce_url()` |
| `eme-tasks.php` | 1 `admin_url()` call wrapped with `wp_nonce_url()` |

## Test results

Tested against containerized WordPress 6.7 + PHP 8.2 + MariaDB.

| Suite | Result |
|-------|--------|
| Static analysis (`code-checks.sh`) | 17 passed, 14 failed, 1 warning |
| Runtime tests (`run-tests.sh`) | **54 passed, 0 failed** |

The 14 static analysis failures are **pre-existing** issues (unsanitized `$_GET/$_POST` in SQL, missing ABSPATH in vendor classes) — not introduced by this PR. These are tracked in #919 for future PRs.

<details>
<summary>Full test output</summary>

**Static analysis (`code-checks.sh`)**
```
=== Events Made Easy — Code Analysis ===

[Nonce Consistency]
  PASS  All nonce-verified action URLs (booking/csv/tasksignups) have wp_nonce_url()
  PASS  eme-actions.php per-action check_admin_referer() — all handled action URLs have nonces
  WARN  54 navigation-only URL(s) without nonces (OK — not verified by eme_actions_init)

[Capability Checks]
  PASS  eme-discounts.php — has capability checks for admin actions
  PASS  eme-categories.php — has capability checks for admin actions
  PASS  eme-holidays.php — has capability checks for admin actions
  PASS  eme-templates.php — has capability checks for admin actions
  PASS  eme-formfields.php — has capability checks for admin actions
  PASS  eme-countries.php — has capability checks for admin actions
  PASS  eme-locations.php — has capability checks for admin actions
  PASS  eme-people.php — has capability checks for admin actions
  PASS  eme-members.php — has capability checks for admin actions
  PASS  eme-events.php — has capability checks for admin actions
  PASS  eme-rsvp.php — has capability checks for admin actions
  PASS  eme-cleanup.php — has capability checks for admin actions
  PASS  eme-cron.php — has capability checks for admin actions
  PASS  eme-mailer.php — has capability checks for admin actions
  PASS  eme-attendances.php — has capability checks for admin actions

[Input Sanitization]
  FAIL  eme-categories.php — direct $_GET/$_POST in SQL without $wpdb->prepare()
  FAIL  eme-events.php — direct $_GET/$_POST in SQL without $wpdb->prepare()
  FAIL  eme-formfields.php — direct $_GET/$_POST in SQL without $wpdb->prepare()
  FAIL  eme-functions.php — direct $_GET/$_POST in SQL without $wpdb->prepare()
  FAIL  eme-holidays.php — direct $_GET/$_POST in SQL without $wpdb->prepare()
  FAIL  eme-locations.php — direct $_GET/$_POST in SQL without $wpdb->prepare()
  FAIL  eme-mailer.php — direct $_GET/$_POST in SQL without $wpdb->prepare()
  FAIL  eme-recurrence.php — direct $_GET/$_POST in SQL without $wpdb->prepare()
  FAIL  eme-rsvp.php — direct $_GET/$_POST in SQL without $wpdb->prepare()
  FAIL  eme-tasks.php — direct $_GET/$_POST in SQL without $wpdb->prepare()
  FAIL  eme-templates.php — direct $_GET/$_POST in SQL without $wpdb->prepare()

[ABSPATH Protection]
  FAIL  class-eme-updater.php — missing ABSPATH protection
  FAIL  class-expressivedate.php — missing ABSPATH protection
  FAIL  class-qrcode.php — missing ABSPATH protection

[WP Store Readiness]
  INFO  Unescaped output: ~319 (target: 0)
  INFO  $wpdb without prepare(): ~458 (target: 0)
  INFO  Unsanitized superglobals: ~697 (target: 0)
  INFO  Files with inline <script>: 4 / <style>: 4 (target: 0)
  INFO  Text domain issues: ~0 (target: 0)
  INFO  Unprefixed functions: 2 (target: 0)

=== Results: 17 passed, 14 failed, 1 warnings ===
```

**Runtime tests (`run-tests.sh`)**
```
=== Events Made Easy — Runtime Test Suite (5 layers) ===

[1/5] Smoke Tests
  PASS  Plugin is active
  PASS  No PHP fatal errors in debug.log
  PASS  PHP syntax check (39 files)
  PASS  DB version = 419
  PASS  25 database tables exist
  PASS  10/10 core shortcodes registered
  PASS  2/2 widgets registered
  PASS  REST route registered
  PASS  Events page created

[2/5] Admin Page HTTP Tests
  PASS  eme-manager               → 200 (156046B)
  PASS  eme-locations             → 200 (153112B)
  PASS  eme-people                → 200 (157831B)
  PASS  eme-groups                → 200 (154401B)
  PASS  eme-options               → 200 (171337B)
  PASS  eme-formfields            → 200 (152983B)
  PASS  eme-templates             → 200 (151837B)
  PASS  eme-holidays              → 200 (150747B)
  PASS  eme-countries             → 200 (150646B)
  PASS  eme-emails                → 200 (180721B)
  PASS  eme-attendance-reports    → 200 (151831B)
  PASS  eme-cron                  → 200 (153695B)
  PASS  eme-cleanup               → 200 (153824B)

  Sub-navigation (with nonce):
  PASS  eme-discounts/discounts   → 200 (153657B)
  PASS  eme-discounts/dgroups     → 200 (152253B)
  PASS  eme-countries/countries   → 200 (152520B)
  PASS  eme-countries/states      → 200 (152422B)

  Action URL CSRF protection:
  PASS  booking_printable         → nonce OK (200) / no nonce blocked (403)
  PASS  booking_csv               → nonce OK (200) / no nonce blocked (403)
  PASS  tasksignups_csv           → nonce OK (200) / no nonce blocked (403)

  PHP error monitoring:
  PASS  No new PHP errors during page loads

[3/5] AJAX Endpoint Tests
  PASS  eme_events_list           → 200
  PASS  eme_locations_list        → 200
  PASS  eme_people_list           → 200
  PASS  eme_categories_list       → 200
  PASS  eme_templates_list        → 200
  PASS  eme_countries_list        → 200
  PASS  eme_holidays_list         → 200
  PASS  eme_formfields_list       → 200
  PASS  eme_discounts_list        → 200
  PASS  eme_members_list          → 200
  PASS  eme_bookings_list         → 200
  PASS  eme_memberships_list      → 200

[4/5] Plugin Check — WP Store Readiness
  SKIP  Plugin Check not installed. Run: bash setup.sh

[5/5] CRUD Workflow Tests
  Simple entities:
  PASS  Location create → read → delete (id=34)
  PASS  Category create → read → delete (id=9)
  PASS  Person create → read → trash → cleanup (id=30)
  PASS  Discount create → read → delete (id=9)
  PASS  Template create → read → delete (id=6)
  PASS  Holiday create → read → parse → delete (id=6)
  PASS  Event create → read → verify → delete (id=45)
  Complex workflows:
  PASS  Booking: location → event → person → book → verify → cleanup (id=9)
  PASS  Membership: plan → person → enroll → verify → cleanup (id=9)
  PASS  Group: create → add person → verify → remove → cleanup (id=6)
  Recurring event:
  PASS  Recurrence: weekly → 6:5events → verify → delete

  PHP error monitoring (CRUD):
  PASS  No new PHP errors during CRUD operations

=== Results: 54 passed, 0 failed ===
```

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)