### PR TITLE
Replace eme_trans_esc_html() with WP escaping, wrap admin_url() in esc_url()

### DIFF
--- a/eme-actions.php
+++ b/eme-actions.php
@@ -354,7 +354,7 @@ function eme_register_scripts() {
     $eme_fs_options = get_option('eme_fs');
     $translation_array = [
         'translate_plugin_url'         => EME_PLUGIN_URL,
-        'translate_ajax_url'           => admin_url( 'admin-ajax.php' ),
+        'translate_ajax_url'           => esc_url( admin_url( 'admin-ajax.php' ) ),
         'translate_selectstate'        => __( 'Select state/province', 'events-made-easy' ),
         'translate_selectcountry'      => __( 'Select country', 'events-made-easy' ),
         'translate_frontendnonce'      => wp_create_nonce( 'eme_frontend' ),
@@ -375,7 +375,7 @@ function eme_register_scripts() {
     if ( get_option( 'eme_use_client_clock' ) && ! isset( $_COOKIE['eme_client_time'] ) ) {
         // client clock should be executed asap, so load it in the header, and no defer
         $translation_array = [
-            'translate_ajax_url' => admin_url( 'admin-ajax.php' ),
+            'translate_ajax_url' => esc_url( admin_url( 'admin-ajax.php' ) ),
         ];
         wp_register_script( 'eme-client_clock_submit', EME_PLUGIN_URL . 'js/client-clock.js', [ ], EME_VERSION );
         wp_localize_script( 'eme-client_clock_submit', 'emeclock', $translation_array );
@@ -411,7 +411,7 @@ function eme_register_scripts() {
     }
     $map_is_active = $eme_map_is_active ? 'true' : 'false';
     $translation_array = [
-        'translate_ajax_url'        => admin_url( 'admin-ajax.php' ),
+        'translate_ajax_url'        => esc_url( admin_url( 'admin-ajax.php' ) ),
         'translate_plugin_url'      => EME_PLUGIN_URL,
         'translate_map_is_active'   => $map_is_active,
         'translate_flanguage'       => $language,
@@ -510,7 +510,7 @@ function eme_admin_notices() {
             }
         }
         if ( empty($eme_hello_notice_ignore) && !empty($plugin_page) && preg_match( '/^eme-/', $plugin_page ) ) { ?>
-        <div class="notice-updated notice" style="padding: 10px 10px 10px 10px; border: 1px solid #ddd; background-color:#FFFFE0;"><?php echo sprintf( __( "<p>Hey, <strong>%s</strong>, welcome to <strong>Events Made Easy</strong>! We hope you like it around here.</p><p>Now it's time to insert events lists through <a href='%s' title='Widgets page'>widgets</a>, <a href='%s' title='Template tags documentation'>template tags</a> or <a href='%s' title='Shortcodes documentation'>shortcodes</a>.</p><p>By the way, have you taken a look at the <a href='%s' title='Change settings'>Settings page</a>? That's where you customize the way events and locations are displayed.</p><p>What? Tired of seeing this advice? I hear you, <a href='#' class='eme-dismiss-notice' data-notice='hello' title=\"Don't show this advice again\">click here</a> and you won't see this again!</p>", 'events-made-easy' ), esc_html($current_user->display_name), admin_url( 'widgets.php' ), '//www.e-dynamics.be/wordpress/#template-tags', '//www.e-dynamics.be/wordpress/#shortcodes', admin_url( 'admin.php?page=eme-options' ) ); ?></div>
+        <div class="notice-updated notice" style="padding: 10px 10px 10px 10px; border: 1px solid #ddd; background-color:#FFFFE0;"><?php echo sprintf( __( "<p>Hey, <strong>%s</strong>, welcome to <strong>Events Made Easy</strong>! We hope you like it around here.</p><p>Now it's time to insert events lists through <a href='%s' title='Widgets page'>widgets</a>, <a href='%s' title='Template tags documentation'>template tags</a> or <a href='%s' title='Shortcodes documentation'>shortcodes</a>.</p><p>By the way, have you taken a look at the <a href='%s' title='Change settings'>Settings page</a>? That's where you customize the way events and locations are displayed.</p><p>What? Tired of seeing this advice? I hear you, <a href='#' class='eme-dismiss-notice' data-notice='hello' title=\"Don't show this advice again\">click here</a> and you won't see this again!</p>", 'events-made-easy' ), esc_html($current_user->display_name), esc_url( admin_url( 'widgets.php' ) ), '//www.e-dynamics.be/wordpress/#template-tags', '//www.e-dynamics.be/wordpress/#shortcodes', esc_url( admin_url( 'admin.php?page=eme-options' ) ) ); ?></div>
 <?php
         }
 

--- a/eme-attendances.php
+++ b/eme-attendances.php
@@ -220,7 +220,7 @@ function eme_ajax_attendances_list() {
 				$person_info_shown .= ' ' . $person['firstname'];
 			}
 			$person_info_shown           .= ' (' . $person['email'] . ')';
-			$rows[ $key ]['person']       = "<a href='" . admin_url( 'admin.php?page=eme-people&amp;eme_admin_action=edit_person&amp;person_id=' . $person['person_id'] ) . "' title='" . __( 'Edit person', 'events-made-easy' ) . "'>" . eme_esc_html( $person_info_shown ) . '</a>';
+			$rows[ $key ]['person']       = "<a href='" . esc_url( admin_url( 'admin.php?page=eme-people&eme_admin_action=edit_person&person_id=' . $person['person_id'] ) ) . "' title='" . __( 'Edit person', 'events-made-easy' ) . "'>" . eme_esc_html( $person_info_shown ) . '</a>';
 			$rows[ $key ]['related_name'] = '';
 			if ( $row['type'] == 'event' ) {
 				$event = eme_get_event( $row['related_id'] );
@@ -240,12 +240,12 @@ function eme_ajax_attendances_list() {
 						$datetime .= "$localized_start_time - $localized_end_time";
 					}
 
-					$rows[ $key ]['related_name'] = eme_trans_esc_html( $event['event_name'] ) . "<br>$datetime";
+					$rows[ $key ]['related_name'] = esc_html( eme_translate( $event['event_name'] ) ) . "<br>$datetime";
 				}
 			} elseif ( $row['type'] == 'membership' ) {
 				$membership = eme_get_membership( $row['related_id'] );
 				if ( $membership ) {
-					$rows[ $key ]['related_name'] = eme_trans_esc_html( $membership['name'] );
+					$rows[ $key ]['related_name'] = esc_html( eme_translate( $membership['name'] ) );
 				}
 			} else {
 				$rows[ $key ]['related_name'] = __( 'Manual entry', 'events-made-easy' );

--- a/eme-categories.php
+++ b/eme-categories.php
@@ -507,7 +507,7 @@ function eme_replace_categories_placeholders( $format, $cat = '', $target = 'htm
 
 		if ( $found ) {
 			if ( $target == 'html' ) {
-				$replacement = eme_trans_esc_html( $replacement, $lang );
+				$replacement = esc_html( eme_translate( $replacement, $lang ) );
 				$replacement = apply_filters( 'eme_general', $replacement );
 			} elseif ( $target == 'rss' ) {
 				$replacement = eme_translate( $replacement, $lang );
@@ -570,8 +570,8 @@ function eme_ajax_action_categories_list() {
         if ( empty( $row['category_name'] ) ) {
             $row['category_name'] = __( 'No name', 'events-made-easy' );
         }
-        $record['category_id'] = "<a href='" . wp_nonce_url( admin_url( 'admin.php?page=eme-categories&amp;eme_admin_action=edit_category&amp;category_id=' . $row['category_id'] ), 'eme_admin', 'eme_admin_nonce' ) . "'>" . $row['category_id'] . '</a>';
-        $record['category_name'] = "<a href='" . wp_nonce_url( admin_url( 'admin.php?page=eme-categories&amp;eme_admin_action=edit_category&amp;category_id=' . $row['category_id'] ), 'eme_admin', 'eme_admin_nonce' ) . "'>" . eme_trans_esc_html( $row['category_name'] ) . '</a>';
+        $record['category_id'] = "<a href='" . esc_url( wp_nonce_url( admin_url( 'admin.php?page=eme-categories&eme_admin_action=edit_category&category_id=' . $row['category_id'] ), 'eme_admin', 'eme_admin_nonce' ) ) . "'>" . $row['category_id'] . '</a>';
+        $record['category_name'] = "<a href='" . esc_url( wp_nonce_url( admin_url( 'admin.php?page=eme-categories&eme_admin_action=edit_category&category_id=' . $row['category_id'] ), 'eme_admin', 'eme_admin_nonce' ) ) . "'>" . esc_html( eme_translate( $row['category_name'] ) ) . '</a>';
         $records[] = $record;
     }
     $fTableResult['Result']           = 'OK';

--- a/eme-countries.php
+++ b/eme-countries.php
@@ -490,7 +490,7 @@ function eme_states_edit_layout( $state_id = 0, $message = '' ) {
 		$layout .= "
       <div id='ajax-response'></div>
 
-      <form name='edit_states' id='edit_states' method='post' action='" . admin_url( "admin.php?page=$plugin_page" ) . "'>
+      <form name='edit_states' id='edit_states' method='post' action='" . esc_url( admin_url( "admin.php?page=$plugin_page" ) ) . "'>
       <input type='hidden' name='eme_admin_action' value='do_editstate'>
       <input type='hidden' name='id' value='" . $state_id . "'>
       $nonce_field
@@ -556,7 +556,7 @@ function eme_countries_edit_layout( $country_id = 0, $message = '' ) {
 		$layout .= "
       <div id='ajax-response'></div>
 
-      <form name='edit_countries' id='edit_countries' method='post' action='" . admin_url( "admin.php?page=$plugin_page" ) . "'>
+      <form name='edit_countries' id='edit_countries' method='post' action='" . esc_url( admin_url( "admin.php?page=$plugin_page" ) ) . "'>
       <input type='hidden' name='eme_admin_action' value='do_editcountry'>
       <input type='hidden' name='id' value='" . esc_attr( $country_id ) . "'>
       $nonce_field
@@ -875,7 +875,7 @@ function eme_ajax_countries_list() {
 		$sql  = "SELECT * FROM $table $where $orderby $limit";
 		$rows = $wpdb->get_results( $sql, ARRAY_A );
 		foreach ( $rows as $key => $row ) {
-			$rows[ $key ]['name'] = "<a href='" . wp_nonce_url( admin_url( 'admin.php?page=eme-countries&amp;eme_admin_action=edit_country&amp;id=' . $row['id'] ), 'eme_admin', 'eme_admin_nonce' ) . "'>" . $row['name'] . '</a>';
+			$rows[ $key ]['name'] = "<a href='" . esc_url( wp_nonce_url( admin_url( 'admin.php?page=eme-countries&eme_admin_action=edit_country&id=' . $row['id'] ), 'eme_admin', 'eme_admin_nonce' ) ) . "'>" . $row['name'] . '</a>';
 		}
 		$fTableResult['Result']           = 'OK';
 		$fTableResult['Records']          = $rows;
@@ -903,7 +903,7 @@ function eme_ajax_states_list() {
 		$sql  = "SELECT state.*,country.lang,country.name AS country_name FROM $table AS state LEFT JOIN $countries_table AS country ON state.country_id=country.id $orderby $limit";
 		$rows = $wpdb->get_results( $sql, ARRAY_A );
 		foreach ( $rows as $key => $row ) {
-			$rows[ $key ]['name'] = "<a href='" . wp_nonce_url( admin_url( 'admin.php?page=eme-countries&amp;eme_admin_action=edit_state&amp;id=' . $row['id'] ), 'eme_admin', 'eme_admin_nonce' ) . "'>" . $row['name'] . '</a>';
+			$rows[ $key ]['name'] = "<a href='" . esc_url( wp_nonce_url( admin_url( 'admin.php?page=eme-countries&eme_admin_action=edit_state&id=' . $row['id'] ), 'eme_admin', 'eme_admin_nonce' ) ) . "'>" . $row['name'] . '</a>';
 		}
 
 		$fTableResult['Result']           = 'OK';

--- a/eme-discounts.php
+++ b/eme-discounts.php
@@ -1792,7 +1792,7 @@ function eme_ajax_discounts_list() {
 			$rows[ $key ]['type']             = eme_get_discounttype( $row['type'] );
 				$rows[ $key ]['strcase']      = ( $row['strcase'] == 1 ) ? __( 'Yes', 'events-made-easy' ) : __( 'No', 'events-made-easy' );
 				$rows[ $key ]['use_per_seat'] = ( $row['use_per_seat'] == 1 ) ? __( 'Yes', 'events-made-easy' ) : __( 'No', 'events-made-easy' );
-				$rows[ $key ]['name']         = "<a href='" . wp_nonce_url( admin_url( 'admin.php?page=eme-discounts&amp;eme_admin_action=edit_discount&amp;id=' . $row['id'] ), 'eme_admin', 'eme_admin_nonce' ) . "'>" . $row['name'] . '</a>';
+				$rows[ $key ]['name']         = "<a href='" . esc_url( wp_nonce_url( admin_url( 'admin.php?page=eme-discounts&eme_admin_action=edit_discount&id=' . $row['id'] ), 'eme_admin', 'eme_admin_nonce' ) ) . "'>" . $row['name'] . '</a>';
 		}
 		$fTableResult['Result']           = 'OK';
 		$fTableResult['Records']          = $rows;
@@ -1832,7 +1832,7 @@ function eme_ajax_discountgroups_list() {
 		$sql  = "SELECT * FROM $table $where $orderby $limit";
 		$rows = $wpdb->get_results( $sql, ARRAY_A );
 		foreach ( $rows as $key => $row ) {
-				$rows[ $key ]['name'] = "<a href='" . wp_nonce_url( admin_url( 'admin.php?page=eme-discounts&amp;eme_admin_action=edit_dgroup&amp;id=' . $row['id'] ), 'eme_admin', 'eme_admin_nonce' ) . "'>" . $row['name'] . '</a>';
+				$rows[ $key ]['name'] = "<a href='" . esc_url( wp_nonce_url( admin_url( 'admin.php?page=eme-discounts&eme_admin_action=edit_dgroup&id=' . $row['id'] ), 'eme_admin', 'eme_admin_nonce' ) ) . "'>" . $row['name'] . '</a>';
 		}
 		$fTableResult['Result']           = 'OK';
 		$fTableResult['Records']          = $rows;

--- a/eme-events.php
+++ b/eme-events.php
@@ -1736,10 +1736,10 @@ add_filter( 'template_include', 'eme_single_event_page_template', 99 );
 function eme_edit_post_link( $data ) {
     if ( eme_is_single_event_page() ) {
         $event_id = eme_sanitize_request( get_query_var( 'event_id' ) );
-        return admin_url( 'admin.php?page=eme-manager&amp;eme_admin_action=edit_event&amp;event_id=' . $event_id );
+        return esc_url( admin_url( 'admin.php?page=eme-manager&eme_admin_action=edit_event&event_id=' . $event_id ) );
     } elseif ( eme_is_single_location_page() ) {
         $location_id = eme_sanitize_request( get_query_var( 'location_id' ) );
-        return admin_url( 'admin.php?page=eme-locations&amp;eme_admin_action=edit_location&amp;location_id=' . $location_id );
+        return esc_url( admin_url( 'admin.php?page=eme-locations&eme_admin_action=edit_location&location_id=' . $location_id ) );
     } else {
         return $data;
     }
@@ -2483,10 +2483,7 @@ function eme_replace_event_placeholders( $format, $event, $target = 'html', $lan
             if ( preg_match( '/#_EDITEVENTLINK/', $result ) ) {
                 if ( current_user_can( get_option( 'eme_cap_edit_events' ) ) ||
                     ( current_user_can( get_option( 'eme_cap_author_event' ) ) && $event['event_author'] == $current_userid ) ) {
-                    $url = admin_url( 'admin.php?page=eme-manager&eme_admin_action=edit_event&event_id=' . $event['event_id'] );
-                    if ( $target == 'html' ) {
-                        $url = esc_url( $url );
-                    }
+                    $url = esc_url( admin_url( 'admin.php?page=eme-manager&eme_admin_action=edit_event&event_id=' . $event['event_id'] ) );
                     $replacement = "<a href='$url'>" . __( 'Edit', 'events-made-easy' ) . '</a>';
                 }
             } elseif ( preg_match( '/#_EDITEVENTURL/', $result ) ) {
@@ -2500,14 +2497,11 @@ function eme_replace_event_placeholders( $format, $event, $target = 'html', $lan
             } elseif ( preg_match( '/#_PRINTBOOKINGSLINK/', $result ) ) {
                 if ( current_user_can( get_option( 'eme_cap_edit_events' ) ) || 
                     ( current_user_can( get_option( 'eme_cap_list_events' ) ) && ($event['event_author'] == $current_userid || $event['event_contactperson_id'] == $current_userid) ) ) {
-                    $url = admin_url( 'admin.php?page=eme-people&eme_admin_action=booking_printable&event_id=' . $event['event_id'] );
-                    if ( $target == 'html' ) {
-                        $url = esc_url( $url );
-                    }
+                    $url = esc_url( admin_url( 'admin.php?page=eme-people&eme_admin_action=booking_printable&event_id=' . $event['event_id'] ) );
                     $replacement = "<a href='$url'>" . __( 'Printable view of bookings', 'events-made-easy' ) . '</a>';
                 }
             } elseif ( preg_match( '/#_PRINTBOOKINGSURL/', $result ) ) {
-                if ( current_user_can( get_option( 'eme_cap_edit_events' ) ) || 
+                if ( current_user_can( get_option( 'eme_cap_edit_events' ) ) ||
                     ( current_user_can( get_option( 'eme_cap_list_events' ) ) && ($event['event_author'] == $current_userid || $event['event_contactperson_id'] == $current_userid) ) ) {
                     $replacement = admin_url( 'admin.php?page=eme-people&eme_admin_action=booking_printable&event_id=' . $event['event_id'] );
                     if ( $target == 'html' ) {
@@ -2517,14 +2511,11 @@ function eme_replace_event_placeholders( $format, $event, $target = 'html', $lan
             } elseif ( preg_match( '/#_CSVBOOKINGSLINK/', $result ) ) {
                 if ( current_user_can( get_option( 'eme_cap_edit_events' ) ) || 
                     ( current_user_can( get_option( 'eme_cap_list_events' ) ) && ($event['event_author'] == $current_userid || $event['event_contactperson_id'] == $current_userid) ) ) {
-                    $url = admin_url( 'admin.php?page=eme-people&eme_admin_action=booking_csv&event_id=' . $event['event_id'] );
-                    if ( $target == 'html' ) {
-                        $url = esc_url( $url );
-                    }
+                    $url = esc_url( admin_url( 'admin.php?page=eme-people&eme_admin_action=booking_csv&event_id=' . $event['event_id'] ) );
                     $replacement = "<a href='$url'>" . __( 'CSV view of bookings', 'events-made-easy' ) . '</a>';
                 }
             } elseif ( preg_match( '/#_CSVBOOKINGSURL/', $result ) ) {
-                if ( current_user_can( get_option( 'eme_cap_edit_events' ) ) || 
+                if ( current_user_can( get_option( 'eme_cap_edit_events' ) ) ||
                     ( current_user_can( get_option( 'eme_cap_list_events' ) ) && ($event['event_author'] == $current_userid || $event['event_contactperson_id'] == $current_userid) ) ) {
                     $replacement = admin_url( 'admin.php?page=eme-people&eme_admin_action=booking_csv&event_id=' . $event['event_id'] );
                     if ( $target == 'html' ) {
@@ -2897,7 +2888,7 @@ function eme_replace_event_placeholders( $format, $event, $target = 'html', $lan
                 }
                 if ( $target == 'html' ) {
                     $event_link  = esc_url( $event_link );
-                    $replacement = "<a href='$event_link' $linktarget title='" . eme_trans_esc_html( $event['event_name'], $lang ) . "'>" . eme_trans_esc_html( $event['event_name'], $lang ) . '</a>';
+                    $replacement = "<a href='$event_link' $linktarget title='" . esc_attr( eme_translate( $event['event_name'], $lang ) ) . "'>" . esc_html( eme_translate( $event['event_name'], $lang ) ) . '</a>';
                 } else {
                     $replacement = eme_translate( $event['event_name'], $lang );
                 }
@@ -3000,7 +2991,7 @@ function eme_replace_event_placeholders( $format, $event, $target = 'html', $lan
                     if ( $target == 'html' ) {
                         $url = esc_url( $url );
                     }
-                    $replacement = "<img src='$url' alt='" . eme_trans_esc_html( $event['event_name'], $lang ) . "'>";
+                    $replacement = "<img src='$url' alt='" . esc_attr( eme_translate( $event['event_name'], $lang ) ) . "'>";
                 }
                 if ( ! empty( $replacement ) ) {
                     if ( $target == 'html' ) {
@@ -3064,7 +3055,7 @@ function eme_replace_event_placeholders( $format, $event, $target = 'html', $lan
                 if ( isset( $event[ $tmp_attkey ] ) && ! is_array( $event[ $tmp_attkey ] ) ) {
                     $replacement = $event[ $tmp_attkey ];
                     if ( $target == 'html' ) {
-                        $replacement = eme_trans_esc_html( $replacement, $lang );
+                        $replacement = esc_html( eme_translate( $replacement, $lang ) );
                         $replacement = apply_filters( 'eme_general', $replacement );
                     } elseif ( $target == 'rss' ) {
                         $replacement = eme_translate( $replacement, $lang );
@@ -3081,7 +3072,7 @@ function eme_replace_event_placeholders( $format, $event, $target = 'html', $lan
                 if ( ! empty( $tmp_event ) && isset( $tmp_event['event_attributes'][ $tmp_event_attkey ] ) ) {
                     $replacement = $tmp_event['event_attributes'][ $tmp_event_attkey ];
                     if ( $target == 'html' ) {
-                        $replacement = eme_trans_esc_html( $replacement, $lang );
+                        $replacement = esc_html( eme_translate( $replacement, $lang ) );
                         $replacement = apply_filters( 'eme_general', $replacement );
                     } elseif ( $target == 'rss' ) {
                         $replacement = eme_translate( $replacement, $lang );
@@ -3096,7 +3087,7 @@ function eme_replace_event_placeholders( $format, $event, $target = 'html', $lan
                 $formfield = eme_get_formfield( $field_key );
                 if ( ! empty( $formfield ) ) {
                     if ( $target == 'html' ) {
-                        $replacement = eme_trans_esc_html( $formfield['field_name'], $lang );
+                        $replacement = esc_html( eme_translate( $formfield['field_name'], $lang ) );
                         $replacement = apply_filters( 'eme_general', $replacement );
                     } else {
                         $replacement = eme_translate( $formfield['field_name'], $lang );
@@ -3179,7 +3170,7 @@ function eme_replace_event_placeholders( $format, $event, $target = 'html', $lan
                     $replacement = $event[ $field ];
                 }
                 if ( $target == 'html' ) {
-                    $replacement = eme_trans_esc_html( $replacement, $lang );
+                    $replacement = esc_html( eme_translate( $replacement, $lang ) );
                     $replacement = apply_filters( 'eme_general', $replacement );
                 } elseif ( $target == 'rss' ) {
                     $replacement = eme_translate( $replacement, $lang );
@@ -3553,7 +3544,7 @@ function eme_replace_event_placeholders( $format, $event, $target = 'html', $lan
             } elseif ( preg_match( '/#_CATEGORYIDS$/', $result ) && get_option( 'eme_categories_enabled' ) ) {
                 $category_ids = $event['event_category_ids'];
                 if ( $target == 'html' ) {
-                    $replacement = eme_trans_esc_html( $category_ids, $lang );
+                    $replacement = esc_html( eme_translate( $category_ids, $lang ) );
                     $replacement = apply_filters( 'eme_general', $replacement );
                 } elseif ( $target == 'rss' ) {
                     $replacement = eme_translate( $category_ids, $lang );
@@ -3569,7 +3560,7 @@ function eme_replace_event_placeholders( $format, $event, $target = 'html', $lan
                 $cat_names = array_column( $event_categories, 'category_name' );
                 foreach ( $cat_names as $key => $cat_name ) {
                     if ( $target == 'html' ) {
-                        $cat_names[ $key ] = eme_trans_esc_html( $cat_name, $lang );
+                        $cat_names[ $key ] = esc_html( eme_translate( $cat_name, $lang ) );
                     } else {
                         $cat_names[ $key ] = eme_translate( $cat_name, $lang );
                     }
@@ -3592,7 +3583,7 @@ function eme_replace_event_placeholders( $format, $event, $target = 'html', $lan
                 }
                 $cat_names = array_column( $event_categories, 'category_name' );
                 if ( $target == 'html' ) {
-                    $replacement = eme_trans_esc_html( join( ' ', $cat_names ), $lang );
+                    $replacement = esc_html( eme_translate( join( ' ', $cat_names ), $lang ) );
                     $replacement = apply_filters( 'eme_general', $replacement );
                 } elseif ( $target == 'rss' ) {
                     $replacement = eme_translate( join( ' ', $cat_names ), $lang );
@@ -3628,7 +3619,7 @@ function eme_replace_event_placeholders( $format, $event, $target = 'html', $lan
                     $cat_name = $category['category_name'];
                     if ( $target == 'html' ) {
                         $cat_link = esc_url( $cat_link );
-                        $cat_links[] = "<a href='$cat_link' title='" . eme_trans_esc_html( $cat_name, $lang ) . "'>" . eme_trans_esc_html( $cat_name, $lang ) . '</a>';
+                        $cat_links[] = "<a href='$cat_link' title='" . esc_attr( eme_translate( $cat_name, $lang ) ) . "'>" . esc_html( eme_translate( $cat_name, $lang ) ) . '</a>';
                     } else {
                         $cat_links[] = eme_translate( $cat_name, $lang );
                     }
@@ -3662,7 +3653,7 @@ function eme_replace_event_placeholders( $format, $event, $target = 'html', $lan
                 $cat_names        = [];
                 foreach ( $t_categories as $cat_name ) {
                     if ( $target == 'html' ) {
-                        $cat_names[] = eme_trans_esc_html( $cat_name, $lang );
+                        $cat_names[] = esc_html( eme_translate( $cat_name, $lang ) );
                     } else {
                         $cat_names[] = eme_translate( $cat_name, $lang );
                     }
@@ -3694,7 +3685,7 @@ function eme_replace_event_placeholders( $format, $event, $target = 'html', $lan
                 $extra_conditions = join( ' AND ', $extra_conditions_arr );
                 $t_categories     = eme_get_event_category_names( $event['event_id'], $extra_conditions, $order_by );
                 if ( $target == 'html' ) {
-                    $replacement = eme_trans_esc_html( join( ' ', $t_categories ), $lang );
+                    $replacement = esc_html( eme_translate( join( ' ', $t_categories ), $lang ) );
                     $replacement = apply_filters( 'eme_general', $replacement );
                 } elseif ( $target == 'rss' ) {
                     $replacement = eme_translate( join( ' ', $t_categories ), $lang );
@@ -3749,7 +3740,7 @@ function eme_replace_event_placeholders( $format, $event, $target = 'html', $lan
                     $cat_name = $category['category_name'];
                     if ( $target == 'html' ) {
                         $cat_link = esc_url( $cat_link );
-                        $cat_links[] = "<a href='$cat_link' title='" . eme_trans_esc_html( $cat_name, $lang ) . "'>" . eme_trans_esc_html( $cat_name, $lang ) . '</a>';
+                        $cat_links[] = "<a href='$cat_link' title='" . esc_attr( eme_translate( $cat_name, $lang ) ) . "'>" . esc_html( eme_translate( $cat_name, $lang ) ) . '</a>';
                     } else {
                         $cat_links[] = eme_translate( $cat_name, $lang );
                     }
@@ -6072,7 +6063,7 @@ function eme_events_table( $message = '' ) {
     <?php if ( current_user_can( get_option( 'eme_cap_add_event' ) ) ) : ?>
     <h1><?php esc_html_e( 'Add a new event', 'events-made-easy' ); ?></h1>
     <div class="wrap">
-        <form id="locations-filter" method="post" action="<?php echo admin_url( 'admin.php?page=eme-manager' ); ?>">
+        <form id="locations-filter" method="post" action="<?php echo esc_url( admin_url( 'admin.php?page=eme-manager' ) ); ?>">
         <input type="hidden" name="eme_admin_action" value="add_new_event">
         <input type="submit" class="button-primary" name="submit" value="<?php esc_attr_e( 'Add event', 'events-made-easy' ); ?>">
         </form>
@@ -6080,13 +6071,13 @@ function eme_events_table( $message = '' ) {
 <?php endif; ?>
 
     <h1><?php esc_html_e( 'Manage events', 'events-made-easy' ); ?>
-        <a href="<?php echo admin_url( "admin.php?page=$plugin_page&recurrences=1" ); ?>"><?php esc_html_e( 'Manage recurrences', 'events-made-easy' ); ?></a><br>
+        <a href="<?php echo esc_url( admin_url( "admin.php?page=$plugin_page&recurrences=1" ) ); ?>"><?php esc_html_e( 'Manage recurrences', 'events-made-easy' ); ?></a><br>
     </h1>
 
     <?php if ( isset( $_GET['trash'] ) && $_GET['trash'] == 1 ) { ?>
-        <a href="<?php echo admin_url( "admin.php?page=$plugin_page" ); ?>"><?php esc_html_e( 'Show regular content', 'events-made-easy' ); ?></a><br>
+        <a href="<?php echo esc_url( admin_url( "admin.php?page=$plugin_page" ) ); ?>"><?php esc_html_e( 'Show regular content', 'events-made-easy' ); ?></a><br>
     <?php } else { ?>
-        <a href="<?php echo admin_url( "admin.php?page=$plugin_page&trash=1" ); ?>"><?php esc_html_e( 'Show trash content', 'events-made-easy' ); ?></a><br>
+        <a href="<?php echo esc_url( admin_url( "admin.php?page=$plugin_page&trash=1" ) ); ?>"><?php esc_html_e( 'Show trash content', 'events-made-easy' ); ?></a><br>
         <?php if ( current_user_can( get_option( 'eme_cap_cleanup' ) ) ) { ?>
         <span class="eme_import_form_img">
             <?php esc_html_e( 'Click on the icon to show the import form', 'events-made-easy' ); ?>
@@ -6254,7 +6245,7 @@ function eme_recurrences_table( $message = '' ) {
     <?php if ( current_user_can( get_option( 'eme_cap_add_event' ) ) ) : ?>
     <h1><?php esc_html_e( 'Add a new recurrence', 'events-made-easy' ); ?></h1>
     <div class="wrap">
-        <form id="locations-filter" method="post" action="<?php echo admin_url( 'admin.php?page=eme-manager' ); ?>">
+        <form id="locations-filter" method="post" action="<?php echo esc_url( admin_url( 'admin.php?page=eme-manager' ) ); ?>">
         <input type="hidden" name="eme_admin_action" value="add_new_recurrence">
         <input type="submit" class="button-primary" name="submit" value="<?php esc_html_e( 'Add recurrence', 'events-made-easy' ); ?>">
         </form>
@@ -6262,7 +6253,7 @@ function eme_recurrences_table( $message = '' ) {
 <?php endif; ?>
 
     <h1><?php esc_html_e( 'Manage recurrences', 'events-made-easy' ); ?>
-        <a href="<?php echo admin_url( "admin.php?page=$plugin_page" ); ?>"><?php esc_html_e( 'Manage events', 'events-made-easy' ); ?></a><br>
+        <a href="<?php echo esc_url( admin_url( "admin.php?page=$plugin_page" ) ); ?>"><?php esc_html_e( 'Manage events', 'events-made-easy' ); ?></a><br>
     </h1>
 
     <form method='post' action="#">
@@ -6424,7 +6415,7 @@ function eme_event_form( $event, $info, $edit_recurrence = 0 ) {
             esc_html_e( 'WARNING: This event is part of a recurrence.', 'events-made-easy' );
             echo '<br>';
             esc_html_e( 'If you change this event, it will become an independent event and be removed from the recurrence.', 'events-made-easy' );
-            echo "<br> <a href='" . admin_url( 'admin.php?page=eme-manager&amp;eme_admin_action=edit_recurrence&amp;recurrence_id=' . $event['recurrence_id'] ) . "'>";
+            echo "<br> <a href='" . esc_url( admin_url( 'admin.php?page=eme-manager&eme_admin_action=edit_recurrence&recurrence_id=' . $event['recurrence_id'] ) ) . "'>";
             esc_html_e( 'Edit Recurrence', 'events-made-easy' );
             echo '</a>';
         }
@@ -6746,19 +6737,19 @@ function eme_event_form( $event, $info, $edit_recurrence = 0 ) {
                     $available_seats_string = $available_seats;
                 }
                 $info_line .= __( 'Free:', 'events-made-easy' ) . ' ' . $available_seats_string;
-                $info_line .= ', ' . "<a href='" . admin_url( 'admin.php?page=eme-registration-seats&amp;event_id=' . $event['event_id'] ) . "'>" . __( 'Approved:', 'events-made-easy' ) . " $booked_seats_string</a>";
+                $info_line .= ', ' . "<a href='" . esc_url( admin_url( 'admin.php?page=eme-registration-seats&event_id=' . $event['event_id'] ) ) . "'>" . __( 'Approved:', 'events-made-easy' ) . " $booked_seats_string</a>";
             } else {
                 $total_seats_string    = '&infin;';
-                $info_line .= "<a href='" . admin_url( 'admin.php?page=eme-registration-seats&amp;event_id=' . $event['event_id'] ) . "'>" . __( 'Approved:', 'events-made-easy' ) . "  $booked_seats_string</a>";
+                $info_line .= "<a href='" . esc_url( admin_url( 'admin.php?page=eme-registration-seats&event_id=' . $event['event_id'] ) ) . "'>" . __( 'Approved:', 'events-made-easy' ) . "  $booked_seats_string</a>";
             }
 
             if ( $pending_seats > 0 ) {
-                $info_line .= ', ' . "<a href='" . admin_url( 'admin.php?page=eme-registration-approval&amp;event_id=' . $event['event_id'] ) . "'>" . __( 'Pending:', 'events-made-easy' ) . " $pending_seats_string</a>";
+                $info_line .= ', ' . "<a href='" . esc_url( admin_url( 'admin.php?page=eme-registration-approval&event_id=' . $event['event_id'] ) ) . "'>" . __( 'Pending:', 'events-made-easy' ) . " $pending_seats_string</a>";
             }
             if ( $event['event_properties']['take_attendance'] ) {
                 $absent_bookings = eme_get_absent_bookings( $event['event_id'] );
                 if ( $absent_bookings > 0 ) {
-                    $info_line .= ', ' . "<a href='" . admin_url( 'admin.php?page=eme-registration-seats&amp;event_id=' . $event['event_id'] ) . "'>" . __( 'Absent:', 'events-made-easy' ) . " $absent_bookings</a>";
+                    $info_line .= ', ' . "<a href='" . esc_url( admin_url( 'admin.php?page=eme-registration-seats&event_id=' . $event['event_id'] ) ) . "'>" . __( 'Absent:', 'events-made-easy' ) . " $absent_bookings</a>";
                 }
             }
 	    $location = eme_get_location( $event['location_id'] );
@@ -6773,10 +6764,10 @@ function eme_event_form( $event, $info, $edit_recurrence = 0 ) {
                 $info_line .= ' ' . sprintf( __( '(%d waiting list seats included)', 'events-made-easy' ), $waitinglist_seats );
             }
             if ( $booked_seats > 0 || $pending_seats > 0 ) {
-                $printable_address     = admin_url( 'admin.php?page=eme-manager&amp;eme_admin_action=booking_printable&amp;event_id=' . $event['event_id'] );
-                $csv_address           = admin_url( 'admin.php?page=eme-manager&amp;eme_admin_action=booking_csv&amp;event_id=' . $event['event_id'] );
-                $info_line .= "<br>(<a id='booking_printable_" . $event['event_id'] . "' href='".esc_url($printable_address)."'>" . __( 'Printable view', 'events-made-easy' ) . '</a>)';
-                $info_line .= " (<a id='booking_csv_" . $event['event_id'] . "' href='".esc_url($csv_address)."'>" . __( 'CSV export', 'events-made-easy' ) . '</a>)';
+                $printable_address     = esc_url( admin_url( 'admin.php?page=eme-manager&eme_admin_action=booking_printable&event_id=' . $event['event_id'] ) );
+                $csv_address           = esc_url( admin_url( 'admin.php?page=eme-manager&eme_admin_action=booking_csv&event_id=' . $event['event_id'] ) );
+                $info_line .= "<br>(<a id='booking_printable_" . $event['event_id'] . "' href='".$printable_address."'>" . __( 'Printable view', 'events-made-easy' ) . '</a>)';
+                $info_line .= " (<a id='booking_csv_" . $event['event_id'] . "' href='".$csv_address."'>" . __( 'CSV export', 'events-made-easy' ) . '</a>)';
             }
         }
 
@@ -6799,9 +6790,9 @@ function eme_event_form( $event, $info, $edit_recurrence = 0 ) {
                 }
                 $info_line .= sprintf( __('Task Info: %d tasks', 'events-made-easy' ), $task_count );
                 if ( $pending_spaces >0 ) {
-                    $info_line .= ', ' . "<a href='" . admin_url( 'admin.php?page=eme-task-signups&amp;status=0&amp;event_id=' . $event['event_id'] ) . "'>" . __( 'Pending:', 'events-made-easy' ) . " $pending_spaces</a>";
+                    $info_line .= ', ' . "<a href='" . esc_url( admin_url( 'admin.php?page=eme-task-signups&status=0&event_id=' . $event['event_id'] ) ) . "'>" . __( 'Pending:', 'events-made-easy' ) . " $pending_spaces</a>";
                 }
-                $info_line .= ', ' . "<a href='" . admin_url( 'admin.php?page=eme-task-signups&amp;status=1&amp;event_id=' . $event['event_id'] ) . "'>" . __( 'Approved:', 'events-made-easy' ) . " $used_spaces</a>";
+                $info_line .= ', ' . "<a href='" . esc_url( admin_url( 'admin.php?page=eme-task-signups&status=1&event_id=' . $event['event_id'] ) ) . "'>" . __( 'Approved:', 'events-made-easy' ) . " $used_spaces</a>";
             }
         }
         print $info_line; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- HTML with admin URLs and translated strings
@@ -8533,7 +8524,7 @@ function eme_meta_box_div_event_customfields( $event ) {
     }
 
     foreach ( $formfields as $formfield ) {
-        $field_name     = eme_trans_esc_html( $formfield['field_name'] );
+        $field_name     = esc_html( eme_translate( $formfield['field_name'] ) );
         $field_id       = $formfield['field_id'];
         $postfield_name = 'FIELD' . $field_id;
         $entered_val    = '';
@@ -9537,7 +9528,7 @@ function eme_admin_enqueue_js() {
         remove_action( 'admin_enqueue_scripts', 'widgetopts_load_admin_scripts', 100 );
         $translation_array = [
             'translate_plugin_url'         => esc_url(EME_PLUGIN_URL),
-            'translate_ajax_url'           => admin_url( 'admin-ajax.php' ),
+            'translate_ajax_url'           => esc_url( admin_url( 'admin-ajax.php' ) ),
             'translate_selectstate'        => __( 'Select state/province', 'events-made-easy' ),
             'translate_selectcountry'      => __( 'Select country', 'events-made-easy' ),
             'translate_frontendnonce'      => wp_create_nonce( 'eme_frontend' ),
@@ -9691,7 +9682,7 @@ function eme_admin_enqueue_js() {
             'translate_pleasewait'                 => __( 'Please wait', 'events-made-easy' ),
             'translate_apply'                      => __( 'Apply', 'events-made-easy' ),
             'translate_areyousuretodeleteselected' => __( 'Are you sure to delete the selected records?', 'events-made-easy' ),
-            'translate_admin_sendmails_url'        => admin_url( 'admin.php?page=eme-emails' ),
+            'translate_admin_sendmails_url'        => esc_url( admin_url( 'admin.php?page=eme-emails' ) ),
             'translate_adminnonce'                 => wp_create_nonce( 'eme_admin' ),
             'translate_tasksignup_status'          => __( 'Status', 'events-made-easy' ),
             'translate_tasksignup_date'            => __( 'Signup date', 'events-made-easy' ),
@@ -9870,7 +9861,7 @@ function eme_admin_enqueue_js() {
             'translate_publicgroup'                => __( 'Public group', 'events-made-easy' ),
             'translate_groupcount'                 => __( 'Nbr People', 'events-made-easy' ),
             'translate_adminnonce'                 => wp_create_nonce( 'eme_admin' ),
-            'translate_admin_sendmails_url'        => admin_url( 'admin.php?page=eme-emails' ),
+            'translate_admin_sendmails_url'        => esc_url( admin_url( 'admin.php?page=eme-emails' ) ),
         ];
         wp_localize_script( 'eme-people', 'emepeople', $translation_array );
         wp_enqueue_script( 'eme-people' );
@@ -9925,7 +9916,7 @@ function eme_admin_enqueue_js() {
             'translate_nbrreminder'                => __( 'Reminders sent', 'events-made-easy' ),
             'translate_status'                     => __( 'Status', 'events-made-easy' ),
             'translate_adminnonce'                 => wp_create_nonce( 'eme_admin' ),
-            'translate_admin_sendmails_url'        => admin_url( 'admin.php?page=eme-emails' ),
+            'translate_admin_sendmails_url'        => esc_url( admin_url( 'admin.php?page=eme-emails' ) ),
             'translate_addatachments'              => __( 'Add attachments', 'events-made-easy' ),
             'translate_discount'                   => __( 'Discount', 'events-made-easy' ),
             'translate_dcodes_used'                => __( 'Used discount codes', 'events-made-easy' ),
@@ -9973,7 +9964,7 @@ function eme_admin_enqueue_js() {
             'translate_apply'                      => __( 'Apply', 'events-made-easy' ),
             'translate_areyousuretodeleteselected' => __( 'Are you sure to delete the selected records?', 'events-made-easy' ),
             'translate_adminnonce'                 => wp_create_nonce( 'eme_admin' ),
-            'translate_admin_sendmails_url'        => admin_url( 'admin.php?page=eme-emails' ),
+            'translate_admin_sendmails_url'        => esc_url( admin_url( 'admin.php?page=eme-emails' ) ),
             'translate_attend_count'               => __( 'Attendance count', 'events-made-easy' ),
             'translate_selectonerowonlyforpartial' => __( 'Please select only one record in order to do partial payments', 'events-made-easy' ),
         ];
@@ -10048,7 +10039,7 @@ function eme_admin_enqueue_js() {
             'translate_addatachments'   => __( 'Add attachments', 'events-made-easy' ),
             'translate_selecteddates'   => __( 'Selected dates:', 'events-made-easy' ),
             'translate_adminnonce'      => wp_create_nonce( 'eme_admin' ),
-            'translate_admin_sendmails_url'        => admin_url( 'admin.php?page=eme-emails' ),
+            'translate_admin_sendmails_url'        => esc_url( admin_url( 'admin.php?page=eme-emails' ) ),
         ];
         wp_localize_script( 'eme-sendmails', 'ememails', $translation_array );
         wp_enqueue_script( 'eme-sendmails' );
@@ -10256,9 +10247,9 @@ function eme_ajax_events_list() {
         $date_obj = new emeExpressiveDate( $event['event_start'], EME_TIMEZONE );
 
         if ($no_edit_links==1) {
-            $record['event_name'] = "<strong>" . eme_trans_esc_html( $event['event_name'] ) . '</strong>';
+            $record['event_name'] = "<strong>" . esc_html( eme_translate( $event['event_name'] ) ) . '</strong>';
         } else {
-            $record['event_name'] = "<strong><a href='" . admin_url( 'admin.php?page=eme-manager&amp;eme_admin_action=edit_event&amp;event_id=' . $event['event_id'] ) . "' title='" . __( 'Edit event', 'events-made-easy' ) . "'>" . eme_trans_esc_html( $event['event_name'] ) . '</a></strong>';
+            $record['event_name'] = "<strong><a href='" . esc_url( admin_url( 'admin.php?page=eme-manager&eme_admin_action=edit_event&event_id=' . $event['event_id'] ) ) . "' title='" . __( 'Edit event', 'events-made-easy' ) . "'>" . esc_html( eme_translate( $event['event_name'] ) ) . '</a></strong>';
         }
         if ( ! empty( $event['event_category_ids'] ) ) {
             $categories            = explode( ',', $event['event_category_ids'] );
@@ -10267,7 +10258,7 @@ function eme_ajax_events_list() {
             foreach ( $categories as $cat ) {
                 $category = eme_get_category( $cat );
                 if ( $category ) {
-                    $cat_names[] = eme_trans_esc_html( $category['category_name'] );
+                    $cat_names[] = esc_html( eme_translate( $category['category_name'] ) );
                 }
             }
             $record['event_name'] .= implode( ', ', $cat_names );
@@ -10306,14 +10297,14 @@ function eme_ajax_events_list() {
                 if ($no_edit_links==1) {
                     $record['event_name'] .= ', ' . __( 'Approved:', 'events-made-easy' ) . " $booked_seats_string";
                 } else {
-                    $record['event_name'] .= ', ' . "<a href='" . admin_url( 'admin.php?page=eme-registration-seats&amp;event_id=' . $event['event_id'] ) . "'>" . __( 'Approved:', 'events-made-easy' ) . " $booked_seats_string</a>";
+                    $record['event_name'] .= ', ' . "<a href='" . esc_url( admin_url( 'admin.php?page=eme-registration-seats&event_id=' . $event['event_id'] ) ) . "'>" . __( 'Approved:', 'events-made-easy' ) . " $booked_seats_string</a>";
                 }
             } else {
                 $total_seats_string    = '&infin;';
                 if ($no_edit_links==1) {
                     $record['event_name'] .= __( 'Approved:', 'events-made-easy' ) . "  $booked_seats_string";
                 } else {
-                    $record['event_name'] .= "<a href='" . admin_url( 'admin.php?page=eme-registration-seats&amp;event_id=' . $event['event_id'] ) . "'>" . __( 'Approved:', 'events-made-easy' ) . "  $booked_seats_string</a>";
+                    $record['event_name'] .= "<a href='" . esc_url( admin_url( 'admin.php?page=eme-registration-seats&event_id=' . $event['event_id'] ) ) . "'>" . __( 'Approved:', 'events-made-easy' ) . "  $booked_seats_string</a>";
                 }
             }
 
@@ -10321,7 +10312,7 @@ function eme_ajax_events_list() {
                 if ($no_edit_links==1) {
                     $record['event_name'] .= ', ' . __( 'Pending:', 'events-made-easy' ) . "$pending_seats_string";
                 } else {
-                    $record['event_name'] .= ', ' . "<a href='" . admin_url( 'admin.php?page=eme-registration-approval&amp;event_id=' . $event['event_id'] ) . "'>" . __( 'Pending:', 'events-made-easy' ) . "$pending_seats_string</a>";
+                    $record['event_name'] .= ', ' . "<a href='" . esc_url( admin_url( 'admin.php?page=eme-registration-approval&event_id=' . $event['event_id'] ) ) . "'>" . __( 'Pending:', 'events-made-easy' ) . "$pending_seats_string</a>";
                 }
             }
             if ( $event['event_properties']['take_attendance'] ) {
@@ -10330,7 +10321,7 @@ function eme_ajax_events_list() {
                     if ($no_edit_links==1) {
                         $record['event_name'] .= ', ' . __( 'Absent:', 'events-made-easy' ) . " $absent_bookings";
                     } else {
-                        $record['event_name'] .= ', ' . "<a href='" . admin_url( 'admin.php?page=eme-registration-seats&amp;event_id=' . $event['event_id'] ) . "'>" . __( 'Absent:', 'events-made-easy' ) . " $absent_bookings</a>";
+                        $record['event_name'] .= ', ' . "<a href='" . esc_url( admin_url( 'admin.php?page=eme-registration-seats&event_id=' . $event['event_id'] ) ) . "'>" . __( 'Absent:', 'events-made-easy' ) . " $absent_bookings</a>";
                     }
                 }
             }
@@ -10345,10 +10336,10 @@ function eme_ajax_events_list() {
                 $record['event_name'] .= ' ' . sprintf( __( '(%d waiting list seats included)', 'events-made-easy' ), $waitinglist_seats );
             }
             if ( $booked_seats > 0 || $pending_seats > 0 ) {
-                $printable_address     = admin_url( 'admin.php?page=eme-manager&amp;eme_admin_action=booking_printable&amp;event_id=' . $event['event_id'] );
-                $csv_address           = admin_url( 'admin.php?page=eme-manager&amp;eme_admin_action=booking_csv&amp;event_id=' . $event['event_id'] );
-                $record['event_name'] .= "<br>(<a id='booking_printable_" . $event['event_id'] . "' href='".esc_url($printable_address)."'>" . __( 'Printable view', 'events-made-easy' ) . '</a>)';
-                $record['event_name'] .= " (<a id='booking_csv_" . $event['event_id'] . "' href='".esc_url($csv_address)."'>" . __( 'CSV export', 'events-made-easy' ) . '</a>)';
+                $printable_address     = esc_url( admin_url( 'admin.php?page=eme-manager&eme_admin_action=booking_printable&event_id=' . $event['event_id'] ) );
+                $csv_address           = esc_url( admin_url( 'admin.php?page=eme-manager&eme_admin_action=booking_csv&event_id=' . $event['event_id'] ) );
+                $record['event_name'] .= "<br>(<a id='booking_printable_" . $event['event_id'] . "' href='".$printable_address."'>" . __( 'Printable view', 'events-made-easy' ) . '</a>)';
+                $record['event_name'] .= " (<a id='booking_csv_" . $event['event_id'] . "' href='".$csv_address."'>" . __( 'CSV export', 'events-made-easy' ) . '</a>)';
             }
         }
 
@@ -10371,13 +10362,13 @@ function eme_ajax_events_list() {
                     if ($no_edit_links==1) {
                         $record['event_name'] .= ', ' . __( 'Pending:', 'events-made-easy' ) . " $pending_spaces";
                     } else {
-                        $record['event_name'] .= ', ' . "<a href='" . admin_url( 'admin.php?page=eme-task-signups&amp;status=0&amp;event_id=' . $event['event_id'] ) . "'>" . __( 'Pending:', 'events-made-easy' ) . " $pending_spaces</a>";
+                        $record['event_name'] .= ', ' . "<a href='" . esc_url( admin_url( 'admin.php?page=eme-task-signups&status=0&event_id=' . $event['event_id'] ) ) . "'>" . __( 'Pending:', 'events-made-easy' ) . " $pending_spaces</a>";
                     }
                 }
                 if ($no_edit_links==1) {
                     $record['event_name'] .= ', ' . __( 'Approved:', 'events-made-easy' ) . " $used_spaces";
                 } else {
-                    $record['event_name'] .= ', ' . "<a href='" . admin_url( 'admin.php?page=eme-task-signups&amp;status=1&amp;event_id=' . $event['event_id'] ) . "'>" . __( 'Approved:', 'events-made-easy' ) . " $used_spaces</a>";
+                    $record['event_name'] .= ', ' . "<a href='" . esc_url( admin_url( 'admin.php?page=eme-task-signups&status=1&event_id=' . $event['event_id'] ) ) . "'>" . __( 'Approved:', 'events-made-easy' ) . " $used_spaces</a>";
                 }
             }
         }
@@ -10385,20 +10376,20 @@ function eme_ajax_events_list() {
         if ( empty( $event['location_name'] ) ) {
             $record['location_name'] = '';
         } else {
-            $record['location_name'] = "<a href='" . admin_url( 'admin.php?page=eme-locations&amp;eme_admin_action=edit_location&amp;location_id=' . $event['location_id'] ) . "' title='" . __( 'Edit location', 'events-made-easy' ) . "'>" . eme_trans_esc_html( $event['location_name'] ) . '</a>';
+            $record['location_name'] = "<a href='" . esc_url( admin_url( 'admin.php?page=eme-locations&eme_admin_action=edit_location&location_id=' . $event['location_id'] ) ) . "' title='" . __( 'Edit location', 'events-made-easy' ) . "'>" . esc_html( eme_translate( $event['location_name'] ) ) . '</a>';
             if ( ! $event['location_latitude'] && ! $event['location_longitude'] && get_option( 'eme_map_is_active' ) && ! $event['location_properties']['online_only'] ) {
                 $record['location_name'] .= "&nbsp;<img style='vertical-align: middle;' src='" . esc_url(EME_PLUGIN_URL) . "images/warning.png' alt='warning' title='" . __( 'Location map coordinates are empty! Please edit the location to correct this, otherwise it will not show correctly on your website.', 'events-made-easy' ) . "'>";
             }
         }
 
         if ( ! empty( $event['location_address1'] ) || ! empty( $event['location_address2'] ) ) {
-            $record['location_name'] .= '<br>' . eme_trans_esc_html( $event['location_address1'] ) . ' ' . eme_trans_esc_html( $event['location_address2'] );
+            $record['location_name'] .= '<br>' . esc_html( eme_translate( $event['location_address1'] ) ) . ' ' . esc_html( eme_translate( $event['location_address2'] ) );
         }
         if ( ! empty( $event['location_city'] ) || ! empty( $event['location_state'] ) || ! empty( $event['location_zip'] ) || ! empty( $event['location_country'] ) ) {
-            $record['location_name'] .= '<br>' . eme_trans_esc_html( $event['location_city'] ) . ' ' . eme_trans_esc_html( $event['location_state'] ) . ' ' . eme_trans_esc_html( $event['location_zip'] ) . ' ' . eme_trans_esc_html( $event['location_country'] );
+            $record['location_name'] .= '<br>' . esc_html( eme_translate( $event['location_city'] ) ) . ' ' . esc_html( eme_translate( $event['location_state'] ) ) . ' ' . esc_html( eme_translate( $event['location_zip'] ) ) . ' ' . esc_html( eme_translate( $event['location_country'] ) );
         }
         if ( ! $event['location_properties']['online_only'] && ! empty( $event['location_url'] ) ) {
-            $record['location_name'] .= '<br>' . eme_trans_esc_html( $event['location_url'] );
+            $record['location_name'] .= '<br>' . esc_html( eme_translate( $event['location_url'] ) );
         }
 
         if ( isset( $event_status_array[ $event['event_status'] ] ) ) {
@@ -10414,7 +10405,7 @@ function eme_ajax_events_list() {
         }
 
         if (current_user_can(get_option('eme_cap_add_event'))) {
-            $copy_link='window.location.href="'.admin_url( 'admin.php?page=eme-manager&amp;eme_admin_action=duplicate_event&amp;event_id=' . $event['event_id'] ).'";';
+            $copy_link='window.location.href="'.esc_url( admin_url( 'admin.php?page=eme-manager&eme_admin_action=duplicate_event&event_id=' . $event['event_id'] ) ).'";';
             $record[ 'copy'] = "<button onclick='$copy_link' title='" . __( 'Duplicate this event', 'events-made-easy' ) . "' class='ftable-command-button eme-copy-button'><span>copy</span></a>";
         } else {
             $record['copy'] = "";
@@ -10427,7 +10418,7 @@ function eme_ajax_events_list() {
                 $page = 'eme-registration-seats';
             }
 
-            $record['rsvp'] = "<a href='" . wp_nonce_url( admin_url( "admin.php?page=$page&amp;eme_admin_action=newBooking&amp;event_id=" . $event['event_id'] ), 'eme_admin', 'eme_admin_nonce' ) . "' title='" . __( 'Add booking for this event', 'events-made-easy' ) . "'>" . __( 'RSVP', 'events-made-easy' ) . '</a>';
+            $record['rsvp'] = "<a href='" . esc_url( wp_nonce_url( admin_url( "admin.php?page=$page&eme_admin_action=newBooking&event_id=" . $event['event_id'] ), 'eme_admin', 'eme_admin_nonce' ) ) . "' title='" . __( 'Add booking for this event', 'events-made-easy' ) . "'>" . __( 'RSVP', 'events-made-easy' ) . '</a>';
             if ( ! empty( $event['event_properties']['rsvp_password'] ) ) {
                 $record['rsvp'] .= '<br>(' . __( 'Password protected', 'events-made-easy' ) . ')';
             }
@@ -10476,7 +10467,7 @@ function eme_ajax_events_list() {
             if ($no_edit_links==1) {
                 $record['recinfo']  = $recurrence_desc;
             } else {
-                $record['recinfo']  = "$recurrence_desc <br> <a href='" . admin_url( 'admin.php?page=eme-manager&amp;eme_admin_action=edit_recurrence&amp;recurrence_id=' . $event['recurrence_id'] ) . "'>";
+                $record['recinfo']  = "$recurrence_desc <br> <a href='" . esc_url( admin_url( 'admin.php?page=eme-manager&eme_admin_action=edit_recurrence&recurrence_id=' . $event['recurrence_id'] ) ) . "'>";
                 $record['recinfo'] .= __( 'Edit Recurrence', 'events-made-easy' );
                 $record['recinfo'] .= '</a>';
             }

--- a/eme-filters.php
+++ b/eme-filters.php
@@ -29,7 +29,7 @@ function eme_filter_form_shortcode( $atts ) {
 	$template_id = intval($atts['template_id']);
 	$category = eme_sanitize_request($atts['category']);
 	$notcategory = eme_sanitize_request($atts['notcategory']);
-	$submit = eme_trans_esc_html($atts['submit']);
+	$submit = esc_attr( eme_translate( $atts['submit'] ) );
 
 	if ( $template_id ) {
 		// when using a template, don't bother with fields, the template should contain the things needed
@@ -498,7 +498,7 @@ function eme_replace_filter_form_placeholders( $format, $multiple, $multisize, $
 			} else {
 				$label = __( 'Submit', 'events-made-easy' );
 			}
-			$replacement = "<input name='eme_submit_button' class='eme_submit_button' type='submit' value='" . eme_trans_esc_html( $label ) . "'>";
+			$replacement = "<input name='eme_submit_button' class='eme_submit_button' type='submit' value='" . esc_attr( eme_translate( $label ) ) . "'>";
 		} else {
 			$found = 0;
 		}

--- a/eme-formfields.php
+++ b/eme-formfields.php
@@ -200,7 +200,7 @@ function eme_formfields_table_layout( $message = '' ) {
     global $plugin_page;
     $field_types    = eme_get_fieldtypes();
     $field_purposes = eme_get_fieldpurpose();
-    $destination    = admin_url( "admin.php?page=$plugin_page" );
+    $destination    = esc_url( admin_url( "admin.php?page=$plugin_page" ) );
     if ( empty( $message ) ) {
         $hidden_class = 'eme-hidden';
     } else {
@@ -302,7 +302,7 @@ function eme_formfields_edit_layout( $field_id = 0, $message = '', $t_formfield 
     $layout .= "
       <div id='ajax-response'></div>
 
-      <form name='edit_formfield' id='edit_formfield' method='post' action='" . admin_url( "admin.php?page=$plugin_page" ) . "' class='validate'>
+      <form name='edit_formfield' id='edit_formfield' method='post' action='" . esc_url( admin_url( "admin.php?page=$plugin_page" ) ) . "' class='validate'>
       <input type='hidden' name='eme_admin_action' value='do_editformfield'>
       $nonce_field
       <input type='hidden' name='field_id' value='" . $field_id . "'>
@@ -1181,7 +1181,7 @@ function eme_replace_task_signupformfields_placeholders( $form_id, $format ) {
             if ( isset( $matches[2] ) ) {
                 // remove { and } (first and last char of second match)
                 $placeholder_text = substr( $matches[2], 1, -1 );
-                $placeholder_text = eme_trans_esc_html( $placeholder_text );
+                $placeholder_text = esc_attr( eme_translate( $placeholder_text ) );
             } else {
                 $placeholder_text = esc_html__( 'Last name', 'events-made-easy' );
             }
@@ -1197,7 +1197,7 @@ function eme_replace_task_signupformfields_placeholders( $form_id, $format ) {
             if ( isset( $matches[1] ) ) {
                 // remove { and } (first and last char of second match)
                 $placeholder_text = substr( $matches[1], 1, -1 );
-                $placeholder_text = eme_trans_esc_html( $placeholder_text );
+                $placeholder_text = esc_attr( eme_translate( $placeholder_text ) );
             } else {
                 $placeholder_text = esc_html__( 'First name', 'events-made-easy' );
             }
@@ -1206,7 +1206,7 @@ function eme_replace_task_signupformfields_placeholders( $form_id, $format ) {
             if ( isset( $matches[2] ) ) {
                 // remove { and } (first and last char of second match)
                 $placeholder_text = substr( $matches[2], 1, -1 );
-                $placeholder_text = eme_trans_esc_html( $placeholder_text );
+                $placeholder_text = esc_attr( eme_translate( $placeholder_text ) );
             } else {
                 $placeholder_text = esc_html__( 'Email', 'events-made-easy' );
             }
@@ -1219,7 +1219,7 @@ function eme_replace_task_signupformfields_placeholders( $form_id, $format ) {
             if ( isset( $matches[2] ) ) {
                 // remove { and } (first and last char of second match)
                 $placeholder_text = substr( $matches[2], 1, -1 );
-                $placeholder_text = eme_trans_esc_html( $placeholder_text );
+                $placeholder_text = esc_attr( eme_translate( $placeholder_text ) );
             } else {
                 $placeholder_text = esc_html__( 'Phone number', 'events-made-easy' );
             }
@@ -1228,7 +1228,7 @@ function eme_replace_task_signupformfields_placeholders( $form_id, $format ) {
             if ( isset( $matches[1] ) ) {
                 // remove { and } (first and last char of second match)
                 $placeholder_text = substr( $matches[1], 1, -1 );
-                $placeholder_text = eme_trans_esc_html( $placeholder_text );
+                $placeholder_text = esc_attr( eme_translate( $placeholder_text ) );
             } else {
                 $placeholder_text = esc_html__( 'Comment', 'events-made-easy' );
             }
@@ -1247,7 +1247,7 @@ function eme_replace_task_signupformfields_placeholders( $form_id, $format ) {
             if ( isset( $matches[1] ) ) {
                 // remove { and } (first and last char of second match)
                 $placeholder_text = substr( $matches[1], 1, -1 );
-                $placeholder_text = eme_trans_esc_html( $placeholder_text );
+                $placeholder_text = esc_attr( eme_translate( $placeholder_text ) );
             } else {
                 $placeholder_text = esc_html__( 'Date of birth', 'events-made-easy' );
             }
@@ -1259,7 +1259,7 @@ function eme_replace_task_signupformfields_placeholders( $form_id, $format ) {
             if ( isset( $matches[1] ) ) {
                 // remove { and } (first and last char of second match)
                 $placeholder_text = substr( $matches[1], 1, -1 );
-                $placeholder_text = eme_trans_esc_html( $placeholder_text );
+                $placeholder_text = esc_attr( eme_translate( $placeholder_text ) );
             } else {
                 $placeholder_text = esc_html__( 'Place of birth', 'events-made-easy' );
             }
@@ -1269,9 +1269,9 @@ function eme_replace_task_signupformfields_placeholders( $form_id, $format ) {
             if ( isset( $matches[1] ) ) {
                 // remove { and } (first and last char of second match)
                 $placeholder_text = substr( $matches[1], 1, -1 );
-                $placeholder_text = eme_trans_esc_html( $placeholder_text );
+                $placeholder_text = esc_attr( eme_translate( $placeholder_text ) );
             } else {
-                $placeholder_text = eme_trans_esc_html( get_option( 'eme_address1_string' ) );
+                $placeholder_text = esc_attr( eme_translate( get_option( 'eme_address1_string' ) ) );
             }
             $replacement = "<input $required_att type='text' name='$fieldname' id='$fieldname' value='$bookerAddress1' placeholder='$placeholder_text' >";
         } elseif ( preg_match( '/#_ADDRESS2(\{.+?\})?$/', $result, $matches ) ) {
@@ -1279,9 +1279,9 @@ function eme_replace_task_signupformfields_placeholders( $form_id, $format ) {
             if ( isset( $matches[1] ) ) {
                 // remove { and } (first and last char of second match)
                 $placeholder_text = substr( $matches[1], 1, -1 );
-                $placeholder_text = eme_trans_esc_html( $placeholder_text );
+                $placeholder_text = esc_attr( eme_translate( $placeholder_text ) );
             } else {
-                $placeholder_text = eme_trans_esc_html( get_option( 'eme_address2_string' ) );
+                $placeholder_text = esc_attr( eme_translate( get_option( 'eme_address2_string' ) ) );
             }
             $replacement = "<input $required_att type='text' name='$fieldname' id='$fieldname' value='$bookerAddress2' placeholder='$placeholder_text' $readonly >";
         } elseif ( preg_match( '/#_CITY(\{.+?\})?$/', $result, $matches ) ) {
@@ -1289,7 +1289,7 @@ function eme_replace_task_signupformfields_placeholders( $form_id, $format ) {
             if ( isset( $matches[1] ) ) {
                 // remove { and } (first and last char of second match)
                 $placeholder_text = substr( $matches[1], 1, -1 );
-                $placeholder_text = eme_trans_esc_html( $placeholder_text );
+                $placeholder_text = esc_attr( eme_translate( $placeholder_text ) );
             } else {
                 $placeholder_text = esc_html__( 'City', 'events-made-easy' );
             }
@@ -1299,7 +1299,7 @@ function eme_replace_task_signupformfields_placeholders( $form_id, $format ) {
             if ( isset( $matches[2] ) ) {
                 // remove { and } (first and last char of second match)
                 $placeholder_text = substr( $matches[2], 1, -1 );
-                $placeholder_text = eme_trans_esc_html( $placeholder_text );
+                $placeholder_text = esc_attr( eme_translate( $placeholder_text ) );
             } else {
                 $placeholder_text = esc_html__( 'Postal code', 'events-made-easy' );
             }
@@ -1378,12 +1378,12 @@ function eme_replace_task_signupformfields_placeholders( $form_id, $format ) {
             } else {
                 $label = __( 'Subscribe', 'events-made-easy' );
             }
-            $replacement = "<img id='task_loading_gif' alt='loading' src='" . esc_url(EME_PLUGIN_URL) . "images/spinner.gif' class='eme-hidden'><input name='eme_submit_button' class='eme_submit_button' type='submit' value='" . eme_trans_esc_html( $label ) . "'>";
+            $replacement = "<img id='task_loading_gif' alt='loading' src='" . esc_url(EME_PLUGIN_URL) . "images/spinner.gif' class='eme-hidden'><input name='eme_submit_button' class='eme_submit_button' type='submit' value='" . esc_attr( eme_translate( $label ) ) . "'>";
         } elseif ( preg_match( '/#_FIELDNAME\{(.+)\}/', $result, $matches ) ) {
             $field_key = $matches[1];
             $formfield = eme_get_formfield( $field_key );
             if ( ! empty( $formfield ) ) {
-                $replacement = eme_trans_esc_html( $formfield['field_name'] );
+                $replacement = esc_html( eme_translate( $formfield['field_name'] ) );
             } else {
                 $found = 0;
             }
@@ -1530,7 +1530,7 @@ function eme_replace_cancelformfields_placeholders( $event ) {
             if ( isset( $matches[2] ) ) {
                 // remove { and } (first and last char of second match)
                 $placeholder_text = substr( $matches[2], 1, -1 );
-                $placeholder_text = eme_trans_esc_html( $placeholder_text );
+                $placeholder_text = esc_attr( eme_translate( $placeholder_text ) );
             } else {
                 $placeholder_text = esc_html__( 'Last name', 'events-made-easy' );
             }
@@ -1542,7 +1542,7 @@ function eme_replace_cancelformfields_placeholders( $event ) {
             if ( isset( $matches[1] ) ) {
                 // remove { and } (first and last char of second match)
                 $placeholder_text = substr( $matches[1], 1, -1 );
-                $placeholder_text = eme_trans_esc_html( $placeholder_text );
+                $placeholder_text = esc_attr( eme_translate( $placeholder_text ) );
             } else {
                 $placeholder_text = esc_html__( 'First name', 'events-made-easy' );
             }
@@ -1551,7 +1551,7 @@ function eme_replace_cancelformfields_placeholders( $event ) {
             if ( isset( $matches[2] ) ) {
                 // remove { and } (first and last char of second match)
                 $placeholder_text = substr( $matches[2], 1, -1 );
-                $placeholder_text = eme_trans_esc_html( $placeholder_text );
+                $placeholder_text = esc_attr( eme_translate( $placeholder_text ) );
             } else {
                 $placeholder_text = esc_html__( 'Email', 'events-made-easy' );
             }
@@ -1563,7 +1563,7 @@ function eme_replace_cancelformfields_placeholders( $event ) {
             if ( isset( $matches[1] ) ) {
                 // remove { and } (first and last char of second match)
                 $placeholder_text = substr( $matches[1], 1, -1 );
-                $placeholder_text = eme_trans_esc_html( $placeholder_text );
+                $placeholder_text = esc_attr( eme_translate( $placeholder_text ) );
             } else {
                 $placeholder_text = esc_html__( 'Cancel reason', 'events-made-easy' );
             }
@@ -1581,7 +1581,7 @@ function eme_replace_cancelformfields_placeholders( $event ) {
             } else {
                 $label = get_option( 'eme_rsvp_delbooking_submit_string' );
             }
-            $replacement = "<img id='rsvp_cancel_loading_gif' alt='loading' src='" . esc_url(EME_PLUGIN_URL) . "images/spinner.gif' class='eme-hidden'><input name='eme_submit_button' class='eme_submit_button' type='submit' value='" . eme_trans_esc_html( $label ) . "'>";
+            $replacement = "<img id='rsvp_cancel_loading_gif' alt='loading' src='" . esc_url(EME_PLUGIN_URL) . "images/spinner.gif' class='eme-hidden'><input name='eme_submit_button' class='eme_submit_button' type='submit' value='" . esc_attr( eme_translate( $label ) ) . "'>";
         } else {
             $found = 0;
         }
@@ -1699,7 +1699,7 @@ function eme_replace_cancel_payment_placeholders( $format, $person, $booking_ids
             } else {
                 $label = get_option( 'eme_rsvp_delbooking_submit_string' );
             }
-            $replacement = "<img id='cancel_loading_gif' alt='loading' src='" . esc_url(EME_PLUGIN_URL) . "images/spinner.gif' class='eme-hidden'><input name='eme_submit_button' class='eme_submit_button' type='submit' value='" . eme_trans_esc_html( $label ) . "'>";
+            $replacement = "<img id='cancel_loading_gif' alt='loading' src='" . esc_url(EME_PLUGIN_URL) . "images/spinner.gif' class='eme-hidden'><input name='eme_submit_button' class='eme_submit_button' type='submit' value='" . esc_attr( eme_translate( $label ) ) . "'>";
         } else {
             $found = 0;
         }
@@ -1846,7 +1846,7 @@ function eme_replace_extra_multibooking_formfields_placeholders( $form_id, $form
             if ( isset( $matches[2] ) ) {
                 // remove { and } (first and last char of second match)
                 $placeholder_text = substr( $matches[2], 1, -1 );
-                $placeholder_text = eme_trans_esc_html( $placeholder_text );
+                $placeholder_text = esc_attr( eme_translate( $placeholder_text ) );
             } else {
                 $placeholder_text = esc_html__( 'Last name', 'events-made-easy' );
             }
@@ -1862,7 +1862,7 @@ function eme_replace_extra_multibooking_formfields_placeholders( $form_id, $form
             if ( isset( $matches[1] ) ) {
                 // remove { and } (first and last char of second match)
                 $placeholder_text = substr( $matches[1], 1, -1 );
-                $placeholder_text = eme_trans_esc_html( $placeholder_text );
+                $placeholder_text = esc_attr( eme_translate( $placeholder_text ) );
             } else {
                 $placeholder_text = esc_html__( 'First name', 'events-made-easy' );
             }
@@ -1871,7 +1871,7 @@ function eme_replace_extra_multibooking_formfields_placeholders( $form_id, $form
             if ( isset( $matches[1] ) ) {
                 // remove { and } (first and last char of second match)
                 $placeholder_text = substr( $matches[1], 1, -1 );
-                $placeholder_text = eme_trans_esc_html( $placeholder_text );
+                $placeholder_text = esc_attr( eme_translate( $placeholder_text ) );
             } else {
                 $placeholder_text = esc_html__( 'Date of birth', 'events-made-easy' );
             }
@@ -1881,7 +1881,7 @@ function eme_replace_extra_multibooking_formfields_placeholders( $form_id, $form
             if ( isset( $matches[1] ) ) {
                 // remove { and } (first and last char of second match)
                 $placeholder_text = substr( $matches[1], 1, -1 );
-                $placeholder_text = eme_trans_esc_html( $placeholder_text );
+                $placeholder_text = esc_attr( eme_translate( $placeholder_text ) );
             } else {
                 $placeholder_text = esc_html__( 'Place of birth', 'events-made-easy' );
             }
@@ -1890,25 +1890,25 @@ function eme_replace_extra_multibooking_formfields_placeholders( $form_id, $form
             if ( isset( $matches[1] ) ) {
                 // remove { and } (first and last char of second match)
                 $placeholder_text = substr( $matches[1], 1, -1 );
-                $placeholder_text = eme_trans_esc_html( $placeholder_text );
+                $placeholder_text = esc_attr( eme_translate( $placeholder_text ) );
             } else {
-                $placeholder_text = eme_trans_esc_html( get_option( 'eme_address1_string' ) );
+                $placeholder_text = esc_attr( eme_translate( get_option( 'eme_address1_string' ) ) );
             }
             $replacement = "<input $required_att type='text' name='address1' id='address1' value='$bookerAddress1' placeholder='$placeholder_text'>";
         } elseif ( preg_match( '/#_ADDRESS2(\{.+?\})?$/', $result, $matches ) ) {
             if ( isset( $matches[1] ) ) {
                 // remove { and } (first and last char of second match)
                 $placeholder_text = substr( $matches[1], 1, -1 );
-                $placeholder_text = eme_trans_esc_html( $placeholder_text );
+                $placeholder_text = esc_attr( eme_translate( $placeholder_text ) );
             } else {
-                $placeholder_text = eme_trans_esc_html( get_option( 'eme_address2_string' ) );
+                $placeholder_text = esc_attr( eme_translate( get_option( 'eme_address2_string' ) ) );
             }
             $replacement = "<input $required_att type='text' name='address2' id='address2' value='$bookerAddress2' placeholder='$placeholder_text'>";
         } elseif ( preg_match( '/#_CITY(\{.+?\})?$/', $result, $matches ) ) {
             if ( isset( $matches[1] ) ) {
                 // remove { and } (first and last char of second match)
                 $placeholder_text = substr( $matches[1], 1, -1 );
-                $placeholder_text = eme_trans_esc_html( $placeholder_text );
+                $placeholder_text = esc_attr( eme_translate( $placeholder_text ) );
             } else {
                 $placeholder_text = esc_html__( 'City', 'events-made-easy' );
             }
@@ -1930,7 +1930,7 @@ function eme_replace_extra_multibooking_formfields_placeholders( $form_id, $form
             if ( isset( $matches[2] ) ) {
                 // remove { and } (first and last char of second match)
                 $placeholder_text = substr( $matches[2], 1, -1 );
-                $placeholder_text = eme_trans_esc_html( $placeholder_text );
+                $placeholder_text = esc_attr( eme_translate( $placeholder_text ) );
             } else {
                 $placeholder_text = esc_html__( 'Postal code', 'events-made-easy' );
             }
@@ -1975,7 +1975,7 @@ function eme_replace_extra_multibooking_formfields_placeholders( $form_id, $form
             if ( isset( $matches[2] ) ) {
                 // remove { and } (first and last char of second match)
                 $placeholder_text = substr( $matches[2], 1, -1 );
-                $placeholder_text = eme_trans_esc_html( $placeholder_text );
+                $placeholder_text = esc_attr( eme_translate( $placeholder_text ) );
             } else {
                 $placeholder_text = esc_html__( 'Email', 'events-made-easy' );
             }
@@ -2046,7 +2046,7 @@ function eme_replace_extra_multibooking_formfields_placeholders( $form_id, $form
                 if ( isset( $matches[1] ) ) {
                     // remove { and } (first and last char of second match)
                     $placeholder_text = substr( $matches[1], 1, -1 );
-                    $placeholder_text = eme_trans_esc_html( $placeholder_text );
+                    $placeholder_text = esc_attr( eme_translate( $placeholder_text ) );
                 } else {
                     $placeholder_text = esc_html__( 'Password', 'events-made-easy' );
                 }
@@ -2058,7 +2058,7 @@ function eme_replace_extra_multibooking_formfields_placeholders( $form_id, $form
             if ( isset( $matches[2] ) ) {
                 // remove { and } (first and last char of second match)
                 $placeholder_text = substr( $matches[2], 1, -1 );
-                $placeholder_text = eme_trans_esc_html( $placeholder_text );
+                $placeholder_text = esc_attr( eme_translate( $placeholder_text ) );
             } else {
                 $placeholder_text = esc_html__( 'Phone number', 'events-made-easy' );
             }
@@ -2067,7 +2067,7 @@ function eme_replace_extra_multibooking_formfields_placeholders( $form_id, $form
             if ( isset( $matches[1] ) ) {
                 // remove { and } (first and last char of second match)
                 $placeholder_text = substr( $matches[1], 1, -1 );
-                $placeholder_text = eme_trans_esc_html( $placeholder_text );
+                $placeholder_text = esc_attr( eme_translate( $placeholder_text ) );
             } else {
                 $placeholder_text = esc_html__( 'Comment', 'events-made-easy' );
             }
@@ -2085,7 +2085,7 @@ function eme_replace_extra_multibooking_formfields_placeholders( $form_id, $form
             } else {
                 $label = get_option( 'eme_rsvp_addbooking_submit_string' );
             }
-            $replacement = "<img id='rsvp_add_loading_gif' alt='loading' src='" . esc_url(EME_PLUGIN_URL) . "images/spinner.gif' class='eme-hidden'><input name='eme_submit_button' class='eme_submit_button' type='submit' value='" . eme_trans_esc_html( $label ) . "'>";
+            $replacement = "<img id='rsvp_add_loading_gif' alt='loading' src='" . esc_url(EME_PLUGIN_URL) . "images/spinner.gif' class='eme-hidden'><input name='eme_submit_button' class='eme_submit_button' type='submit' value='" . esc_attr( eme_translate( $label ) ) . "'>";
         } elseif ( preg_match( '/#_DYNAMICPRICE$/', $result ) ) {
             $replacement = "<span id='eme_calc_bookingprice'></span>";
         } elseif ( preg_match( '/#_DYNAMICPRICE_PER_PG|#_DYNAMICPRICE_DETAILED$/', $result ) ) {
@@ -2094,7 +2094,7 @@ function eme_replace_extra_multibooking_formfields_placeholders( $form_id, $form
             $field_key = $matches[1];
             $formfield = eme_get_formfield( $field_key );
             if ( ! empty( $formfield ) ) {
-                $replacement = eme_trans_esc_html( $formfield['field_name'] );
+                $replacement = esc_html( eme_translate( $formfield['field_name'] ) );
             } else {
                 $found = 0;
             }
@@ -2191,7 +2191,7 @@ function eme_replace_dynamic_rsvp_formfields_placeholders( $event, $booking, $fo
             $field_key = $matches[1];
             $formfield = eme_get_formfield( $field_key );
             if ( ! empty( $formfield ) ) {
-                $replacement = eme_trans_esc_html( $formfield['field_name'] );
+                $replacement = esc_html( eme_translate( $formfield['field_name'] ) );
             } else {
                 $found = 0;
             }
@@ -2306,7 +2306,7 @@ function eme_replace_dynamic_membership_formfields_placeholders( $membership, $m
             $field_key = $matches[1];
             $formfield = eme_get_formfield( $field_key );
             if ( ! empty( $formfield ) ) {
-                $replacement = eme_trans_esc_html( $formfield['field_name'] );
+                $replacement = esc_html( eme_translate( $formfield['field_name'] ) );
             } else {
                 $found = 0;
             }
@@ -2902,7 +2902,7 @@ function eme_replace_rsvp_formfields_placeholders( $form_id, $event, $booking, $
                 if ( isset( $matches[2] ) ) {
                     // remove { and } (first and last char of second match)
                     $placeholder_text = substr( $matches[2], 1, -1 );
-                    $placeholder_text = eme_trans_esc_html( $placeholder_text );
+                    $placeholder_text = esc_attr( eme_translate( $placeholder_text ) );
                 } else {
                     $placeholder_text = esc_html__( 'Last name', 'events-made-easy' );
                 }
@@ -2929,7 +2929,7 @@ function eme_replace_rsvp_formfields_placeholders( $form_id, $event, $booking, $
                 if ( isset( $matches[1] ) ) {
                     // remove { and } (first and last char of second match)
                     $placeholder_text = substr( $matches[1], 1, -1 );
-                    $placeholder_text = eme_trans_esc_html( $placeholder_text );
+                    $placeholder_text = esc_attr( eme_translate( $placeholder_text ) );
                 } else {
                     $placeholder_text = esc_html__( 'First name', 'events-made-easy' );
                 }
@@ -2940,7 +2940,7 @@ function eme_replace_rsvp_formfields_placeholders( $form_id, $event, $booking, $
                 if ( isset( $matches[1] ) ) {
                     // remove { and } (first and last char of second match)
                     $placeholder_text = substr( $matches[1], 1, -1 );
-                    $placeholder_text = eme_trans_esc_html( $placeholder_text );
+                    $placeholder_text = esc_attr( eme_translate( $placeholder_text ) );
                 } else {
                     $placeholder_text = esc_html__( 'Date of birth', 'events-made-easy' );
                 }
@@ -2954,7 +2954,7 @@ function eme_replace_rsvp_formfields_placeholders( $form_id, $event, $booking, $
                 if ( isset( $matches[1] ) ) {
                     // remove { and } (first and last char of second match)
                     $placeholder_text = substr( $matches[1], 1, -1 );
-                    $placeholder_text = eme_trans_esc_html( $placeholder_text );
+                    $placeholder_text = esc_attr( eme_translate( $placeholder_text ) );
                 } else {
                     $placeholder_text = esc_html__( 'Place of birth', 'events-made-easy' );
                 }
@@ -2966,9 +2966,9 @@ function eme_replace_rsvp_formfields_placeholders( $form_id, $event, $booking, $
                 if ( isset( $matches[1] ) ) {
                     // remove { and } (first and last char of second match)
                     $placeholder_text = substr( $matches[1], 1, -1 );
-                    $placeholder_text = eme_trans_esc_html( $placeholder_text );
+                    $placeholder_text = esc_attr( eme_translate( $placeholder_text ) );
                 } else {
-                    $placeholder_text = eme_trans_esc_html( get_option( 'eme_address1_string' ) );
+                    $placeholder_text = esc_attr( eme_translate( get_option( 'eme_address1_string' ) ) );
                 }
                 $replacement = "<input $required_att type='text' name='$fieldname' id='$fieldname' value='$bookerAddress1' placeholder='$placeholder_text' $readonly $dynamic_field_class>";
             }
@@ -2978,9 +2978,9 @@ function eme_replace_rsvp_formfields_placeholders( $form_id, $event, $booking, $
                 if ( isset( $matches[1] ) ) {
                     // remove { and } (first and last char of second match)
                     $placeholder_text = substr( $matches[1], 1, -1 );
-                    $placeholder_text = eme_trans_esc_html( $placeholder_text );
+                    $placeholder_text = esc_attr( eme_translate( $placeholder_text ) );
                 } else {
-                    $placeholder_text = eme_trans_esc_html( get_option( 'eme_address2_string' ) );
+                    $placeholder_text = esc_attr( eme_translate( get_option( 'eme_address2_string' ) ) );
                 }
                 $replacement = "<input $required_att type='text' name='$fieldname' id='$fieldname' value='$bookerAddress2' placeholder='$placeholder_text' $readonly $dynamic_field_class>";
             }
@@ -2990,7 +2990,7 @@ function eme_replace_rsvp_formfields_placeholders( $form_id, $event, $booking, $
                 if ( isset( $matches[1] ) ) {
                     // remove { and } (first and last char of second match)
                     $placeholder_text = substr( $matches[1], 1, -1 );
-                    $placeholder_text = eme_trans_esc_html( $placeholder_text );
+                    $placeholder_text = esc_attr( eme_translate( $placeholder_text ) );
                 } else {
                     $placeholder_text = esc_html__( 'City', 'events-made-easy' );
                 }
@@ -3002,7 +3002,7 @@ function eme_replace_rsvp_formfields_placeholders( $form_id, $event, $booking, $
                 if ( isset( $matches[2] ) ) {
                     // remove { and } (first and last char of second match)
                     $placeholder_text = substr( $matches[2], 1, -1 );
-                    $placeholder_text = eme_trans_esc_html( $placeholder_text );
+                    $placeholder_text = esc_attr( eme_translate( $placeholder_text ) );
                 } else {
                     $placeholder_text = esc_html__( 'Postal code', 'events-made-easy' );
                 }
@@ -3053,7 +3053,7 @@ function eme_replace_rsvp_formfields_placeholders( $form_id, $event, $booking, $
                 if ( isset( $matches[2] ) ) {
                     // remove { and } (first and last char of second match)
                     $placeholder_text = substr( $matches[2], 1, -1 );
-                    $placeholder_text = eme_trans_esc_html( $placeholder_text );
+                    $placeholder_text = esc_attr( eme_translate( $placeholder_text ) );
                 } else {
                     $placeholder_text = esc_html__( 'Email', 'events-made-easy' );
                 }
@@ -3072,7 +3072,7 @@ function eme_replace_rsvp_formfields_placeholders( $form_id, $event, $booking, $
                 if ( isset( $matches[2] ) ) {
                     // remove { and } (first and last char of second match)
                     $placeholder_text = substr( $matches[2], 1, -1 );
-                    $placeholder_text = eme_trans_esc_html( $placeholder_text );
+                    $placeholder_text = esc_attr( eme_translate( $placeholder_text ) );
                 } else {
                     $placeholder_text = esc_html__( 'Phone number', 'events-made-easy' );
                 }
@@ -3164,7 +3164,7 @@ function eme_replace_rsvp_formfields_placeholders( $form_id, $event, $booking, $
                 if ( isset( $matches[1] ) ) {
                     // remove { and } (first and last char of second match)
                     $placeholder_text = substr( $matches[1], 1, -1 );
-                    $placeholder_text = eme_trans_esc_html( $placeholder_text );
+                    $placeholder_text = esc_attr( eme_translate( $placeholder_text ) );
                 } else {
                     $placeholder_text = esc_html__( 'First name', 'events-made-easy' );
                 }
@@ -3256,7 +3256,7 @@ function eme_replace_rsvp_formfields_placeholders( $form_id, $event, $booking, $
                 if ( isset( $matches[1] ) ) {
                     // remove { and } (first and last char of second match)
                     $placeholder_text = substr( $matches[1], 1, -1 );
-                    $placeholder_text = eme_trans_esc_html( $placeholder_text );
+                    $placeholder_text = esc_attr( eme_translate( $placeholder_text ) );
                 } else {
                     $placeholder_text = esc_html__( 'Comment', 'events-made-easy' );
                 }
@@ -3272,7 +3272,7 @@ function eme_replace_rsvp_formfields_placeholders( $form_id, $event, $booking, $
             $field_key = $matches[1];
             $formfield = eme_get_formfield( $field_key );
             if ( ! empty( $formfield ) ) {
-                $replacement = eme_trans_esc_html( $formfield['field_name'] );
+                $replacement = esc_html( eme_translate( $formfield['field_name'] ) );
             } else {
                 $found = 0;
             }
@@ -3357,7 +3357,7 @@ function eme_replace_rsvp_formfields_placeholders( $form_id, $event, $booking, $
                     if ( isset( $matches[1] ) ) {
                         // remove { and } (first and last char of second match)
                         $placeholder_text = substr( $matches[1], 1, -1 );
-                        $placeholder_text = eme_trans_esc_html( $placeholder_text );
+                        $placeholder_text = esc_attr( eme_translate( $placeholder_text ) );
                     } else {
                         $placeholder_text = esc_html__( 'Discount code', 'events-made-easy' );
                     }
@@ -3410,7 +3410,7 @@ function eme_replace_rsvp_formfields_placeholders( $form_id, $event, $booking, $
                 } else {
                     $label = get_option( 'eme_rsvp_addbooking_submit_string' );
                 }
-                $replacement .= "<img id='rsvp_add_loading_gif' alt='loading' src='" . esc_url(EME_PLUGIN_URL) . "images/spinner.gif' class='eme-hidden'><input name='eme_submit_button' class='eme_submit_button' type='submit' value='" . eme_trans_esc_html( $label ) . "'>";
+                $replacement .= "<img id='rsvp_add_loading_gif' alt='loading' src='" . esc_url(EME_PLUGIN_URL) . "images/spinner.gif' class='eme-hidden'><input name='eme_submit_button' class='eme_submit_button' type='submit' value='" . esc_attr( eme_translate( $label ) ) . "'>";
             }
         } else {
             $found = 0;
@@ -3496,7 +3496,7 @@ function eme_replace_membership_familyformfields_placeholders( $format, $counter
             if ( isset( $matches[2] ) ) {
                 // remove { and } (first and last char of second match)
                 $placeholder_text = substr( $matches[2], 1, -1 );
-                $placeholder_text = eme_trans_esc_html( $placeholder_text );
+                $placeholder_text = esc_attr( eme_translate( $placeholder_text ) );
             } else {
                 $placeholder_text = esc_html__( 'Last name', 'events-made-easy' );
             }
@@ -3512,7 +3512,7 @@ function eme_replace_membership_familyformfields_placeholders( $format, $counter
             if ( isset( $matches[1] ) ) {
                 // remove { and } (first and last char of second match)
                 $placeholder_text = substr( $matches[1], 1, -1 );
-                $placeholder_text = eme_trans_esc_html( $placeholder_text );
+                $placeholder_text = esc_attr( eme_translate( $placeholder_text ) );
             } else {
                 $placeholder_text = esc_html__( 'First name', 'events-made-easy' );
             }
@@ -3528,7 +3528,7 @@ function eme_replace_membership_familyformfields_placeholders( $format, $counter
             if ( isset( $matches[2] ) ) {
                 // remove { and } (first and last char of second match)
                 $placeholder_text = substr( $matches[2], 1, -1 );
-                $placeholder_text = eme_trans_esc_html( $placeholder_text );
+                $placeholder_text = esc_attr( eme_translate( $placeholder_text ) );
             } else {
                 $placeholder_text = esc_html__( 'Phone number', 'events-made-easy' );
             }
@@ -3543,7 +3543,7 @@ function eme_replace_membership_familyformfields_placeholders( $format, $counter
             if ( isset( $matches[2] ) ) {
                 // remove { and } (first and last char of second match)
                 $placeholder_text = substr( $matches[2], 1, -1 );
-                $placeholder_text = eme_trans_esc_html( $placeholder_text );
+                $placeholder_text = esc_attr( eme_translate( $placeholder_text ) );
             } else {
                 $placeholder_text = esc_html__( 'Email', 'events-made-easy' );
             }
@@ -3584,7 +3584,7 @@ function eme_replace_membership_familyformfields_placeholders( $format, $counter
             if ( isset( $matches[1] ) ) {
                 // remove { and } (first and last char of second match)
                 $placeholder_text = substr( $matches[1], 1, -1 );
-                $placeholder_text = eme_trans_esc_html( $placeholder_text );
+                $placeholder_text = esc_attr( eme_translate( $placeholder_text ) );
             } else {
                 $placeholder_text = esc_html__( 'Place of birth', 'events-made-easy' );
             }
@@ -3600,7 +3600,7 @@ function eme_replace_membership_familyformfields_placeholders( $format, $counter
             if ( isset( $matches[1] ) ) {
                 // remove { and } (first and last char of second match)
                 $placeholder_text = substr( $matches[1], 1, -1 );
-                $placeholder_text = eme_trans_esc_html( $placeholder_text );
+                $placeholder_text = esc_attr( eme_translate( $placeholder_text ) );
             } else {
                 $placeholder_text = esc_html__( 'Date of birth', 'events-made-easy' );
             }
@@ -3611,7 +3611,7 @@ function eme_replace_membership_familyformfields_placeholders( $format, $counter
             $field_key = $matches[1];
             $formfield = eme_get_formfield( $field_key );
             if ( ! empty( $formfield ) ) {
-                $replacement = eme_trans_esc_html( $formfield['field_name'] );
+                $replacement = esc_html( eme_translate( $formfield['field_name'] ) );
             } else {
                 $found = 0;
             }
@@ -3879,7 +3879,7 @@ function eme_replace_membership_formfields_placeholders( $form_id, $membership, 
             if ( isset( $matches[2] ) ) {
                 // remove { and } (first and last char of second match)
                 $placeholder_text = substr( $matches[2], 1, -1 );
-                $placeholder_text = eme_trans_esc_html( $placeholder_text );
+                $placeholder_text = esc_attr( eme_translate( $placeholder_text ) );
             } else {
                 $placeholder_text = esc_html__( 'Last name', 'events-made-easy' );
             }
@@ -3903,7 +3903,7 @@ function eme_replace_membership_formfields_placeholders( $form_id, $membership, 
             if ( isset( $matches[1] ) ) {
                 // remove { and } (first and last char of second match)
                 $placeholder_text = substr( $matches[1], 1, -1 );
-                $placeholder_text = eme_trans_esc_html( $placeholder_text );
+                $placeholder_text = esc_attr( eme_translate( $placeholder_text ) );
             } else {
                 $placeholder_text = esc_html__( 'First name', 'events-made-easy' );
             }
@@ -3914,7 +3914,7 @@ function eme_replace_membership_formfields_placeholders( $form_id, $membership, 
             if ( isset( $matches[1] ) ) {
                 // remove { and } (first and last char of second match)
                 $placeholder_text = substr( $matches[1], 1, -1 );
-                $placeholder_text = eme_trans_esc_html( $placeholder_text );
+                $placeholder_text = esc_attr( eme_translate( $placeholder_text ) );
             } else {
                 $placeholder_text = esc_html__( 'Date of birth', 'events-made-easy' );
             }
@@ -3925,7 +3925,7 @@ function eme_replace_membership_formfields_placeholders( $form_id, $membership, 
             if ( isset( $matches[1] ) ) {
                 // remove { and } (first and last char of second match)
                 $placeholder_text = substr( $matches[1], 1, -1 );
-                $placeholder_text = eme_trans_esc_html( $placeholder_text );
+                $placeholder_text = esc_attr( eme_translate( $placeholder_text ) );
             } else {
                 $placeholder_text = esc_html__( 'Place of birth', 'events-made-easy' );
             }
@@ -3935,9 +3935,9 @@ function eme_replace_membership_formfields_placeholders( $form_id, $membership, 
             if ( isset( $matches[1] ) ) {
                 // remove { and } (first and last char of second match)
                 $placeholder_text = substr( $matches[1], 1, -1 );
-                $placeholder_text = eme_trans_esc_html( $placeholder_text );
+                $placeholder_text = esc_attr( eme_translate( $placeholder_text ) );
             } else {
-                $placeholder_text = eme_trans_esc_html( get_option( 'eme_address1_string' ) );
+                $placeholder_text = esc_attr( eme_translate( get_option( 'eme_address1_string' ) ) );
             }
             $replacement = "<input $required_att type='text' name='$fieldname' id='$fieldname' value='$bookerAddress1' $readonly class='$dynamic_field_class_basic $personal_info_class' placeholder='$placeholder_text'>";
         } elseif ( preg_match( '/#_ADDRESS2(\{.+?\})?$/', $result, $matches ) ) {
@@ -3945,9 +3945,9 @@ function eme_replace_membership_formfields_placeholders( $form_id, $membership, 
             if ( isset( $matches[1] ) ) {
                 // remove { and } (first and last char of second match)
                 $placeholder_text = substr( $matches[1], 1, -1 );
-                $placeholder_text = eme_trans_esc_html( $placeholder_text );
+                $placeholder_text = esc_attr( eme_translate( $placeholder_text ) );
             } else {
-                $placeholder_text = eme_trans_esc_html( get_option( 'eme_address2_string' ) );
+                $placeholder_text = esc_attr( eme_translate( get_option( 'eme_address2_string' ) ) );
             }
             $replacement = "<input $required_att type='text' name='$fieldname' id='$fieldname' value='$bookerAddress2' $readonly class='$dynamic_field_class_basic $personal_info_class' placeholder='$placeholder_text'>";
         } elseif ( preg_match( '/#_CITY(\{.+?\})?$/', $result, $matches ) ) {
@@ -3955,7 +3955,7 @@ function eme_replace_membership_formfields_placeholders( $form_id, $membership, 
             if ( isset( $matches[1] ) ) {
                 // remove { and } (first and last char of second match)
                 $placeholder_text = substr( $matches[1], 1, -1 );
-                $placeholder_text = eme_trans_esc_html( $placeholder_text );
+                $placeholder_text = esc_attr( eme_translate( $placeholder_text ) );
             } else {
                 $placeholder_text = esc_html__( 'City', 'events-made-easy' );
             }
@@ -3965,7 +3965,7 @@ function eme_replace_membership_formfields_placeholders( $form_id, $membership, 
             if ( isset( $matches[2] ) ) {
                 // remove { and } (first and last char of second match)
                 $placeholder_text = substr( $matches[2], 1, -1 );
-                $placeholder_text = eme_trans_esc_html( $placeholder_text );
+                $placeholder_text = esc_attr( eme_translate( $placeholder_text ) );
             } else {
                 $placeholder_text = esc_html__( 'Postal code', 'events-made-easy' );
             }
@@ -4013,7 +4013,7 @@ function eme_replace_membership_formfields_placeholders( $form_id, $membership, 
             if ( isset( $matches[2] ) ) {
                 // remove { and } (first and last char of second match)
                 $placeholder_text = substr( $matches[2], 1, -1 );
-                $placeholder_text = eme_trans_esc_html( $placeholder_text );
+                $placeholder_text = esc_attr( eme_translate( $placeholder_text ) );
             } else {
                 $placeholder_text = esc_html__( 'Email', 'events-made-easy' );
             }
@@ -4024,7 +4024,7 @@ function eme_replace_membership_formfields_placeholders( $form_id, $membership, 
             if ( isset( $matches[2] ) ) {
                 // remove { and } (first and last char of second match)
                 $placeholder_text = substr( $matches[2], 1, -1 );
-                $placeholder_text = eme_trans_esc_html( $placeholder_text );
+                $placeholder_text = esc_attr( eme_translate( $placeholder_text ) );
             } else {
                 $placeholder_text = esc_html__( 'Phone number', 'events-made-easy' );
             }
@@ -4111,7 +4111,7 @@ function eme_replace_membership_formfields_placeholders( $form_id, $membership, 
                     if ( isset( $matches[1] ) ) {
                         // remove { and } (first and last char of second match)
                         $placeholder_text = substr( $matches[1], 1, -1 );
-                        $placeholder_text = eme_trans_esc_html( $placeholder_text );
+                        $placeholder_text = esc_attr( eme_translate( $placeholder_text ) );
                     } else {
                         $placeholder_text = esc_html__( 'Discount code', 'events-made-easy' );
                     }
@@ -4197,7 +4197,7 @@ function eme_replace_membership_formfields_placeholders( $form_id, $membership, 
             $field_key = $matches[1];
             $formfield = eme_get_formfield( $field_key );
             if ( ! empty( $formfield ) ) {
-                $replacement = eme_trans_esc_html( $formfield['field_name'] );
+                $replacement = esc_html( eme_translate( $formfield['field_name'] ) );
             } else {
                 $found = 0;
             }
@@ -4256,7 +4256,7 @@ function eme_replace_membership_formfields_placeholders( $form_id, $membership, 
             } else {
                 $label = __( 'Become member', 'events-made-easy' );
             }
-            $replacement = "<img id='member_loading_gif' alt='loading' src='" . esc_url(EME_PLUGIN_URL) . "images/spinner.gif' class='eme-hidden'><input name='eme_submit_button' class='eme_submit_button' type='submit' value='" . eme_trans_esc_html( $label ) . "'>";
+            $replacement = "<img id='member_loading_gif' alt='loading' src='" . esc_url(EME_PLUGIN_URL) . "images/spinner.gif' class='eme-hidden'><input name='eme_submit_button' class='eme_submit_button' type='submit' value='" . esc_attr( eme_translate( $label ) ) . "'>";
         } else {
             $found = 0;
         }
@@ -4351,7 +4351,7 @@ function eme_replace_subscribeform_placeholders( $format, $unsubscribe = 0 ) {
                 if ( isset( $matches[2] ) ) {
                     // remove { and } (first and last char of second match)
                     $placeholder_text = substr( $matches[2], 1, -1 );
-                    $placeholder_text = eme_trans_esc_html( $placeholder_text );
+                    $placeholder_text = esc_attr( eme_translate( $placeholder_text ) );
                 } else {
                     $placeholder_text = esc_html__( 'Last name', 'events-made-easy' );
                 }
@@ -4365,7 +4365,7 @@ function eme_replace_subscribeform_placeholders( $format, $unsubscribe = 0 ) {
                 if ( isset( $matches[1] ) ) {
                     // remove { and } (first and last char of second match)
                     $placeholder_text = substr( $matches[1], 1, -1 );
-                    $placeholder_text = eme_trans_esc_html( $placeholder_text );
+                    $placeholder_text = esc_attr( eme_translate( $placeholder_text ) );
                 } else {
                     $placeholder_text = esc_html__( 'First name', 'events-made-easy' );
                 }
@@ -4378,7 +4378,7 @@ function eme_replace_subscribeform_placeholders( $format, $unsubscribe = 0 ) {
             if ( isset( $matches[2] ) ) {
                 // remove { and } (first and last char of second match)
                 $placeholder_text = substr( $matches[2], 1, -1 );
-                $placeholder_text = eme_trans_esc_html( $placeholder_text );
+                $placeholder_text = esc_attr( eme_translate( $placeholder_text ) );
             } else {
                 $placeholder_text = esc_html__( 'Email', 'events-made-easy' );
             }
@@ -4462,7 +4462,7 @@ function eme_replace_subscribeform_placeholders( $format, $unsubscribe = 0 ) {
             } else {
                 $label = __( 'Subscribe', 'events-made-easy' );
             }
-            $replacement = "<img id='loading_gif' alt='loading' src='" . esc_url(EME_PLUGIN_URL) . "images/spinner.gif' class='eme-hidden'><input name='eme_submit_button' class='eme_submit_button' type='submit' value='" . eme_trans_esc_html( $label ) . "'>";
+            $replacement = "<img id='loading_gif' alt='loading' src='" . esc_url(EME_PLUGIN_URL) . "images/spinner.gif' class='eme-hidden'><input name='eme_submit_button' class='eme_submit_button' type='submit' value='" . esc_attr( eme_translate( $label ) ) . "'>";
         } else {
             $found = 0;
         }
@@ -4550,7 +4550,7 @@ function eme_replace_cpiform_placeholders( $format, $person ) {
             if ( isset( $matches[2] ) ) {
                 // remove { and } (first and last char of second match)
                 $placeholder_text = substr( $matches[2], 1, -1 );
-                $placeholder_text = eme_trans_esc_html( $placeholder_text );
+                $placeholder_text = esc_attr( eme_translate( $placeholder_text ) );
             } else {
                 $placeholder_text = esc_html__( 'Last name', 'events-made-easy' );
             }
@@ -4565,7 +4565,7 @@ function eme_replace_cpiform_placeholders( $format, $person ) {
             if ( isset( $matches[1] ) ) {
                 // remove { and } (first and last char of second match)
                 $placeholder_text = substr( $matches[1], 1, -1 );
-                $placeholder_text = eme_trans_esc_html( $placeholder_text );
+                $placeholder_text = esc_attr( eme_translate( $placeholder_text ) );
             } else {
                 $placeholder_text = esc_html__( 'First name', 'events-made-easy' );
             }
@@ -4579,7 +4579,7 @@ function eme_replace_cpiform_placeholders( $format, $person ) {
             if ( isset( $matches[1] ) ) {
                 // remove { and } (first and last char of second match)
                 $placeholder_text = substr( $matches[1], 1, -1 );
-                $placeholder_text = eme_trans_esc_html( $placeholder_text );
+                $placeholder_text = esc_attr( eme_translate( $placeholder_text ) );
             } else {
                 $placeholder_text = esc_html__( 'Date of birth', 'events-made-easy' );
             }
@@ -4590,7 +4590,7 @@ function eme_replace_cpiform_placeholders( $format, $person ) {
             if ( isset( $matches[1] ) ) {
                 // remove { and } (first and last char of second match)
                 $placeholder_text = substr( $matches[1], 1, -1 );
-                $placeholder_text = eme_trans_esc_html( $placeholder_text );
+                $placeholder_text = esc_attr( eme_translate( $placeholder_text ) );
             } else {
                 $placeholder_text = esc_html__( 'Place of birth', 'events-made-easy' );
             }
@@ -4598,25 +4598,25 @@ function eme_replace_cpiform_placeholders( $format, $person ) {
             if ( isset( $matches[1] ) ) {
                 // remove { and } (first and last char of second match)
                 $placeholder_text = substr( $matches[1], 1, -1 );
-                $placeholder_text = eme_trans_esc_html( $placeholder_text );
+                $placeholder_text = esc_attr( eme_translate( $placeholder_text ) );
             } else {
-                $placeholder_text = eme_trans_esc_html( get_option( 'eme_address1_string' ) );
+                $placeholder_text = esc_attr( eme_translate( get_option( 'eme_address1_string' ) ) );
             }
             $replacement = "<input $required_att type='text' name='address1' id='address1' value='$bookerAddress1' placeholder='$placeholder_text'>";
         } elseif ( preg_match( '/#_ADDRESS2(\{.+?\})?$/', $result, $matches ) ) {
             if ( isset( $matches[1] ) ) {
                 // remove { and } (first and last char of second match)
                 $placeholder_text = substr( $matches[1], 1, -1 );
-                $placeholder_text = eme_trans_esc_html( $placeholder_text );
+                $placeholder_text = esc_attr( eme_translate( $placeholder_text ) );
             } else {
-                $placeholder_text = eme_trans_esc_html( get_option( 'eme_address2_string' ) );
+                $placeholder_text = esc_attr( eme_translate( get_option( 'eme_address2_string' ) ) );
             }
             $replacement = "<input $required_att type='text' name='address2' id='address2' value='$bookerAddress2' placeholder='$placeholder_text'>";
         } elseif ( preg_match( '/#_CITY(\{.+?\})?$/', $result, $matches ) ) {
             if ( isset( $matches[1] ) ) {
                 // remove { and } (first and last char of second match)
                 $placeholder_text = substr( $matches[1], 1, -1 );
-                $placeholder_text = eme_trans_esc_html( $placeholder_text );
+                $placeholder_text = esc_attr( eme_translate( $placeholder_text ) );
             } else {
                 $placeholder_text = esc_html__( 'City', 'events-made-easy' );
             }
@@ -4632,7 +4632,7 @@ function eme_replace_cpiform_placeholders( $format, $person ) {
             if ( isset( $matches[2] ) ) {
                 // remove { and } (first and last char of second match)
                 $placeholder_text = substr( $matches[2], 1, -1 );
-                $placeholder_text = eme_trans_esc_html( $placeholder_text );
+                $placeholder_text = esc_attr( eme_translate( $placeholder_text ) );
             } else {
                 $placeholder_text = esc_html__( 'Postal code', 'events-made-easy' );
             }
@@ -4661,7 +4661,7 @@ function eme_replace_cpiform_placeholders( $format, $person ) {
             if ( isset( $matches[2] ) ) {
                 // remove { and } (first and last char of second match)
                 $placeholder_text = substr( $matches[2], 1, -1 );
-                $placeholder_text = eme_trans_esc_html( $placeholder_text );
+                $placeholder_text = esc_attr( eme_translate( $placeholder_text ) );
             } else {
                 $placeholder_text = esc_html__( 'Email', 'events-made-easy' );
             }
@@ -4675,7 +4675,7 @@ function eme_replace_cpiform_placeholders( $format, $person ) {
             if ( isset( $matches[2] ) ) {
                 // remove { and } (first and last char of second match)
                 $placeholder_text = substr( $matches[2], 1, -1 );
-                $placeholder_text = eme_trans_esc_html( $placeholder_text );
+                $placeholder_text = esc_attr( eme_translate( $placeholder_text ) );
             } else {
                 $placeholder_text = esc_html__( 'Phone number', 'events-made-easy' );
             }
@@ -4724,7 +4724,7 @@ function eme_replace_cpiform_placeholders( $format, $person ) {
             $field_key = $matches[1];
             $formfield = eme_get_formfield( $field_key );
             if ( ! empty( $formfield ) ) {
-                    $replacement = eme_trans_esc_html( $formfield['field_name'] );
+                    $replacement = esc_html( eme_translate( $formfield['field_name'] ) );
             } else {
                 $found = 0;
             }
@@ -4780,7 +4780,7 @@ function eme_replace_cpiform_placeholders( $format, $person ) {
             } else {
                 $label = __( 'Save personal info', 'events-made-easy' );
             }
-            $replacement = "<img id='loading_gif' alt='loading' src='" . esc_url(EME_PLUGIN_URL) . "images/spinner.gif' class='eme-hidden'><input name='eme_submit_button' class='eme_submit_button' type='submit' value='" . eme_trans_esc_html( $label ) . "'>";
+            $replacement = "<img id='loading_gif' alt='loading' src='" . esc_url(EME_PLUGIN_URL) . "images/spinner.gif' class='eme-hidden'><input name='eme_submit_button' class='eme_submit_button' type='submit' value='" . esc_attr( eme_translate( $label ) ) . "'>";
         } else {
             $found = 0;
         }
@@ -5183,9 +5183,9 @@ function eme_ajax_formfields_list() {
             $rows[ $key ]['extra_charge']   = ( $formfield['extra_charge'] == 1 ) ? __( 'Yes', 'events-made-easy' ) : __( 'No', 'events-made-easy' );
             $rows[ $key ]['searchable']     = ( $formfield['searchable'] == 1 ) ? __( 'Yes', 'events-made-easy' ) : __( 'No', 'events-made-easy' );
             $rows[ $key ]['used']           = in_array( $formfield['field_id'], $used_formfield_ids ) ? __( 'Yes', 'events-made-easy' ) : __( 'No', 'events-made-easy' );
-            $rows[ $key ]['field_name']     = "<a href='" . admin_url( 'admin.php?page=eme-formfields&amp;eme_admin_action=edit_formfield&amp;field_id=' . $formfield['field_id'] ) . "'>" . $formfield['field_name'] . '</a>';
+            $rows[ $key ]['field_name']     = "<a href='" . esc_url( admin_url( 'admin.php?page=eme-formfields&eme_admin_action=edit_formfield&field_id=' . $formfield['field_id'] ) ) . "'>" . esc_html( $formfield['field_name'] ) . '</a>';
 
-            $copy_link='window.location.href="'.admin_url( 'admin.php?page=eme-formfields&amp;eme_admin_action=copy_formfield&amp;field_id=' . $formfield['field_id'] ).'";';
+            $copy_link='window.location.href="'.esc_url( admin_url( 'admin.php?page=eme-formfields&eme_admin_action=copy_formfield&field_id=' . $formfield['field_id'] ) ).'";';
             $rows[ $key ][ 'copy'] = "<button onclick='$copy_link' title='" . __( 'Copy', 'events-made-easy' ) . "' class='ftable-command-button eme-copy-button'><span>copy</span></a>";
 
         }

--- a/eme-fs.php
+++ b/eme-fs.php
@@ -373,7 +373,7 @@ function eme_event_fs_form( $format, $startdatetime = '' ) {
             } else {
                 $label = __( 'Create event', 'events-made-easy' );
             }
-            $replacement = "<img id='loading_gif' alt='loading' src='" . esc_url(EME_PLUGIN_URL) . "images/spinner.gif' class='eme-hidden'><input name='eme_submit_button' class='eme_submit_button' type='submit' value='" . eme_trans_esc_html( $label ) . "'>";
+            $replacement = "<img id='loading_gif' alt='loading' src='" . esc_url(EME_PLUGIN_URL) . "images/spinner.gif' class='eme-hidden'><input name='eme_submit_button' class='eme_submit_button' type='submit' value='" . esc_attr( eme_translate( $label ) ) . "'>";
         } else {
             $found = 0;
         }

--- a/eme-functions.php
+++ b/eme-functions.php
@@ -2254,7 +2254,7 @@ function eme_calc_bookingprice_detail_ajax() {
         $event = eme_get_event( $event_id );
         // if there's more than 1 event: show the event name too
         if ($count>1) {
-            $result .= eme_trans_esc_html( $event['event_name'] . ' (' . eme_localized_date( $event['event_start'], EME_TIMEZONE, 1 ) . ')' ) . "<br>";
+            $result .= esc_html( eme_translate( $event['event_name'] . ' (' . eme_localized_date( $event['event_start'], EME_TIMEZONE, 1 ) . ')' ) ) . "<br>";
         }
         if ( ! empty( $event ) ) {
             $fake_booking = eme_fake_booking( $event );
@@ -2318,7 +2318,7 @@ function eme_dyndata_people_ajax() {
             foreach ( $fields as $formfield ) {
                 $field_id       = $formfield['field_id'];
                 $form_html     .= '<tr><td>';
-                $name           = eme_trans_esc_html( $formfield['field_name'] );
+                $name           = esc_html( eme_translate( $formfield['field_name'] ) );
                 $form_html     .= "$name</td><td>";
                 $var_prefix     = "dynamic_personfields[$person_id][";
                 $var_postfix    = ']';
@@ -3250,7 +3250,7 @@ function eme_get_uploaded_files( $id, $type = 'bookings' ) {
                     $line['field_id']  = $info[1];
                     $formfield         = eme_get_formfield( $info[1] );
                     if ( $formfield ) {
-                        $line['field_name'] = eme_trans_esc_html( $formfield['field_name'] );
+                        $line['field_name'] = esc_html( eme_translate( $formfield['field_name'] ) );
                     } else {
                         // unknown ...
                         $line['field_name'] = $entry;

--- a/eme-gdpr.php
+++ b/eme-gdpr.php
@@ -443,7 +443,7 @@ function eme_show_personal_info( $email ) {
 			foreach ( $answers as $answer ) {
 				$formfield = eme_get_formfield( $answer['field_id'] );
 				if ( ! empty( $formfield ) ) {
-					$name       = eme_trans_esc_html( $formfield['field_name'] );
+					$name       = esc_html( eme_translate( $formfield['field_name'] ) );
 					$tmp_answer = eme_answer2readable( $answer['answer'], $formfield, 1, '<br>', 'html' );
 					$output    .= "<tr><td>$name</td><td>$tmp_answer</td></tr>";
 				}
@@ -452,7 +452,7 @@ function eme_show_personal_info( $email ) {
 			$files = eme_get_uploaded_files( $person_id, 'people' );
 			if ( ! empty( $files ) ) {
 				foreach ( $files as $file ) {
-					$output .= '<tr><td>' . eme_trans_esc_html( $file['field_name'] ) . '</td><td>' . "<a href='" . $file['url'] . "'>" . eme_esc_html( $file['name'] ) . '</a></td></tr>';
+					$output .= '<tr><td>' . esc_html( eme_translate( $file['field_name'] ) ) . '</td><td>' . "<a href='" . $file['url'] . "'>" . eme_esc_html( $file['name'] ) . '</a></td></tr>';
 				}
 			}
 			$output .= '</table>';
@@ -482,7 +482,7 @@ function eme_show_personal_info( $email ) {
 					foreach ( $answers as $answer ) {
 						$formfield = eme_get_formfield( $answer['field_id'] );
 						if ( ! empty( $formfield ) ) {
-							$name       = eme_trans_esc_html( $formfield['field_name'] );
+							$name       = esc_html( eme_translate( $formfield['field_name'] ) );
 							$tmp_answer = eme_answer2readable( $answer['answer'], $formfield, 1, '<br>', 'html' );
 							$output    .= "<tr><td>$name</td><td>$tmp_answer</td></tr>";
 						}
@@ -491,7 +491,7 @@ function eme_show_personal_info( $email ) {
 					$files = eme_get_uploaded_files( $member['member_id'], 'members' );
 					if ( ! empty( $files ) ) {
 						foreach ( $files as $file ) {
-							$output .= '<tr><td>' . eme_trans_esc_html( $file['field_name'] ) . '</td><td>' . "<a href='" . $file['url'] . "'>" . eme_esc_html( $file['name'] ) . '</a></td></tr>';
+							$output .= '<tr><td>' . esc_html( eme_translate( $file['field_name'] ) ) . '</td><td>' . "<a href='" . $file['url'] . "'>" . eme_esc_html( $file['name'] ) . '</a></td></tr>';
 						}
 					}
 					$output .= '</table>';

--- a/eme-holidays.php
+++ b/eme-holidays.php
@@ -133,7 +133,7 @@ function eme_holidays_edit_layout() {
     $layout .= "
       <div id='ajax-response'></div>
 
-      <form name='edit_holidays' id='edit_holidays' method='post' action='" . admin_url( "admin.php?page=$plugin_page" ) . "'>
+      <form name='edit_holidays' id='edit_holidays' method='post' action='" . esc_url( admin_url( "admin.php?page=$plugin_page" ) ) . "'>
       <input type='hidden' name='eme_admin_action' value='do_editholidays'>
       <input type='hidden' name='id' value='" . $holidays_id . "'>
       $nonce_field
@@ -249,7 +249,7 @@ function eme_holidays_shortcode( $atts ) {
 		} else {
 			print '<span id="eme_holidays_date">' . eme_localized_date( $day, EME_TIMEZONE ) . '</span>'; //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		}
-		print '&nbsp; <span id="eme_holidays_name">' . eme_trans_esc_html( $name ) . '</span><br>'; //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		print '&nbsp; <span id="eme_holidays_name">' . esc_html( eme_translate( $name ) ) . '</span><br>'; //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	}
 	print '</div>';
 }
@@ -286,8 +286,8 @@ function eme_ajax_action_holidays_list() {
         if ( empty( $row['name'] ) ) {
             $row['name'] = __( 'No name', 'events-made-easy' );
         }
-        $record['id'] = "<a href='" . wp_nonce_url( admin_url( 'admin.php?page=eme-holidays&amp;eme_admin_action=edit_holidays&amp;id=' . $row['id'] ), 'eme_admin', 'eme_admin_nonce' ) . "'>" . $row['id'] . '</a>';
-        $record['name'] = "<a href='" . wp_nonce_url( admin_url( 'admin.php?page=eme-holidays&amp;eme_admin_action=edit_holidays&amp;id=' . $row['id'] ), 'eme_admin', 'eme_admin_nonce' ) . "'>" . eme_trans_esc_html( $row['name'] ) . '</a>';
+        $record['id'] = "<a href='" . esc_url( wp_nonce_url( admin_url( 'admin.php?page=eme-holidays&eme_admin_action=edit_holidays&id=' . $row['id'] ), 'eme_admin', 'eme_admin_nonce' ) ) . "'>" . $row['id'] . '</a>';
+        $record['name'] = "<a href='" . esc_url( wp_nonce_url( admin_url( 'admin.php?page=eme-holidays&eme_admin_action=edit_holidays&id=' . $row['id'] ), 'eme_admin', 'eme_admin_nonce' ) ) . "'>" . esc_html( eme_translate( $row['name'] ) ) . '</a>';
         $records[] = $record;
     }
     $fTableResult['Result']           = 'OK';

--- a/eme-locations.php
+++ b/eme-locations.php
@@ -367,7 +367,7 @@ function eme_locations_edit_layout( $location, $message = '' ) {
         <div id="eme-location-changed" class='notice is-dismissible eme-message-admin eme-hidden'>
         <p><?php esc_html_e( 'The location details have changed. Please verify the coordinates and press Save when done', 'events-made-easy' ); ?></p>
         </div>
-    <form enctype="multipart/form-data" name="locationForm" id="locationForm" autocomplete="off" method="post" action="<?php echo admin_url( "admin.php?page=$plugin_page" ); ?>" class="validate">
+    <form enctype="multipart/form-data" name="locationForm" id="locationForm" autocomplete="off" method="post" action="<?php echo esc_url( admin_url( "admin.php?page=$plugin_page" ) ); ?>" class="validate">
     <?php wp_nonce_field( 'eme_admin', 'eme_admin_nonce' ); ?>
     <?php if ( $action == 'add' ) { ?>
     <input type="hidden" name="eme_admin_action" value="do_addlocation">
@@ -380,7 +380,7 @@ function eme_locations_edit_layout( $location, $message = '' ) {
     if ( $action == 'add' ) {
         esc_html_e( 'Insert New Location', 'events-made-easy' );
     } else {
-        echo sprintf( __( "Edit Location '%s'", 'events-made-easy' ), eme_trans_esc_html( $location['location_name'] ) );
+        echo sprintf( __( "Edit Location '%s'", 'events-made-easy' ), esc_html( eme_translate( $location['location_name'] ) ) );
     }
 ?>
         </h1>
@@ -459,7 +459,7 @@ function eme_locations_edit_layout( $location, $message = '' ) {
     } else {
         foreach ( $categories as $category ) {
 ?>
-                            <input type="checkbox" name="location_category_ids[]" value="<?php echo esc_attr( $category['category_id'] ); ?>" <?php checked( $location['location_category_ids'] && in_array( $category['category_id'], explode( ',', $location['location_category_ids'] ) ) ); ?>><?php echo eme_trans_esc_html( $category['category_name'] ); ?><br>
+                            <input type="checkbox" name="location_category_ids[]" value="<?php echo esc_attr( $category['category_id'] ); ?>" <?php checked( $location['location_category_ids'] && in_array( $category['category_id'], explode( ',', $location['location_category_ids'] ) ) ); ?>><?php echo esc_html( eme_translate( $category['category_name'] ) ); ?><br>
 <?php
         } // end foreach
     } // end if
@@ -785,7 +785,7 @@ function eme_meta_box_div_location_customfields( $location ) {
     }
 
     foreach ( $formfields as $formfield ) {
-        $field_name     = eme_trans_esc_html( $formfield['field_name'] );
+        $field_name     = esc_html( eme_translate( $formfield['field_name'] ) );
         $field_id       = $formfield['field_id'];
         $postfield_name = 'FIELD' . $field_id;
         $entered_val    = '';
@@ -833,7 +833,7 @@ function eme_locations_table( $message = '' ) {
     <?php if ( current_user_can( get_option( 'eme_cap_add_locations' ) ) ) : ?>
         <h1><?php esc_html_e( 'Add a new location', 'events-made-easy' ); ?></h1>
         <div class="wrap">
-        <form id="locations-filter" method="post" action="<?php echo admin_url( 'admin.php?page=eme-locations' ); ?>">
+        <form id="locations-filter" method="post" action="<?php echo esc_url( admin_url( 'admin.php?page=eme-locations' ) ); ?>">
             <?php wp_nonce_field( 'eme_admin', 'eme_admin_nonce' ); ?>
             <input type="hidden" name="eme_admin_action" value="add_location">
             <input type="submit" class="button-primary" name="submit" value="<?php esc_html_e( 'Add location', 'events-made-easy' ); ?>">
@@ -1697,7 +1697,7 @@ function eme_global_map_shortcode( $atts ) {
         if ( $show_locations ) {
             $loc_list .= "<li id='location-" . $location['location_id'] . "_$id_base" .
                 "' $letter_style><a>" .
-                eme_trans_esc_html( $location['location_name'] ) . '</a></li>';
+                esc_html( eme_translate( $location['location_name'] ) ) . '</a></li>';
         }
         if ( $show_events ) {
             $events    = eme_get_events( scope: $scope, offset: $scope_offset, location_id: $location['location_id'], category: $atts['category'] );
@@ -1706,11 +1706,11 @@ function eme_global_map_shortcode( $atts ) {
                 if ( $show_locations ) {
                     $loc_list .= "<li id='location-" . $location['location_id'] . "_$id_base" .
                         "' style='list-style-type: none'>- <a>" .
-                        eme_trans_esc_html( $event['event_name'] ) . '</a></li>';
+                        esc_html( eme_translate( $event['event_name'] ) ) . '</a></li>';
                 } else {
                     $loc_list .= "<li id='location-" . $location['location_id'] . "_$id_base" .
                         "' style='list-style-type: none'>$firstletter. <a>" .
-                        eme_trans_esc_html( $event['event_name'] ) . '</a></li>';
+                        esc_html( eme_translate( $event['event_name'] ) ) . '</a></li>';
                 }
             }
             $loc_list .= '</ol>';
@@ -2056,7 +2056,7 @@ function eme_replace_locations_placeholders( $format, $location = '', $target = 
                 if ( isset( $location[ $field ] ) ) {
                     $replacement = $location[ $field ];
                 }
-                $replacement = eme_trans_esc_html( $replacement, $lang );
+                $replacement = esc_html( eme_translate( $replacement, $lang ) );
                 if ( $target == 'html' ) {
                     $replacement = apply_filters( 'eme_general', $replacement );
                 } elseif ( $target == 'rss' ) {
@@ -2069,7 +2069,7 @@ function eme_replace_locations_placeholders( $format, $location = '', $target = 
                 if ( isset( $location[ $field ] ) ) {
                     $replacement = $location[ $field ];
                 }
-                $replacement = eme_trans_esc_html( $replacement, $lang );
+                $replacement = esc_html( eme_translate( $replacement, $lang ) );
                 if ( $target == 'html' ) {
                     $replacement = apply_filters( 'eme_general', $replacement );
                 } elseif ( $target == 'rss' ) {
@@ -2082,7 +2082,7 @@ function eme_replace_locations_placeholders( $format, $location = '', $target = 
                 if ( isset( $location[ $field ] ) ) {
                     $replacement = $location[ $field ];
                 }
-                $replacement = eme_trans_esc_html( $replacement, $lang );
+                $replacement = esc_html( eme_translate( $replacement, $lang ) );
                 if ( $target == 'html' ) {
                     $replacement = apply_filters( 'eme_general', $replacement );
                 } elseif ( $target == 'rss' ) {
@@ -2157,7 +2157,7 @@ function eme_replace_locations_placeholders( $format, $location = '', $target = 
                     if ( $target == 'html' ) {
                         $url = esc_url( $url );
                     }
-                    $replacement = "<img src='$url' alt='" . eme_trans_esc_html( $location['location_name'], $lang ) . "'>";
+                    $replacement = "<img src='$url' alt='" . esc_attr( eme_translate( $location['location_name'], $lang ) ) . "'>";
                 }
                 if ( ! empty( $replacement ) ) {
                     if ( $target == 'html' ) {
@@ -2242,7 +2242,7 @@ function eme_replace_locations_placeholders( $format, $location = '', $target = 
                 if ( isset( $location[ $tmp_attkey ] ) && ! is_array( $location[ $tmp_attkey ] ) ) {
                     $replacement = $location[ $tmp_attkey ];
                     if ( $target == 'html' ) {
-                        $replacement = eme_trans_esc_html( $replacement, $lang );
+                        $replacement = esc_html( eme_translate( $replacement, $lang ) );
                         $replacement = apply_filters( 'eme_general', $replacement );
                     } elseif ( $target == 'rss' ) {
                         $replacement = eme_translate( $replacement, $lang );
@@ -2257,7 +2257,7 @@ function eme_replace_locations_placeholders( $format, $location = '', $target = 
                 if ( isset( $location['location_attributes'][ $tmp_attkey ] ) ) {
                     $replacement = $location['location_attributes'][ $tmp_attkey ];
                     if ( $target == 'html' ) {
-                        $replacement = eme_trans_esc_html( $replacement, $lang );
+                        $replacement = esc_html( eme_translate( $replacement, $lang ) );
                         $replacement = apply_filters( 'eme_general', $replacement );
                     } elseif ( $target == 'rss' ) {
                         $replacement = eme_translate( $replacement, $lang );
@@ -2278,7 +2278,7 @@ function eme_replace_locations_placeholders( $format, $location = '', $target = 
                     }
                     $cat_names = array_column( $location_categories, 'category_name' );
                     if ( $target == 'html' ) {
-                        $replacement = eme_trans_esc_html( join( $sep, $cat_names ), $lang );
+                        $replacement = esc_html( eme_translate( join( $sep, $cat_names ), $lang ) );
                         $replacement = apply_filters( 'eme_general', $replacement );
                     } elseif ( $target == 'rss' ) {
                         $replacement = eme_translate( join( $sep, $cat_names ), $lang );
@@ -2295,7 +2295,7 @@ function eme_replace_locations_placeholders( $format, $location = '', $target = 
                     }
                     $cat_names = array_column( $location_categories, 'category_name' );
                     if ( $target == 'html' ) {
-                        $replacement = eme_trans_esc_html( join( ' ', $cat_names ), $lang );
+                        $replacement = esc_html( eme_translate( join( ' ', $cat_names ), $lang ) );
                         $replacement = apply_filters( 'eme_general', $replacement );
                     } elseif ( $target == 'rss' ) {
                         $replacement = eme_translate( join( ' ', $cat_names ), $lang );
@@ -2316,7 +2316,7 @@ function eme_replace_locations_placeholders( $format, $location = '', $target = 
                     }
                     $cat_descs = array_column( $location_categories, 'description' );
                     if ( $target == 'html' ) {
-                        $replacement = eme_trans_esc_html( join( $sep, $cat_descs ), $lang );
+                        $replacement = esc_html( eme_translate( join( $sep, $cat_descs ), $lang ) );
                         $replacement = apply_filters( 'eme_general', $replacement );
                     } elseif ( $target == 'rss' ) {
                         $replacement = eme_translate( join( $sep, $cat_descs ), $lang );
@@ -2343,7 +2343,7 @@ function eme_replace_locations_placeholders( $format, $location = '', $target = 
                 $cat_names        = [];
                 foreach ( $categories as $cat_name ) {
                     if ( $target == 'html' ) {
-                        $cat_names[] = eme_trans_esc_html( $cat_name, $lang );
+                        $cat_names[] = esc_html( eme_translate( $cat_name, $lang ) );
                     } else {
                         $cat_names[] = eme_translate( $cat_name, $lang );
                     }
@@ -2375,7 +2375,7 @@ function eme_replace_locations_placeholders( $format, $location = '', $target = 
                 $extra_conditions = join( ' AND ', $extra_conditions_arr );
                 $categories       = eme_get_location_category_names( $location['location_id'], $extra_conditions, $order_by );
                 if ( $target == 'html' ) {
-                    $replacement = eme_trans_esc_html( join( ' ', $categories ), $lang );
+                    $replacement = esc_html( eme_translate( join( ' ', $categories ), $lang ) );
                     $replacement = apply_filters( 'eme_general', $replacement );
                 } elseif ( $target == 'rss' ) {
                     $replacement = eme_translate( join( ' ', $categories ), $lang );
@@ -2414,7 +2414,7 @@ function eme_replace_locations_placeholders( $format, $location = '', $target = 
                 if ( isset( $location['location_id'] ) && $location['location_id'] > 0 ) {
                     if ( current_user_can( get_option( 'eme_cap_edit_locations' ) ) ||
                         ( current_user_can( get_option( 'eme_cap_author_locations' ) ) && ( $location['location_author'] == $current_userid ) ) ) {
-                        $url = admin_url( 'admin.php?page=eme-locations&amp;eme_admin_action=edit_location&amp;location_id=' . $location['location_id'] );
+                        $url = admin_url( 'admin.php?page=eme-locations&eme_admin_action=edit_location&location_id=' . $location['location_id'] );
                         if ( $target == 'html' ) {
                             $url = esc_url( $url );
                         }
@@ -2425,7 +2425,7 @@ function eme_replace_locations_placeholders( $format, $location = '', $target = 
                 if ( isset( $location['location_id'] ) && $location['location_id'] > 0 ) {
                     if ( current_user_can( get_option( 'eme_cap_edit_locations' ) ) ||
                         ( current_user_can( get_option( 'eme_cap_author_locations' ) ) && ( $location['location_author'] == $current_userid ) ) ) {
-                        $replacement = admin_url( 'admin.php?page=eme-locations&amp;eme_admin_action=edit_location&amp;location_id=' . $location['location_id'] );
+                        $replacement = admin_url( 'admin.php?page=eme-locations&eme_admin_action=edit_location&location_id=' . $location['location_id'] );
                         if ( $target == 'html' ) {
                             $replacement = esc_url( $replacement );
                         }
@@ -2459,7 +2459,7 @@ function eme_replace_locations_placeholders( $format, $location = '', $target = 
                 $formfield = eme_get_formfield( $field_key );
                 if ( ! empty( $formfield ) ) {
                     if ( $target == 'html' ) {
-                        $replacement = eme_trans_esc_html( $formfield['field_name'], $lang );
+                        $replacement = esc_html( eme_translate( $formfield['field_name'], $lang ) );
                         $replacement = apply_filters( 'eme_general', $replacement );
                     } else {
                         $replacement = eme_translate( $formfield['field_name'], $lang );
@@ -2707,7 +2707,7 @@ function eme_global_map_json( $locations, $marker_clustering, $letter_icons ) {
                 //    $tmp_loc = eme_nl2br( $tmp_loc );
         # no other white chars but spaces allowed (wp_json_encode allows them, but the JS-json parses fails)
         $tmp_loc                           = preg_replace( '/\s+/', ' ', $tmp_loc );
-        $json_location['location_balloon'] = eme_trans_esc_html( $tmp_loc );
+        $json_location['location_balloon'] = esc_html( eme_translate( $tmp_loc ) );
 
         # second, we fill in the rest of the info
         foreach ( $location as $key => $value ) {
@@ -2715,7 +2715,7 @@ function eme_global_map_json( $locations, $marker_clustering, $letter_icons ) {
             if ( preg_match( '/location_balloon|location_id|location_latitude|location_longitude/', $key ) ) {
                 # no newlines allowed, otherwise no map is shown
                 $value                 = eme_nl2br( $value );
-                $json_location[ $key ] = eme_trans_esc_html( $value );
+                $json_location[ $key ] = esc_html( eme_translate( $value ) );
             }
             $json_location['map_icon'] = eme_esc_html( $location['location_properties']['map_icon'] );
         }
@@ -2837,18 +2837,18 @@ function eme_locations_search_ajax() {
         } else {
             $record = [];
             $record['id']           = $item['location_id'];
-            $record['name']         = eme_trans_esc_html( $item['location_name'] );
-            $record['address1']     = eme_trans_esc_html( $item['location_address1'] );
-            $record['address2']     = eme_trans_esc_html( $item['location_address2'] );
-            $record['city']         = eme_trans_esc_html( $item['location_city'] );
-            $record['state']        = eme_trans_esc_html( $item['location_state'] );
-            $record['zip']          = eme_trans_esc_html( $item['location_zip'] );
-            $record['country']      = eme_trans_esc_html( $item['location_country'] );
-            $record['latitude']     = eme_trans_esc_html( $item['location_latitude'] );
-            $record['longitude']    = eme_trans_esc_html( $item['location_longitude'] );
-            $record['map_icon']     = eme_trans_esc_html( $item['location_properties']['map_icon'] );
-            $record['online_only']  = eme_trans_esc_html( $item['location_properties']['online_only'] );
-            $record['location_url'] = eme_trans_esc_html( $item['location_url'] );
+            $record['name']         = esc_html( eme_translate( $item['location_name'] ) );
+            $record['address1']     = esc_html( eme_translate( $item['location_address1'] ) );
+            $record['address2']     = esc_html( eme_translate( $item['location_address2'] ) );
+            $record['city']         = esc_html( eme_translate( $item['location_city'] ) );
+            $record['state']        = esc_html( eme_translate( $item['location_state'] ) );
+            $record['zip']          = esc_html( eme_translate( $item['location_zip'] ) );
+            $record['country']      = esc_html( eme_translate( $item['location_country'] ) );
+            $record['latitude']     = esc_html( eme_translate( $item['location_latitude'] ) );
+            $record['longitude']    = esc_html( eme_translate( $item['location_longitude'] ) );
+            $record['map_icon']     = esc_html( eme_translate( $item['location_properties']['map_icon'] ) );
+            $record['online_only']  = esc_html( eme_translate( $item['location_properties']['online_only'] ) );
+            $record['location_url'] = esc_html( eme_translate( $item['location_url'] ) );
             echo wp_json_encode( $record );
         }
     } else {
@@ -2884,18 +2884,18 @@ function eme_ajax_locations_autocomplete( $no_wp_die = 0 ) {
         $properties = eme_init_location_props(eme_unserialize($item['location_properties']));
         $record                = [];
         $record['location_id'] = $item['location_id'];
-        $record['name']        = eme_trans_esc_html( $item['location_name'] );
-        $record['address1']    = eme_trans_esc_html( $item['location_address1'] );
-        $record['address2']    = eme_trans_esc_html( $item['location_address2'] );
-        $record['city']        = eme_trans_esc_html( $item['location_city'] );
-        $record['state']       = eme_trans_esc_html( $item['location_state'] );
-        $record['zip']         = eme_trans_esc_html( $item['location_zip'] );
-        $record['country']     = eme_trans_esc_html( $item['location_country'] );
-        $record['latitude']    = eme_trans_esc_html( $item['location_latitude'] );
-        $record['longitude']   = eme_trans_esc_html( $item['location_longitude'] );
-        $record['location_url']= eme_trans_esc_html( $item['location_url'] );
+        $record['name']        = esc_html( eme_translate( $item['location_name'] ) );
+        $record['address1']    = esc_html( eme_translate( $item['location_address1'] ) );
+        $record['address2']    = esc_html( eme_translate( $item['location_address2'] ) );
+        $record['city']        = esc_html( eme_translate( $item['location_city'] ) );
+        $record['state']       = esc_html( eme_translate( $item['location_state'] ) );
+        $record['zip']         = esc_html( eme_translate( $item['location_zip'] ) );
+        $record['country']     = esc_html( eme_translate( $item['location_country'] ) );
+        $record['latitude']    = esc_html( eme_translate( $item['location_latitude'] ) );
+        $record['longitude']   = esc_html( eme_translate( $item['location_longitude'] ) );
+        $record['location_url']= esc_html( eme_translate( $item['location_url'] ) );
         foreach ($properties as $key=>$val) {
-            $record[$key]    = eme_trans_esc_html( $val );
+            $record[$key]    = esc_html( eme_translate( $val ) );
         }
         $res[]                 = $record;
     }
@@ -3003,7 +3003,7 @@ function eme_ajax_locations_list() {
         }
         $record                  = [];
         $record['location_id']   = $location['location_id'];
-        $record['location_name'] = "<a href='" . admin_url( 'admin.php?page=eme-locations&amp;eme_admin_action=edit_location&amp;location_id=' . $location['location_id'] ) . "' title='" . __( 'Edit location', 'events-made-easy' ) . "'>" . eme_trans_esc_html( $location['location_name'] ) . '</a>';
+        $record['location_name'] = "<a href='" . esc_url( admin_url( 'admin.php?page=eme-locations&eme_admin_action=edit_location&location_id=' . $location['location_id'] ) ) . "' title='" . __( 'Edit location', 'events-made-easy' ) . "'>" . esc_html( eme_translate( $location['location_name'] ) ) . '</a>';
         if ( ! $location['location_latitude'] && ! $location['location_longitude'] && get_option( 'eme_map_is_active' ) && ! $location['location_properties']['online_only'] ) {
             $record['location_name'] .= "&nbsp;<img style='vertical-align: middle;' src='" . esc_url(EME_PLUGIN_URL) . "images/warning.png' alt='warning' title='" . esc_attr__( 'Location map coordinates are empty! Please edit the location to correct this, otherwise it will not show correctly on your website.', 'events-made-easy' ) . "'>";
         }
@@ -3014,7 +3014,7 @@ function eme_ajax_locations_list() {
                         foreach ( $categories as $cat ) {
                                 $category = eme_get_category( $cat );
                                 if ( $category ) {
-                                        $cat_names[] = eme_trans_esc_html( $category['category_name'] );
+                                        $cat_names[] = esc_html( eme_translate( $category['category_name'] ) );
                                 }
                         }
                         $record['location_name'] .= implode( ', ', $cat_names );
@@ -3026,19 +3026,19 @@ function eme_ajax_locations_list() {
                         $record['location_name'] .= '</span>';
         }
 
-        $record['location_address1']  = eme_trans_esc_html( $location['location_address1'] );
-        $record['location_address2']  = eme_trans_esc_html( $location['location_address2'] );
-        $record['location_city']      = eme_trans_esc_html( $location['location_city'] );
-        $record['location_state']     = eme_trans_esc_html( $location['location_state'] );
-        $record['location_zip']       = eme_trans_esc_html( $location['location_zip'] );
-        $record['location_country']   = eme_trans_esc_html( $location['location_country'] );
-        $record['location_latitude']  = eme_trans_esc_html( $location['location_latitude'] );
-        $record['location_longitude'] = eme_trans_esc_html( $location['location_longitude'] );
-        $record['external_url']       = eme_trans_esc_html( $location['location_url'] );
+        $record['location_address1']  = esc_html( eme_translate( $location['location_address1'] ) );
+        $record['location_address2']  = esc_html( eme_translate( $location['location_address2'] ) );
+        $record['location_city']      = esc_html( eme_translate( $location['location_city'] ) );
+        $record['location_state']     = esc_html( eme_translate( $location['location_state'] ) );
+        $record['location_zip']       = esc_html( eme_translate( $location['location_zip'] ) );
+        $record['location_country']   = esc_html( eme_translate( $location['location_country'] ) );
+        $record['location_latitude']  = esc_html( eme_translate( $location['location_latitude'] ) );
+        $record['location_longitude'] = esc_html( eme_translate( $location['location_longitude'] ) );
+        $record['external_url']       = esc_html( eme_translate( $location['location_url'] ) );
         $record['online_only']        = $location['location_properties']['online_only'] ? __( 'Yes', 'events-made-easy' ) : __( 'No', 'events-made-easy' );
         $location_url                 = eme_location_url( $location );
         $record['view']               = "<a href='" . esc_url( $location_url ) . "'>" . __( 'View location', 'events-made-easy' ) . '</a>';
-        $copy_link='window.location.href="'.admin_url( 'admin.php?page=eme-locations&amp;eme_admin_action=copy_location&amp;location_id=' . $location['location_id'] ).'";';
+        $copy_link='window.location.href="'.esc_url( admin_url( 'admin.php?page=eme-locations&eme_admin_action=copy_location&location_id=' . $location['location_id'] ) ).'";';
         $record[ 'copy'] = "<button onclick='$copy_link' title='" . __( 'Duplicate this location', 'events-made-easy' ) . "' class='ftable-command-button eme-copy-button'><span>copy</span></a>";
         $location_cf_values           = eme_get_location_answers( $location['location_id'] );
         foreach ( $formfields as $formfield ) {

--- a/eme-mailer.php
+++ b/eme-mailer.php
@@ -1587,7 +1587,7 @@ function eme_mailingreport_list() {
                 $record['first_read_on'] = '';
                 $record['last_read_on']  = '';
             }
-            $record['action'] = " <a title='".__( 'Reuse this mail', 'events-made-easy' )."' href='" . wp_nonce_url( admin_url( 'admin.php?page=eme-emails&amp;eme_admin_action=reuse_mail&amp;id=' . $id ), 'eme_admin', 'eme_admin_nonce' ) . "'>" . __( 'Reuse', 'events-made-easy' ) . '</a>';
+            $record['action'] = " <a title='".__( 'Reuse this mail', 'events-made-easy' )."' href='" . esc_url( wp_nonce_url( admin_url( 'admin.php?page=eme-emails&eme_admin_action=reuse_mail&id=' . $id ), 'eme_admin', 'eme_admin_nonce' ) ) . "'>" . __( 'Reuse', 'events-made-easy' ) . '</a>';
         } else {
             $record['read_count']    = '';
             $record['sent_datetime'] = '';
@@ -1660,11 +1660,11 @@ function eme_ajax_mailings_list() {
         if ( $mailing['status'] == 'cancelled' ) {
             $stats  = eme_unserialize( $mailing['stats'] );
             $extra  = sprintf( __( '%d emails sent, %d emails failed, %d emails cancelled', 'events-made-easy' ), $stats['sent'], $stats['failed'], $stats['cancelled'] );
-            $action = "<a onclick='return confirm(\"$areyousure\");' href='" . wp_nonce_url( admin_url( 'admin.php?page=eme-emails&amp;eme_admin_action=delete_mailing&amp;id=' . $id ), 'eme_admin', 'eme_admin_nonce' ) . "'>" . __( 'Delete', 'events-made-easy' ) . "</a><br><a onclick='return confirm(\"$areyousure\");' href='" . wp_nonce_url( admin_url( 'admin.php?page=eme-emails&amp;eme_admin_action=archive_mailing&amp;id=' . $id ), 'eme_admin', 'eme_admin_nonce' ) . "'>" . __( 'Archive', 'events-made-easy' ) . '</a>';
+            $action = "<a onclick='return confirm(\"$areyousure\");' href='" . esc_url( wp_nonce_url( admin_url( 'admin.php?page=eme-emails&eme_admin_action=delete_mailing&id=' . $id ), 'eme_admin', 'eme_admin_nonce' ) ) . "'>" . __( 'Delete', 'events-made-easy' ) . "</a><br><a onclick='return confirm(\"$areyousure\");' href='" . esc_url( wp_nonce_url( admin_url( 'admin.php?page=eme-emails&eme_admin_action=archive_mailing&id=' . $id ), 'eme_admin', 'eme_admin_nonce' ) ) . "'>" . __( 'Archive', 'events-made-easy' ) . '</a>';
         } elseif ( $mailing['status'] == 'initial' ) {
             $stats  = '';
             $extra  = '';
-            $action = "<a onclick='return confirm(\"$areyousure\");' href='" . wp_nonce_url( admin_url( 'admin.php?page=eme-emails&amp;eme_admin_action=cancel_mailing&amp;id=' . $id ), 'eme_admin', 'eme_admin_nonce' ) . "'>" . __( 'Cancel', 'events-made-easy' ) . '</a>';
+            $action = "<a onclick='return confirm(\"$areyousure\");' href='" . esc_url( wp_nonce_url( admin_url( 'admin.php?page=eme-emails&eme_admin_action=cancel_mailing&id=' . $id ), 'eme_admin', 'eme_admin_nonce' ) ) . "'>" . __( 'Cancel', 'events-made-easy' ) . '</a>';
         } elseif ( $mailing['status'] == 'planned' ) {
             // older mailings inserted the emails directly and not update the stats
             // newer mailings only set the planned stats and update the receivers the moment the mailing starts
@@ -1674,21 +1674,21 @@ function eme_ajax_mailings_list() {
                 $stats  = eme_unserialize( $mailing['stats'] );
             }
             $extra  = sprintf( __( '%d emails left', 'events-made-easy' ), $stats['planned'] );
-            $action = "<a onclick='return confirm(\"$areyousure\");' title='".__( 'Delete this mailing', 'events-made-easy' )."' href='" . wp_nonce_url( admin_url( 'admin.php?page=eme-emails&amp;eme_admin_action=delete_mailing&amp;id=' . $id ), 'eme_admin', 'eme_admin_nonce' ) . "'>" . __( 'Delete', 'events-made-easy' ) . "</a><br><a onclick='return confirm(\"$areyousure\");' title='".__( 'Cancel the sending of this mailing', 'events-made-easy' )."' href='" . wp_nonce_url( admin_url( 'admin.php?page=eme-emails&amp;eme_admin_action=cancel_mailing&amp;id=' . $id ), 'eme_admin', 'eme_admin_nonce' ) . "'>" . __( 'Cancel', 'events-made-easy' ) . '</a>';
+            $action = "<a onclick='return confirm(\"$areyousure\");' title='".__( 'Delete this mailing', 'events-made-easy' )."' href='" . esc_url( wp_nonce_url( admin_url( 'admin.php?page=eme-emails&eme_admin_action=delete_mailing&id=' . $id ), 'eme_admin', 'eme_admin_nonce' ) ) . "'>" . __( 'Delete', 'events-made-easy' ) . "</a><br><a onclick='return confirm(\"$areyousure\");' title='".__( 'Cancel the sending of this mailing', 'events-made-easy' )."' href='" . esc_url( wp_nonce_url( admin_url( 'admin.php?page=eme-emails&eme_admin_action=cancel_mailing&id=' . $id ), 'eme_admin', 'eme_admin_nonce' ) ) . "'>" . __( 'Cancel', 'events-made-easy' ) . '</a>';
         } elseif ( $mailing['status'] == 'ongoing' ) {
             $stats  = eme_get_mailing_stats( $id );
             $extra  = sprintf( __( '%d emails sent, %d emails failed, %d emails left', 'events-made-easy' ), $stats['sent'], $stats['failed'], $stats['planned'] );
-            $action = "<a onclick='return confirm(\"$areyousure\");' title='".__( 'Cancel the sending of this mailing', 'events-made-easy' )."' href='" . wp_nonce_url( admin_url( 'admin.php?page=eme-emails&amp;eme_admin_action=cancel_mailing&amp;id=' . $id ), 'eme_admin', 'eme_admin_nonce' ) . "'>" . __( 'Cancel', 'events-made-easy' ) . '</a>';
+            $action = "<a onclick='return confirm(\"$areyousure\");' title='".__( 'Cancel the sending of this mailing', 'events-made-easy' )."' href='" . esc_url( wp_nonce_url( admin_url( 'admin.php?page=eme-emails&eme_admin_action=cancel_mailing&id=' . $id ), 'eme_admin', 'eme_admin_nonce' ) ) . "'>" . __( 'Cancel', 'events-made-easy' ) . '</a>';
         } elseif ( $mailing['status'] == 'completed' || $mailing['status'] == '' ) {
             $stats  = eme_unserialize( $mailing['stats'] );
             $extra  = sprintf( __( '%d emails sent, %d emails failed', 'events-made-easy' ), $stats['sent'], $stats['failed'] );
-            $action = "<a onclick='return confirm(\"$areyousure\");' title='".__( 'Delete this mailing', 'events-made-easy' )."' href='" . wp_nonce_url( admin_url( 'admin.php?page=eme-emails&amp;eme_admin_action=delete_mailing&amp;id=' . $id ), 'eme_admin', 'eme_admin_nonce' ) . "'>" . __( 'Delete', 'events-made-easy' ) . "</a><br><a onclick='return confirm(\"$areyousure\");' title='".__( 'Archive this mailing', 'events-made-easy' )."' href='" . wp_nonce_url( admin_url( 'admin.php?page=eme-emails&amp;eme_admin_action=archive_mailing&amp;id=' . $id ), 'eme_admin', 'eme_admin_nonce' ) . "'>" . __( 'Archive', 'events-made-easy' ) . '</a>';
+            $action = "<a onclick='return confirm(\"$areyousure\");' title='".__( 'Delete this mailing', 'events-made-easy' )."' href='" . esc_url( wp_nonce_url( admin_url( 'admin.php?page=eme-emails&eme_admin_action=delete_mailing&id=' . $id ), 'eme_admin', 'eme_admin_nonce' ) ) . "'>" . __( 'Delete', 'events-made-easy' ) . "</a><br><a onclick='return confirm(\"$areyousure\");' title='".__( 'Archive this mailing', 'events-made-easy' )."' href='" . esc_url( wp_nonce_url( admin_url( 'admin.php?page=eme-emails&eme_admin_action=archive_mailing&id=' . $id ), 'eme_admin', 'eme_admin_nonce' ) ) . "'>" . __( 'Archive', 'events-made-easy' ) . '</a>';
         }
         if ( ! empty( $mailing['subject'] ) && ! empty( $mailing['body'] ) ) {
-            $action .= "<br><a title='".__( 'Reuse this mailing', 'events-made-easy' )."' href='" . wp_nonce_url( admin_url( 'admin.php?page=eme-emails&amp;eme_admin_action=reuse_mailing&amp;id=' . $id ), 'eme_admin', 'eme_admin_nonce' ) . "'>" . __( 'Reuse', 'events-made-easy' ) . '</a>';
+            $action .= "<br><a title='".__( 'Reuse this mailing', 'events-made-easy' )."' href='" . esc_url( wp_nonce_url( admin_url( 'admin.php?page=eme-emails&eme_admin_action=reuse_mailing&id=' . $id ), 'eme_admin', 'eme_admin_nonce' ) ) . "'>" . __( 'Reuse', 'events-made-easy' ) . '</a>';
         }
         if ( is_array( $stats ) && !empty( $stats['failed'] ) ) {
-            $action .= "<br><a onclick='return confirm(\"$areyousure\");' title='".__( 'Retry failed messages from this mailing', 'events-made-easy' )."' href='" . wp_nonce_url( admin_url( 'admin.php?page=eme-emails&amp;eme_admin_action=retry_failed_mailing&amp;id=' . $id ), 'eme_admin', 'eme_admin_nonce' ) . "'>" . __( 'Retry failed emails', 'events-made-easy' ) . '</a>';
+            $action .= "<br><a onclick='return confirm(\"$areyousure\");' title='".__( 'Retry failed messages from this mailing', 'events-made-easy' )."' href='" . esc_url( wp_nonce_url( admin_url( 'admin.php?page=eme-emails&eme_admin_action=retry_failed_mailing&id=' . $id ), 'eme_admin', 'eme_admin_nonce' ) ) . "'>" . __( 'Retry failed emails', 'events-made-easy' ) . '</a>';
         }
 
         $record = [];
@@ -1706,7 +1706,7 @@ function eme_ajax_mailings_list() {
             $record['report'] = '';
         } else {
             $record['extra_info'] = eme_esc_html( $extra );
-            $record['report'] = "<a title='".__( 'Show mailing report', 'events-made-easy' )."' href='" . wp_nonce_url( admin_url( 'admin.php?page=eme-emails&amp;eme_admin_action=report_mailing&amp;id=' . $id ), 'eme_admin', 'eme_admin_nonce' ) . "'>" . __( 'Report', 'events-made-easy' ) . '</a>';
+            $record['report'] = "<a title='".__( 'Show mailing report', 'events-made-easy' )."' href='" . esc_url( wp_nonce_url( admin_url( 'admin.php?page=eme-emails&eme_admin_action=report_mailing&id=' . $id ), 'eme_admin', 'eme_admin_nonce' ) ) . "'>" . __( 'Report', 'events-made-easy' ) . '</a>';
         }
         $record['action'] = $action;
         $records[] = $record;
@@ -1794,9 +1794,9 @@ function eme_ajax_archivedmailings_list() {
 
         $stats  = eme_unserialize( $mailing['stats'] );
         $extra  = sprintf( __( '%d emails sent, %d emails failed, %d emails cancelled', 'events-made-easy' ), $stats['sent'], $stats['failed'], $stats['cancelled'] );
-        $action = "<a onclick='return confirm(\"$areyousure\");' title='".__( 'Delete this mailing', 'events-made-easy' )."' href='" . wp_nonce_url( admin_url( 'admin.php?page=eme-emails&amp;eme_admin_action=delete_archivedmailing&amp;id=' . $id ), 'eme_admin', 'eme_admin_nonce' ) . "'>" . __( 'Delete', 'events-made-easy' ) . '</a>';
+        $action = "<a onclick='return confirm(\"$areyousure\");' title='".__( 'Delete this mailing', 'events-made-easy' )."' href='" . esc_url( wp_nonce_url( admin_url( 'admin.php?page=eme-emails&eme_admin_action=delete_archivedmailing&id=' . $id ), 'eme_admin', 'eme_admin_nonce' ) ) . "'>" . __( 'Delete', 'events-made-easy' ) . '</a>';
         if ( ! empty( $mailing['subject'] ) && ! empty( $mailing['body'] ) ) {
-            $action .= "<br><a title='".__( 'Reuse this mailing', 'events-made-easy' )."' href='" . wp_nonce_url( admin_url( 'admin.php?page=eme-emails&amp;eme_admin_action=reuse_mailing&amp;id=' . $id ), 'eme_admin', 'eme_admin_nonce' ) . "'>" . __( 'Reuse', 'events-made-easy' ) . '</a>';
+            $action .= "<br><a title='".__( 'Reuse this mailing', 'events-made-easy' )."' href='" . esc_url( wp_nonce_url( admin_url( 'admin.php?page=eme-emails&eme_admin_action=reuse_mailing&id=' . $id ), 'eme_admin', 'eme_admin_nonce' ) ) . "'>" . __( 'Reuse', 'events-made-easy' ) . '</a>';
         }
 
         $record = [];
@@ -1922,13 +1922,13 @@ function eme_ajax_mails_list() {
                 $record['read_count'] = $row['read_count'];
             }
             $record['error_msg'] = eme_esc_html( $row['error_msg'] );
-            $record['action'] = "<a title='".__( 'Reuse this mail', 'events-made-easy' )."' href='" . wp_nonce_url( admin_url( 'admin.php?page=eme-emails&amp;eme_admin_action=reuse_mail&amp;id=' . $row['id'] ), 'eme_admin', 'eme_admin_nonce' ) . "'>" . __( 'Reuse', 'events-made-easy' ) . '</a>';
+            $record['action'] = "<a title='".__( 'Reuse this mail', 'events-made-easy' )."' href='" . esc_url( wp_nonce_url( admin_url( 'admin.php?page=eme-emails&eme_admin_action=reuse_mail&id=' . $row['id'] ), 'eme_admin', 'eme_admin_nonce' ) ) . "'>" . __( 'Reuse', 'events-made-easy' ) . '</a>';
         } else {
             //$record['action'] = "";
             //if ( $row['mailing_id'] > 0 ) {
             //    $record['action'] = __('This mail is part of a mailing','events-made-easy') . "<br>";
             //}
-            $record['action'] = "<a title='".__( 'Cancel the sending of this mail', 'events-made-easy' )."' href='" . wp_nonce_url( admin_url( 'admin.php?page=eme-emails&amp;eme_admin_action=cancel_mail&amp;id=' . $row['id'] ), 'eme_admin', 'eme_admin_nonce' ) . "'>" . __( 'Cancel', 'events-made-easy' ) . "</a><br><a title='".__( 'Reuse this mail', 'events-made-easy' )."' href='" . wp_nonce_url( admin_url( 'admin.php?page=eme-emails&amp;eme_admin_action=reuse_mail&amp;id=' . $row['id'] ), 'eme_admin', 'eme_admin_nonce' ) . "'>" . __( 'Reuse', 'events-made-easy' ) . '</a>';
+            $record['action'] = "<a title='".__( 'Cancel the sending of this mail', 'events-made-easy' )."' href='" . esc_url( wp_nonce_url( admin_url( 'admin.php?page=eme-emails&eme_admin_action=cancel_mail&id=' . $row['id'] ), 'eme_admin', 'eme_admin_nonce' ) ) . "'>" . __( 'Cancel', 'events-made-easy' ) . "</a><br><a title='".__( 'Reuse this mail', 'events-made-easy' )."' href='" . esc_url( wp_nonce_url( admin_url( 'admin.php?page=eme-emails&eme_admin_action=reuse_mail&id=' . $row['id'] ), 'eme_admin', 'eme_admin_nonce' ) ) . "'>" . __( 'Reuse', 'events-made-easy' ) . '</a>';
         }
         $records[] = $record;
     }

--- a/eme-members.php
+++ b/eme-members.php
@@ -655,7 +655,7 @@ function eme_get_linked_activemembership_names_by_personid( $person_id ) {
     $rows = $wpdb->get_results( $sql, ARRAY_A );
     $memberships_list = '';
     foreach ($rows as $item) {
-        $memberships_list .= "<a href='" . admin_url( 'admin.php?page=eme-members&amp;eme_admin_action=edit_member&amp;member_id=' . $item['member_id'] ) . "' title='" . esc_html__( 'Edit member', 'events-made-easy' ) . "'>" . eme_esc_html( $item['name'] ) . '</a><br>';
+        $memberships_list .= "<a href='" . esc_url( admin_url( 'admin.php?page=eme-members&eme_admin_action=edit_member&member_id=' . $item['member_id'] ) ) . "' title='" . esc_html__( 'Edit member', 'events-made-easy' ) . "'>" . eme_esc_html( $item['name'] ) . '</a><br>';
     }
     return $memberships_list;
 }
@@ -1505,10 +1505,10 @@ function eme_admin_edit_memberform( $member, $membership_id, $limited = 0 ) {
     }
     echo '<h1>' . esc_html( $h1_message ) . ' </h1>';
     if ( $action == 'edit' ) {
-        echo "<a href='" . admin_url( 'admin.php?page=eme-people&amp;eme_admin_action=edit_person&amp;person_id=' . $member['person_id'] ) . "' title='" . esc_html__( 'Click on this link to edit the corresponding person info', 'events-made-easy' ) . "'>" . esc_html__( 'Click on this link to edit the corresponding person info', 'events-made-easy' ) . '</a><br><br>';
+        echo "<a href='" . esc_url( admin_url( 'admin.php?page=eme-people&eme_admin_action=edit_person&person_id=' . $member['person_id'] ) ) . "' title='" . esc_html__( 'Click on this link to edit the corresponding person info', 'events-made-easy' ) . "'>" . esc_html__( 'Click on this link to edit the corresponding person info', 'events-made-easy' ) . '</a><br><br>';
     }
 ?>
-    <form name="eme-member-adminform" id="eme-member-adminform" method="post" autocomplete="off" action="<?php echo admin_url( "admin.php?page=$plugin_page" ); ?>" enctype='multipart/form-data'>
+    <form name="eme-member-adminform" id="eme-member-adminform" method="post" autocomplete="off" action="<?php echo esc_url( admin_url( "admin.php?page=$plugin_page" ) ); ?>" enctype='multipart/form-data'>
 <?php
     wp_nonce_field( 'eme_admin', 'eme_admin_nonce' );
     if ( $action == 'add' ) {
@@ -1614,7 +1614,7 @@ function eme_admin_edit_memberform( $member, $membership_id, $limited = 0 ) {
                      if ( $related_member ) {
                          $related_person = eme_get_person( $related_member['person_id'] );
                          if ( $related_person ) {
-                             print "<br><a href='" . admin_url( "admin.php?page=eme-members&amp;eme_admin_action=edit_member&amp;member_id=$related_member_id" ) . "' title='" . esc_html__( 'Edit member', 'events-made-easy' ) . "'>" . eme_esc_html( eme_format_full_name( $related_person['firstname'], $related_person['lastname'], $related_person['email'] ) ) . '</a>';
+                             print "<br><a href='" . esc_url( admin_url( "admin.php?page=eme-members&eme_admin_action=edit_member&member_id=$related_member_id" ) ) . "' title='" . esc_html__( 'Edit member', 'events-made-easy' ) . "'>" . eme_esc_html( eme_format_full_name( $related_person['firstname'], $related_person['lastname'], $related_person['email'] ) ) . '</a>';
                          }
                      }
                  }
@@ -1843,7 +1843,7 @@ function eme_membership_edit_layout( $membership, $message = '' ) {
 
 
         <div id="ajax-response"></div>
-        <form name="membershipForm" id="membershipForm" method="post" autocomplete="off" action="<?php echo admin_url( "admin.php?page=$plugin_page" ); ?>"  enctype="multipart/form-data" class="validate">
+        <form name="membershipForm" id="membershipForm" method="post" autocomplete="off" action="<?php echo esc_url( admin_url( "admin.php?page=$plugin_page" ) ); ?>"  enctype="multipart/form-data" class="validate">
         <?php wp_nonce_field( 'eme_admin', 'eme_admin_nonce' ); ?>
         <?php if ( $is_new_membership == 1 ) { ?>
         <input type="hidden" name="eme_admin_action" value="do_addmembership">
@@ -2795,7 +2795,7 @@ function eme_meta_box_div_membershipcustomfields( $membership ) {
         $answers = [];
     }
     foreach ( $formfields as $formfield ) {
-        $field_name     = eme_trans_esc_html( $formfield['field_name'] );
+        $field_name     = esc_html( eme_translate( $formfield['field_name'] ) );
         $field_id       = $formfield['field_id'];
         $postfield_name = 'FIELD' . $field_id;
         $entered_val    = '';
@@ -3208,7 +3208,7 @@ function eme_manage_members_layout( $message ) {
         <h1><?php esc_html_e( 'Add a new member', 'events-made-easy' ); ?></h1>
         <div class="wrap">
         <?php if ( ! empty( $memberships ) ) { ?>
-        <form id="members-filter" method="post" action="<?php echo admin_url( "admin.php?page=$plugin_page" ); ?>">
+        <form id="members-filter" method="post" action="<?php echo esc_url( admin_url( "admin.php?page=$plugin_page" ) ); ?>">
             <input type="hidden" name="eme_admin_action" value="add_member">
 <?php
     wp_nonce_field( 'eme_admin', 'eme_admin_nonce' );
@@ -3286,7 +3286,7 @@ function eme_manage_memberships_layout( $message ) {
     <?php if ( current_user_can( get_option( 'eme_cap_edit_members' ) ) ) : ?>
         <h1><?php esc_html_e( 'Add a new membership definition', 'events-made-easy' ); ?></h1>
         <div class="wrap">
-        <form id="memberships-filter" method="post" action="<?php echo admin_url( "admin.php?page=$plugin_page" ); ?>">
+        <form id="memberships-filter" method="post" action="<?php echo esc_url( admin_url( "admin.php?page=$plugin_page" ) ); ?>">
             <?php wp_nonce_field( 'eme_admin', 'eme_admin_nonce' ); ?>
             <input type="hidden" name="eme_admin_action" value="add_membership">
             <input type="submit" class="button-primary" name="submit" value="<?php esc_html_e( 'Add membership', 'events-made-easy' ); ?>">
@@ -5673,7 +5673,7 @@ function eme_replace_member_placeholders( $format, $membership, $member, $target
             $formfield = eme_get_formfield( $field_key );
             if ( ! empty( $formfield ) ) {
                 if ( $target == 'html' ) {
-                    $replacement = eme_trans_esc_html( $formfield['field_name'], $lang );
+                    $replacement = esc_html( eme_translate( $formfield['field_name'], $lang ) );
                     $replacement = apply_filters( 'eme_general', $replacement );
                 } else {
                     $replacement = eme_translate( $formfield['field_name'], $lang );
@@ -5953,7 +5953,7 @@ function eme_replace_membership_placeholders( $format, $membership, $target = 'h
             $formfield = eme_get_formfield( $field_key );
             if ( ! empty( $formfield ) ) {
                 if ( $target == 'html' ) {
-                    $replacement = eme_trans_esc_html( $formfield['field_name'], $lang );
+                    $replacement = esc_html( eme_translate( $formfield['field_name'], $lang ) );
                     $replacement = apply_filters( 'eme_general', $replacement );
                 } else {
                     $replacement = eme_translate( $formfield['field_name'], $lang );
@@ -6548,7 +6548,7 @@ function eme_ajax_memberships_list() {
             $record['name'] = "<s>";
         }
         if ( current_user_can( get_option( 'eme_cap_edit_members' ) ) ) {
-            $record['name'] .= "<a href='" . admin_url( 'admin.php?page=eme-memberships&amp;eme_admin_action=edit_membership&amp;membership_id=' . $item['membership_id'] ) . "' title='" . esc_html__( 'Edit membership', 'events-made-easy' ) . "'>" . eme_esc_html( $item['name'] ) . '</a>';
+            $record['name'] .= "<a href='" . esc_url( admin_url( 'admin.php?page=eme-memberships&eme_admin_action=edit_membership&membership_id=' . $item['membership_id'] ) ) . "' title='" . esc_html__( 'Edit membership', 'events-made-easy' ) . "'>" . eme_esc_html( $item['name'] ) . '</a>';
         } else {
             $record['name'] .= eme_esc_html( $item['name'] );
         }
@@ -6646,7 +6646,7 @@ function eme_ajax_members_list( ) {
             $related_member = eme_get_member( $item['related_member_id'] );
             if ( $related_member ) {
                 $related_person              = eme_get_person( $related_member['person_id'] );
-                $record['related_member_id'] = "<a href='" . admin_url( 'admin.php?page=eme-members&amp;eme_admin_action=edit_member&amp;member_id=' . $item['related_member_id'] ) . "' title='" . esc_html__( 'Edit member', 'events-made-easy' ) . "'>" . eme_esc_html( eme_format_full_name( $related_person['firstname'], $related_person['lastname'], $related_person['email'] ) ) . '</a>';
+                $record['related_member_id'] = "<a href='" . esc_url( admin_url( 'admin.php?page=eme-members&eme_admin_action=edit_member&member_id=' . $item['related_member_id'] ) ) . "' title='" . esc_html__( 'Edit member', 'events-made-easy' ) . "'>" . eme_esc_html( eme_format_full_name( $related_person['firstname'], $related_person['lastname'], $related_person['email'] ) ) . '</a>';
                 $familytext                 .= '<br>' . esc_html__( 'Head of the family: ', 'events-made-easy' ) . $record['related_member_id'];
             }
         } elseif ( ! empty( $membership['properties']['family_membership'] ) ) {
@@ -6655,9 +6655,9 @@ function eme_ajax_members_list( ) {
             $familytext = '';
         }
 
-        $record['lastname']   = "<a href='" . admin_url( 'admin.php?page=eme-members&amp;eme_admin_action=edit_member&amp;member_id=' . $item['member_id'] ) . "' title='" . esc_html__( 'Edit member', 'events-made-easy' ) . "'>" . eme_esc_html( $item['lastname'] ) . '</a> ' . $familytext;
-        $record['firstname']  = "<a href='" . admin_url( 'admin.php?page=eme-members&amp;eme_admin_action=edit_member&amp;member_id=' . $item['member_id'] ) . "' title='" . esc_html__( 'Edit member', 'events-made-easy' ) . "'>" . eme_esc_html( $item['firstname'] ) . '</a> ' . $familytext;
-        $record['email']      = "<a href='" . admin_url( 'admin.php?page=eme-members&amp;eme_admin_action=edit_member&amp;member_id=' . $item['member_id'] ) . "' title='" . esc_html__( 'Edit member', 'events-made-easy' ) . "'>" . eme_esc_html( $item['email'] ) . '</a> ' . $familytext;
+        $record['lastname']   = "<a href='" . esc_url( admin_url( 'admin.php?page=eme-members&eme_admin_action=edit_member&member_id=' . $item['member_id'] ) ) . "' title='" . esc_html__( 'Edit member', 'events-made-easy' ) . "'>" . eme_esc_html( $item['lastname'] ) . '</a> ' . $familytext;
+        $record['firstname']  = "<a href='" . esc_url( admin_url( 'admin.php?page=eme-members&eme_admin_action=edit_member&member_id=' . $item['member_id'] ) ) . "' title='" . esc_html__( 'Edit member', 'events-made-easy' ) . "'>" . eme_esc_html( $item['firstname'] ) . '</a> ' . $familytext;
+        $record['email']      = "<a href='" . esc_url( admin_url( 'admin.php?page=eme-members&eme_admin_action=edit_member&member_id=' . $item['member_id'] ) ) . "' title='" . esc_html__( 'Edit member', 'events-made-easy' ) . "'>" . eme_esc_html( $item['email'] ) . '</a> ' . $familytext;
         $record['birthdate']  = eme_localized_date( $item['birthdate'], EME_TIMEZONE, 1 );
         $record['birthplace'] = eme_esc_html( $item['birthplace'] );
         $record['address1']   = eme_esc_html( $item['address1'] );

--- a/eme-options.php
+++ b/eme-options.php
@@ -1449,7 +1449,7 @@ function eme_explain_slug_conflict( $conflict_found ) {
         } else {
             esc_html_e( 'The EME SEO permalink settings are conflicting with an existing page (the permalink setting for either events, locations or categories is identical with the permalink of another WordPress page). This might cause problems rendering either events or that page. Please resolve the conflict by either changing your EME SEO permalink settings or the permalink of the conflicting page.', 'events-made-easy' );
             echo '<br>';
-            echo sprintf( __( 'The conflicting page can be edited <a href="%s" target="_blank">here</a>.', 'events-made-easy' ), admin_url( "post.php?post=$conflict_found&action=edit" ) );
+            echo sprintf( __( 'The conflicting page can be edited <a href="%s" target="_blank">here</a>.', 'events-made-easy' ), esc_url( admin_url( "post.php?post=$conflict_found&action=edit" ) ) );
         }
         ?>
         </p></div>
@@ -1478,7 +1478,7 @@ function eme_options_page() {
 
 <h2><?php esc_html_e( 'General options', 'events-made-easy' ); ?></h2>
 <p> 
-    <?php printf( __( "Please also check <a href='%s'>your profile</a> for some per-user EME settings.", 'events-made-easy' ), admin_url( 'profile.php' ) ); ?>
+    <?php printf( __( "Please also check <a href='%s'>your profile</a> for some per-user EME settings.", 'events-made-easy' ), esc_url( admin_url( 'profile.php' ) ) ); ?>
 </p>
 <table class="form-table">
             <?php

--- a/eme-people.php
+++ b/eme-people.php
@@ -663,7 +663,7 @@ function eme_replace_people_placeholders( $format, $person, $target = 'html', $l
             if ( isset( $person[ $tmp_attkey ] ) && ! is_array( $person[ $tmp_attkey ] ) ) {
                 $replacement = $person[ $tmp_attkey ];
                 if ( $target == 'html' ) {
-                    $replacement = eme_trans_esc_html( $replacement, $lang );
+                    $replacement = esc_html( eme_translate( $replacement, $lang ) );
                     $replacement = apply_filters( 'eme_general', $replacement );
                 } elseif ( $target == 'rss' ) {
                     $replacement = eme_translate( $replacement, $lang );
@@ -692,7 +692,7 @@ function eme_replace_people_placeholders( $format, $person, $target = 'html', $l
             $formfield = eme_get_formfield( $field_key );
             if ( ! empty( $formfield ) ) {
                 if ( $target == 'html' ) {
-                    $replacement = eme_trans_esc_html( $formfield['field_name'], $lang );
+                    $replacement = esc_html( eme_translate( $formfield['field_name'], $lang ) );
                     $replacement = apply_filters( 'eme_general', $replacement );
                 } else {
                     $replacement = eme_translate( $formfield['field_name'], $lang );
@@ -1477,7 +1477,7 @@ function eme_printable_booking_report( $event_id ) {
     "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
         <html>
         <head>
-    <title><?php echo esc_html__( 'Bookings for', 'events-made-easy' ) . ' ' . eme_trans_esc_html( $event['event_name'] ); ?></title>
+    <title><?php echo esc_html__( 'Bookings for', 'events-made-easy' ) . ' ' . esc_html( eme_translate( $event['event_name'] ) ); ?></title>
     <link rel="stylesheet" href="<?php echo esc_url($stylesheet); ?>" type="text/css" media="screen">
 <?php
     $file_name = get_stylesheet_directory() . '/eme.css';
@@ -1492,7 +1492,7 @@ function eme_printable_booking_report( $event_id ) {
         </head>
         <body id="eme_printable_body">
     <div id="eme_printable_container">
-    <h1><?php echo esc_html__( 'Bookings for', 'events-made-easy' ) . ' ' . eme_trans_esc_html( $event['event_name'] ); ?></h1> 
+    <h1><?php echo esc_html__( 'Bookings for', 'events-made-easy' ) . ' ' . esc_html( eme_translate( $event['event_name'] ) ); ?></h1> 
     <p><?php echo esc_html(eme_localized_datetime( $event['event_start'], EME_TIMEZONE )); ?></p>
     <p>
 <?php
@@ -1859,9 +1859,9 @@ function eme_person_verify_layout() {
             foreach ($person_ids as $person_id) {
                 print "<tr style='border-collapse: collapse;border: 1px solid black;'>";
                 print '<td>' . $person_id . '</td>';
-                print "<td><a href='" . admin_url( 'admin.php?page=eme-people&amp;eme_admin_action=edit_person&amp;person_id=' . $person_id ) . "' title='" . esc_attr__( 'Edit person', 'events-made-easy' ) . "'>" . eme_esc_html( $row['lastname'] ) . '</a></td>';
-                print "<td><a href='" . admin_url( 'admin.php?page=eme-people&amp;eme_admin_action=edit_person&amp;person_id=' . $person_id ) . "' title='" . esc_attr__( 'Edit person', 'events-made-easy' ) . "'>" . eme_esc_html( $row['firstname'] ) . '</a></td>';
-                print "<td><a href='" . admin_url( 'admin.php?page=eme-people&amp;eme_admin_action=edit_person&amp;person_id=' . $person_id ) . "' title='" . esc_attr__( 'Edit person', 'events-made-easy' ) . "'>" . eme_esc_html( $row['email'] ) . '</a></td>';
+                print "<td><a href='" . esc_url( admin_url( 'admin.php?page=eme-people&eme_admin_action=edit_person&person_id=' . $person_id ) ) . "' title='" . esc_attr__( 'Edit person', 'events-made-easy' ) . "'>" . eme_esc_html( $row['lastname'] ) . '</a></td>';
+                print "<td><a href='" . esc_url( admin_url( 'admin.php?page=eme-people&eme_admin_action=edit_person&person_id=' . $person_id ) ) . "' title='" . esc_attr__( 'Edit person', 'events-made-easy' ) . "'>" . eme_esc_html( $row['firstname'] ) . '</a></td>';
+                print "<td><a href='" . esc_url( admin_url( 'admin.php?page=eme-people&eme_admin_action=edit_person&person_id=' . $person_id ) ) . "' title='" . esc_attr__( 'Edit person', 'events-made-easy' ) . "'>" . eme_esc_html( $row['email'] ) . '</a></td>';
                 if ( $row['wp_id'] && isset( $wp_users[ $row['wp_id'] ] ) ) {
                     print '<td>' . eme_esc_html( $wp_users[ $row['wp_id'] ] ) . '</td>';
                 } else {
@@ -1907,9 +1907,9 @@ function eme_person_verify_layout() {
             foreach ($person_ids as $person_id) {
                 print "<tr style='border-collapse: collapse;border: 1px solid black;'>";
                 print '<td>' . $person_id . '</td>';
-                print "<td><a href='" . admin_url( 'admin.php?page=eme-people&amp;eme_admin_action=edit_person&amp;person_id=' . $person_id ) . "' title='" . esc_attr__( 'Edit person', 'events-made-easy' ) . "'>" . eme_esc_html( $row['lastname'] ) . '</a></td>';
-                print "<td><a href='" . admin_url( 'admin.php?page=eme-people&amp;eme_admin_action=edit_person&amp;person_id=' . $person_id ) . "' title='" . esc_attr__( 'Edit person', 'events-made-easy' ) . "'>" . eme_esc_html( $row['firstname'] ) . '</a></td>';
-                print "<td><a href='" . admin_url( 'admin.php?page=eme-people&amp;eme_admin_action=edit_person&amp;person_id=' . $person_id ) . "' title='" . esc_attr__( 'Edit person', 'events-made-easy' ) . "'>" . eme_esc_html( $row['email'] ) . '</a></td>';
+                print "<td><a href='" . esc_url( admin_url( 'admin.php?page=eme-people&eme_admin_action=edit_person&person_id=' . $person_id ) ) . "' title='" . esc_attr__( 'Edit person', 'events-made-easy' ) . "'>" . eme_esc_html( $row['lastname'] ) . '</a></td>';
+                print "<td><a href='" . esc_url( admin_url( 'admin.php?page=eme-people&eme_admin_action=edit_person&person_id=' . $person_id ) ) . "' title='" . esc_attr__( 'Edit person', 'events-made-easy' ) . "'>" . eme_esc_html( $row['firstname'] ) . '</a></td>';
+                print "<td><a href='" . esc_url( admin_url( 'admin.php?page=eme-people&eme_admin_action=edit_person&person_id=' . $person_id ) ) . "' title='" . esc_attr__( 'Edit person', 'events-made-easy' ) . "'>" . eme_esc_html( $row['email'] ) . '</a></td>';
                 $membership_names = eme_get_linked_activemembership_names_by_personid( $person_id );
                 print "<td>$membership_names</td>";
                 $future_bookings = eme_get_bookings_by_person_id( $person_id, "future" );
@@ -1950,9 +1950,9 @@ function eme_person_verify_layout() {
             foreach ($person_ids as $person_id) {
                 print "<tr style='border-collapse: collapse;border: 1px solid black;'>";
                 print '<td>' . $person_id . '</td>';
-                print "<td><a href='" . admin_url( 'admin.php?page=eme-people&amp;eme_admin_action=edit_person&amp;person_id=' . $person_id ) . "' title='" . esc_attr__( 'Edit person', 'events-made-easy' ) . "'>" . eme_esc_html( $row['lastname'] ) . '</a></td>';
-                print "<td><a href='" . admin_url( 'admin.php?page=eme-people&amp;eme_admin_action=edit_person&amp;person_id=' . $person_id ) . "' title='" . esc_attr__( 'Edit person', 'events-made-easy' ) . "'>" . eme_esc_html( $row['firstname'] ) . '</a></td>';
-                print "<td><a href='" . admin_url( 'admin.php?page=eme-people&amp;eme_admin_action=edit_person&amp;person_id=' . $person_id ) . "' title='" . esc_attr__( 'Edit person', 'events-made-easy' ) . "'>" . eme_esc_html( $row['email'] ) . '</a></td>';
+                print "<td><a href='" . esc_url( admin_url( 'admin.php?page=eme-people&eme_admin_action=edit_person&person_id=' . $person_id ) ) . "' title='" . esc_attr__( 'Edit person', 'events-made-easy' ) . "'>" . eme_esc_html( $row['lastname'] ) . '</a></td>';
+                print "<td><a href='" . esc_url( admin_url( 'admin.php?page=eme-people&eme_admin_action=edit_person&person_id=' . $person_id ) ) . "' title='" . esc_attr__( 'Edit person', 'events-made-easy' ) . "'>" . eme_esc_html( $row['firstname'] ) . '</a></td>';
+                print "<td><a href='" . esc_url( admin_url( 'admin.php?page=eme-people&eme_admin_action=edit_person&person_id=' . $person_id ) ) . "' title='" . esc_attr__( 'Edit person', 'events-made-easy' ) . "'>" . eme_esc_html( $row['email'] ) . '</a></td>';
                 $membership_names = eme_get_linked_activemembership_names_by_personid( $person_id );
                 print "<td>$membership_names</td>";
                 $future_bookings = eme_get_bookings_by_person_id( $person_id, "future" );
@@ -2353,7 +2353,7 @@ function eme_manage_people_layout( $message = '' ) {
     <?php if ( current_user_can( get_option( 'eme_cap_edit_people' ) ) ) : ?>
     <h1><?php esc_html_e( 'Add a new person', 'events-made-easy' ); ?></h1>
     <div class="wrap">
-    <form id="people-filter" method="post" action="<?php echo admin_url( 'admin.php?page=eme-people' ); ?>">
+    <form id="people-filter" method="post" action="<?php echo esc_url( admin_url( 'admin.php?page=eme-people' ) ); ?>">
         <?php wp_nonce_field( 'eme_admin', 'eme_admin_nonce' ); ?>
         <input type="hidden" name="eme_admin_action" value="add_person">
         <input type="submit" class="button-primary" name="submit" value="<?php esc_attr_e( 'Add person', 'events-made-easy' ); ?>">
@@ -2362,12 +2362,12 @@ function eme_manage_people_layout( $message = '' ) {
 <?php endif; ?>
 
     <h1><?php esc_html_e( 'Manage people', 'events-made-easy' ); ?></h1>
-    <?php echo sprintf( __( "Click <a href='%s'>here</a> to verify the integrity of EME people", 'events-made-easy' ), admin_url( "admin.php?page=$plugin_page&eme_admin_action=verify_people" ) ); ?><br>
+    <?php echo sprintf( __( "Click <a href='%s'>here</a> to verify the integrity of EME people", 'events-made-easy' ), esc_url( admin_url( "admin.php?page=$plugin_page&eme_admin_action=verify_people" ) ) ); ?><br>
 
     <?php if ( isset( $_GET['trash'] ) && $_GET['trash'] == 1 ) { ?> 
-        <a href="<?php echo admin_url( "admin.php?page=$plugin_page&trash=0" ); ?>"><?php esc_html_e( 'Show regular content', 'events-made-easy' ); ?></a><br>
+        <a href="<?php echo esc_url( admin_url( "admin.php?page=$plugin_page&trash=0" ) ); ?>"><?php esc_html_e( 'Show regular content', 'events-made-easy' ); ?></a><br>
     <?php } else { ?>
-        <a href="<?php echo admin_url( "admin.php?page=$plugin_page&trash=1" ); ?>"><?php esc_html_e( 'Show trash content', 'events-made-easy' ); ?></a><br>
+        <a href="<?php echo esc_url( admin_url( "admin.php?page=$plugin_page&trash=1" ) ); ?>"><?php esc_html_e( 'Show trash content', 'events-made-easy' ); ?></a><br>
         <?php if ( current_user_can( get_option( 'eme_cap_cleanup' ) ) ) { ?>
         <span class="eme_import_form_img">
             <?php esc_html_e( 'Click on the icon to show the import form', 'events-made-easy' ); ?>
@@ -2475,7 +2475,7 @@ function eme_person_edit_layout( $person_id = 0, $message = '' ) {
     <?php } ?>
     <div id="ajax-response"></div>
     <?php if ( ! $readonly ) { ?>
-    <form name="editperson" id="editperson" method="post" autocomplete="off" action="<?php echo admin_url( "admin.php?page=$plugin_page" ); ?>" class="validate" enctype='multipart/form-data'>
+    <form name="editperson" id="editperson" method="post" autocomplete="off" action="<?php echo esc_url( admin_url( "admin.php?page=$plugin_page" ) ); ?>" class="validate" enctype='multipart/form-data'>
             <?php wp_nonce_field( 'eme_admin', 'eme_admin_nonce' ); ?>
             <?php if ( $action == 'add' ) { ?>
             <input type="hidden" name="eme_admin_action" value="do_addperson">
@@ -2543,7 +2543,7 @@ function eme_person_edit_layout( $person_id = 0, $message = '' ) {
         </select>
 <?php
     if ( $person['related_person_id'] > 0 ) {
-        print "<a href='" . admin_url( "admin.php?page=eme-people&amp;eme_admin_action=edit_person&amp;person_id=$related_person_id" ) . "' title='" . esc_attr__( 'Edit person', 'events-made-easy' ) . "'>" . esc_html__( 'Click here to edit that person', 'events-made-easy' ) . '</a>';
+        print "<a href='" . esc_url( admin_url( "admin.php?page=eme-people&eme_admin_action=edit_person&person_id=$related_person_id" ) ) . "' title='" . esc_attr__( 'Edit person', 'events-made-easy' ) . "'>" . esc_html__( 'Click here to edit that person', 'events-made-easy' ) . '</a>';
     }
 ?>
             </td>
@@ -2558,7 +2558,7 @@ function eme_person_edit_layout( $person_id = 0, $message = '' ) {
         foreach ( $familymember_person_ids as $family_person_id ) {
             $family_person = eme_get_person( $family_person_id );
             if ( $family_person ) {
-                print "<a href='" . admin_url( "admin.php?page=eme-people&amp;eme_admin_action=edit_person&amp;person_id=$family_person_id" ) . "' title='" . esc_attr__( 'Edit person', 'events-made-easy' ) . "'>" . eme_esc_html( eme_format_full_name( $family_person['firstname'], $family_person['lastname'], $family_person['email'] ) ) . '</a><br>';
+                print "<a href='" . esc_url( admin_url( "admin.php?page=eme-people&eme_admin_action=edit_person&person_id=$family_person_id" ) ) . "' title='" . esc_attr__( 'Edit person', 'events-made-easy' ) . "'>" . eme_esc_html( eme_format_full_name( $family_person['firstname'], $family_person['lastname'], $family_person['email'] ) ) . '</a><br>';
             }
         }
     }
@@ -2772,7 +2772,7 @@ function eme_group_edit_layout( $group_id = 0, $message = '', $group_type = 'sta
         </div>
     <?php } ?>
     <div id="ajax-response"></div>
-    <form name="editgroup" id="editgroup" method="post" autocomplete="off" action="<?php echo admin_url( "admin.php?page=$plugin_page" ); ?>" class="validate">
+    <form name="editgroup" id="editgroup" method="post" autocomplete="off" action="<?php echo esc_url( admin_url( "admin.php?page=$plugin_page" ) ); ?>" class="validate">
     <?php wp_nonce_field( 'eme_admin', 'eme_admin_nonce' ); ?>
     <input type="hidden" name="group_type" value="<?php echo esc_attr( $group['type'] ); ?>">
     <?php if ( $action == 'add' ) { ?>
@@ -2862,7 +2862,7 @@ function eme_manage_groups_layout( $message = '' ) {
     <?php if ( current_user_can( get_option( 'eme_cap_edit_people' ) ) ) : ?>
     <h1><?php esc_html_e( 'Add a new group', 'events-made-easy' ); ?></h1>
     <div class="wrap">
-    <form id="add-group" method="post" action="<?php echo admin_url( 'admin.php?page=eme-groups' ); ?>">
+    <form id="add-group" method="post" action="<?php echo esc_url( admin_url( 'admin.php?page=eme-groups' ) ); ?>">
         <?php wp_nonce_field( 'eme_admin', 'eme_admin_nonce' ); ?>
         <input type="hidden" name="eme_admin_action" value="add_group">
         <button type="submit" class="button-primary" name="eme_admin_action" value="add_group"><?php esc_html_e( 'Add group', 'events-made-easy' ); ?></button>
@@ -5306,7 +5306,7 @@ function eme_ajax_people_list( ) {
         $record['people.person_id'] = $item['person_id'];
         if ( $item['related_person_id'] ) {
             $related_person              = eme_get_person( $item['related_person_id'] );
-            $record['people.related_to'] = "<a href='" . admin_url( 'admin.php?page=eme-people&amp;eme_admin_action=edit_person&amp;person_id=' . $item['related_person_id'] ) . "' title='" . esc_attr__( 'Edit person', 'events-made-easy' ) . "'>" . eme_esc_html( $related_person['lastname'] . ' ' . $related_person['firstname'] ) . '</a>';
+            $record['people.related_to'] = "<a href='" . esc_url( admin_url( 'admin.php?page=eme-people&eme_admin_action=edit_person&person_id=' . $item['related_person_id'] ) ) . "' title='" . esc_attr__( 'Edit person', 'events-made-easy' ) . "'>" . eme_esc_html( $related_person['lastname'] . ' ' . $related_person['firstname'] ) . '</a>';
             $familytext                  = esc_html__( '(family member)', 'events-made-easy' );
         } else {
             $record['people.related_to'] = '';
@@ -5320,9 +5320,9 @@ function eme_ajax_people_list( ) {
         } else {
             $record['people.wp_user'] = '';
         }
-        $record['people.lastname']   = "<a href='" . admin_url( 'admin.php?page=eme-people&amp;eme_admin_action=edit_person&amp;person_id=' . $item['person_id'] ) . "' title='" . esc_attr__( 'Edit person', 'events-made-easy' ) . "'>" . eme_esc_html( $item['lastname'] ) . '</a> ' . $familytext;
-        $record['people.firstname']  = "<a href='" . admin_url( 'admin.php?page=eme-people&amp;eme_admin_action=edit_person&amp;person_id=' . $item['person_id'] ) . "' title='" . esc_attr__( 'Edit person', 'events-made-easy' ) . "'>" . eme_esc_html( $item['firstname'] ) . '</a> ' . $familytext;
-        $record['people.email']      = "<a href='" . admin_url( 'admin.php?page=eme-people&amp;eme_admin_action=edit_person&amp;person_id=' . $item['person_id'] ) . "' title='" . esc_attr__( 'Edit person', 'events-made-easy' ) . "'>" . eme_esc_html( $item['email'] ) . '</a> ' . $familytext;
+        $record['people.lastname']   = "<a href='" . esc_url( admin_url( 'admin.php?page=eme-people&eme_admin_action=edit_person&person_id=' . $item['person_id'] ) ) . "' title='" . esc_attr__( 'Edit person', 'events-made-easy' ) . "'>" . eme_esc_html( $item['lastname'] ) . '</a> ' . $familytext;
+        $record['people.firstname']  = "<a href='" . esc_url( admin_url( 'admin.php?page=eme-people&eme_admin_action=edit_person&person_id=' . $item['person_id'] ) ) . "' title='" . esc_attr__( 'Edit person', 'events-made-easy' ) . "'>" . eme_esc_html( $item['firstname'] ) . '</a> ' . $familytext;
+        $record['people.email']      = "<a href='" . esc_url( admin_url( 'admin.php?page=eme-people&eme_admin_action=edit_person&person_id=' . $item['person_id'] ) ) . "' title='" . esc_attr__( 'Edit person', 'events-made-easy' ) . "'>" . eme_esc_html( $item['email'] ) . '</a> ' . $familytext;
         $record['people.phone']      = eme_esc_html( $item['phone'] );
         $record['people.birthdate']  = eme_localized_date( $item['birthdate'], EME_TIMEZONE, 1 );
         $record['people.bd_email']   = $item['bd_email'] ? esc_html__( 'Yes', 'events-made-easy' ) : esc_html__( 'No', 'events-made-easy' );
@@ -5415,7 +5415,7 @@ function eme_ajax_groups_list() {
         $record['group_id'] = $group['group_id'];
         $record['public']   = $group['public'] ? esc_html__( 'Yes', 'events-made-easy' ) : esc_html__( 'No', 'events-made-easy' );
         if ( current_user_can( get_option( 'eme_cap_edit_people' ) ) ) {
-            $record['name'] = "<a href='" . admin_url( 'admin.php?page=eme-groups&amp;eme_admin_action=edit_group&amp;group_id=' . $group['group_id'] ) . "' title='" . esc_attr__( 'Edit group', 'events-made-easy' ) . "'>" . eme_esc_html( $group['name'] ) . '</a>';
+            $record['name'] = "<a href='" . esc_url( admin_url( 'admin.php?page=eme-groups&eme_admin_action=edit_group&group_id=' . $group['group_id'] ) ) . "' title='" . esc_attr__( 'Edit group', 'events-made-easy' ) . "'>" . eme_esc_html( $group['name'] ) . '</a>';
         } else {
             $record['name'] = eme_esc_html( $group['name'] );
         }

--- a/eme-recurrence.php
+++ b/eme-recurrence.php
@@ -723,8 +723,8 @@ function eme_ajax_recurrences_list() {
 
 		$record                  = [];
 		$record['recurrence_id'] = $recurrence['recurrence_id'];
-		$record['event_name']    = "<strong><a href='" . wp_nonce_url( admin_url( 'admin.php?page=eme-manager&amp;eme_admin_action=edit_recurrence&amp;recurrence_id=' . $recurrence['recurrence_id'] ), 'eme_admin', 'eme_admin_nonce' ) . "' title='" . __( 'Edit recurrence', 'events-made-easy' ) . "'>" . eme_trans_esc_html( $event['event_name'] ) . '</a></strong>';
-        $copy_link='window.location.href="'.admin_url( 'admin.php?page=eme-manager&amp;eme_admin_action=duplicate_recurrence&amp;recurrence_id=' . $recurrence['recurrence_id'] ).'";';
+		$record['event_name']    = "<strong><a href='" . esc_url( wp_nonce_url( admin_url( 'admin.php?page=eme-manager&eme_admin_action=edit_recurrence&recurrence_id=' . $recurrence['recurrence_id'] ), 'eme_admin', 'eme_admin_nonce' ) ) . "' title='" . __( 'Edit recurrence', 'events-made-easy' ) . "'>" . esc_html( eme_translate( $event['event_name'] ) ) . '</a></strong>';
+        $copy_link='window.location.href="'.esc_url( admin_url( 'admin.php?page=eme-manager&eme_admin_action=duplicate_recurrence&recurrence_id=' . $recurrence['recurrence_id'] ) ).'";';
         $record[ 'copy'] = "<button onclick='$copy_link' title='" . __( 'Duplicate this recurrence', 'events-made-easy' ) . "' class='ftable-command-button eme-copy-button'><span>copy</span></a>";
 		if ( $event['event_rsvp'] ) {
 			$total_seats = eme_get_total( $event['event_seats'] );
@@ -750,7 +750,7 @@ function eme_ajax_recurrences_list() {
 			foreach ( $categories as $cat ) {
 				$category = eme_get_category( $cat );
 				if ( $category ) {
-					$cat_names[] = eme_trans_esc_html( $category['category_name'] );
+					$cat_names[] = esc_html( eme_translate( $category['category_name'] ) );
 				}
 			}
 			$record['event_name'] .= implode( ', ', $cat_names );
@@ -763,20 +763,20 @@ function eme_ajax_recurrences_list() {
 		if ( empty( $location['location_name'] ) ) {
 				$record['location_name'] = '';
 		} else {
-				$record['location_name'] = "<a href='" . admin_url( 'admin.php?page=eme-locations&amp;eme_admin_action=edit_location&amp;location_id=' . $location['location_id'] ) . "' title='" . __( 'Edit location', 'events-made-easy' ) . "'>" . eme_trans_esc_html( $location['location_name'] ) . '</a>';
+				$record['location_name'] = "<a href='" . esc_url( admin_url( 'admin.php?page=eme-locations&eme_admin_action=edit_location&location_id=' . $location['location_id'] ) ) . "' title='" . __( 'Edit location', 'events-made-easy' ) . "'>" . esc_html( eme_translate( $location['location_name'] ) ) . '</a>';
 			if ( ! $location['location_latitude'] && ! $location['location_longitude'] && get_option( 'eme_map_is_active' ) && ! $event['location_properties']['online_only'] ) {
 					$record['location_name'] .= "&nbsp;<img style='vertical-align: middle;' src='" . esc_url(EME_PLUGIN_URL) . "images/warning.png' alt='warning' title='" . __( 'Location map coordinates are empty! Please edit the location to correct this, otherwise it will not show correctly on your website.', 'events-made-easy' ) . "'>";
 			}
 		}
 
 		if ( ! empty( $location['location_address1'] ) || ! empty( $location['location_address2'] ) ) {
-			$record['location_name'] .= '<br>' . eme_trans_esc_html( $location['location_address1'] ) . ' ' . eme_trans_esc_html( $location['location_address2'] );
+			$record['location_name'] .= '<br>' . esc_html( eme_translate( $location['location_address1'] ) ) . ' ' . esc_html( eme_translate( $location['location_address2'] ) );
 		}
 		if ( ! empty( $location['location_city'] ) || ! empty( $location['location_state'] ) || ! empty( $location['location_zip'] ) || ! empty( $location['location_country'] ) ) {
-			$record['location_name'] .= '<br>' . eme_trans_esc_html( $location['location_city'] ) . ' ' . eme_trans_esc_html( $location['location_state'] ) . ' ' . eme_trans_esc_html( $location['location_zip'] ) . ' ' . eme_trans_esc_html( $location['location_country'] );
+			$record['location_name'] .= '<br>' . esc_html( eme_translate( $location['location_city'] ) ) . ' ' . esc_html( eme_translate( $location['location_state'] ) ) . ' ' . esc_html( eme_translate( $location['location_zip'] ) ) . ' ' . esc_html( eme_translate( $location['location_country'] ) );
 		}
 		if ( ! $location['location_properties']['online_only'] && ! empty( $location['location_url'] ) ) {
-			$record['location_name'] .= '<br>' . eme_trans_esc_html( $location['location_url'] );
+			$record['location_name'] .= '<br>' . esc_html( eme_translate( $location['location_url'] ) );
 		}
 
 		if ( isset( $event_status_array[ $event['event_status'] ] ) ) {

--- a/eme-rsvp.php
+++ b/eme-rsvp.php
@@ -3794,7 +3794,7 @@ function eme_replace_booking_placeholders( $format, $event, $booking, $is_multib
             if ( isset( $booking[ $tmp_attkey ] ) && ! is_array( $booking[ $tmp_attkey ] ) ) {
                 $replacement = $booking[ $tmp_attkey ];
                 if ( $target == 'html' ) {
-                    $replacement = eme_trans_esc_html( $replacement, $lang );
+                    $replacement = esc_html( eme_translate( $replacement, $lang ) );
                     $replacement = apply_filters( 'eme_general', $replacement );
                 } elseif ( $target == 'rss' ) {
                     $replacement = eme_translate( $replacement, $lang );
@@ -3942,7 +3942,7 @@ function eme_replace_booking_placeholders( $format, $event, $booking, $is_multib
             $formfield = eme_get_formfield( $field_key );
             if ( ! empty( $formfield ) ) {
                 if ( $target == 'html' ) {
-                    $replacement = eme_trans_esc_html( $formfield['field_name'], $lang );
+                    $replacement = esc_html( eme_translate( $formfield['field_name'], $lang ) );
                     $replacement = apply_filters( 'eme_general', $replacement );
                 } else {
                     $replacement = eme_translate( $formfield['field_name'], $lang );
@@ -4805,7 +4805,7 @@ function eme_registration_seats_page( $pending = 0 ) {
             return;
         }
         // we need to set the action url, otherwise the GET parameters stay and we will fall in this if-statement all over again
-        $action_url  = admin_url( "admin.php?page=$plugin_page" );
+        $action_url  = esc_url( admin_url( "admin.php?page=$plugin_page" ) );
         $nonce_field = wp_nonce_field( "eme_admin", 'eme_admin_nonce', false, false );
         $ret_string  = '<h1>' . __( 'Add booking', 'events-made-easy' ) . '</h1>';
         if ( get_option( 'eme_rsvp_admin_allow_overbooking' ) ) {
@@ -4844,10 +4844,10 @@ function eme_registration_seats_page( $pending = 0 ) {
         }
 
         // we need to set the action url, otherwise the GET parameters stay and we will fall in this if-statement all over again
-        $action_url  = admin_url( "admin.php?page=$plugin_page" );
+        $action_url  = esc_url( admin_url( "admin.php?page=$plugin_page" ) );
         $nonce_field = wp_nonce_field( "eme_admin", 'eme_admin_nonce', false, false );
         $ret_string  = '<h1>' . esc_html__( 'Edit booking', 'events-made-easy' ) . '</h1>';
-        $ret_string .= "<a href='" . admin_url( 'admin.php?page=eme-people&amp;eme_admin_action=edit_person&amp;person_id=' . $booking['person_id'] ) . "' title='" . esc_attr__( 'Click on this link to edit the corresponding person info', 'events-made-easy' ) . "'>" . esc_html__( 'Click on this link to edit the corresponding person info', 'events-made-easy' ) . '</a><br><br>';
+        $ret_string .= "<a href='" . esc_url( admin_url( 'admin.php?page=eme-people&eme_admin_action=edit_person&person_id=' . $booking['person_id'] ) ) . "' title='" . esc_attr__( 'Click on this link to edit the corresponding person info', 'events-made-easy' ) . "'>" . esc_html__( 'Click on this link to edit the corresponding person info', 'events-made-easy' ) . '</a><br><br>';
 
         // the event id can be empty if we are editng a booking where the event has been removed
         if ( ! empty( $event['event_id'] ) ) {
@@ -5238,9 +5238,9 @@ function eme_registration_seats_form_table( $pending = 0 ) {
         } else {
             $event_q_string = '&event_id=' . intval( $_GET['event_id'] );
             if ( $pending ) {
-                printf( __( 'Manage pending bookings for %s', 'events-made-easy' ), eme_trans_esc_html( $event['event_name'] ) );
+                printf( __( 'Manage pending bookings for %s', 'events-made-easy' ), esc_html( eme_translate( $event['event_name'] ) ) );
             } else {
-                printf( __( 'Manage approved bookings for %s', 'events-made-easy' ), eme_trans_esc_html( $event['event_name'] ) );
+                printf( __( 'Manage approved bookings for %s', 'events-made-easy' ), esc_html( eme_translate( $event['event_name'] ) ) );
             }
         }
     } else {
@@ -5257,9 +5257,9 @@ function eme_registration_seats_form_table( $pending = 0 ) {
 ?>
 </h1>
     <?php if ( $trash ) { ?>
-        <a href="<?php echo admin_url( "admin.php?page=$plugin_page&trash=0$event_q_string" ); ?>"><?php esc_html_e( 'Show regular content', 'events-made-easy' ); ?></a><br>
+        <a href="<?php echo esc_url( admin_url( "admin.php?page=$plugin_page&trash=0$event_q_string" ) ); ?>"><?php esc_html_e( 'Show regular content', 'events-made-easy' ); ?></a><br>
     <?php } else { ?>
-        <a href="<?php echo admin_url( "admin.php?page=$plugin_page&trash=1$event_q_string" ); ?>"><?php esc_html_e( 'Show trash content', 'events-made-easy' ); ?></a><br>
+        <a href="<?php echo esc_url( admin_url( "admin.php?page=$plugin_page&trash=1$event_q_string" ) ); ?>"><?php esc_html_e( 'Show trash content', 'events-made-easy' ); ?></a><br>
         <div id="bookings-message" class="eme-hidden"></div>
         <span class="eme_import_form_img">
         <?php esc_html_e( 'Click on the icon to show the import form to import payments', 'events-made-easy' ); ?>
@@ -5895,7 +5895,7 @@ function eme_ajax_bookings_list() {
             } else {
                 $line['wp_user'] = '';
             }
-            $line['booker'] = "<a href='" . admin_url( 'admin.php?page=eme-people&amp;eme_admin_action=edit_person&amp;person_id=' . $person['person_id'] ) . "' title='" . __( 'Click the name of the booker in order to see and/or edit the details of the booker.', 'events-made-easy' ) . "'>" . eme_esc_html( $person_info_shown ) . '</a>';
+            $line['booker'] = "<a href='" . esc_url( admin_url( 'admin.php?page=eme-people&eme_admin_action=edit_person&person_id=' . $person['person_id'] ) ) . "' title='" . __( 'Click the name of the booker in order to see and/or edit the details of the booker.', 'events-made-easy' ) . "'>" . eme_esc_html( $person_info_shown ) . '</a>';
             $line['person_id'] = $booking['person_id'];
         } else {
             $line['booker']  = __( 'Anonymous', 'events-made-easy' );
@@ -5935,7 +5935,7 @@ function eme_ajax_bookings_list() {
         if ( $trash ) {
             $line['edit_link'] = '';
         } else {
-            $line['edit_link'] = "<a href='" . wp_nonce_url( admin_url( "admin.php?page=$page&amp;eme_admin_action=editBooking&amp;booking_id=" . $booking ['booking_id'] ), 'eme_admin', 'eme_admin_nonce' ) . "' title='" . esc_attr__( 'Click here to see and/or edit the details of the booking.', 'events-made-easy' ) . "'>" . "<img src='" . esc_url(EME_PLUGIN_URL) . "images/edit.png' alt='" . esc_attr__( 'Edit', 'events-made-easy' ) . "'> " . '</a>';
+            $line['edit_link'] = "<a href='" . esc_url( wp_nonce_url( admin_url( "admin.php?page=$page&eme_admin_action=editBooking&booking_id=" . $booking ['booking_id'] ), 'eme_admin', 'eme_admin_nonce' ) ) . "' title='" . esc_attr__( 'Click here to see and/or edit the details of the booking.', 'events-made-easy' ) . "'>" . "<img src='" . esc_url(EME_PLUGIN_URL) . "images/edit.png' alt='" . esc_attr__( 'Edit', 'events-made-easy' ) . "'> " . '</a>';
         }
         if ( ! isset( $event_name_info[ $event_id ] ) ) {
             $event_name_info[ $event_id ] = '';
@@ -5944,7 +5944,7 @@ function eme_ajax_bookings_list() {
             $add_event_info = 0;
         }
         if ( $add_event_info ) {
-            $event_name_info[ $event_id ] .= "<strong><a href='" . admin_url( 'admin.php?page=eme-manager&amp;eme_admin_action=edit_event&amp;event_id=' . $event['event_id'] ) . "' title='" . esc_attr__( 'Edit event', 'events-made-easy' ) . "'>" . eme_trans_esc_html( $event['event_name'] ) . '</a></strong>';
+            $event_name_info[ $event_id ] .= "<strong><a href='" . esc_url( admin_url( 'admin.php?page=eme-manager&eme_admin_action=edit_event&event_id=' . $event['event_id'] ) ) . "' title='" . esc_attr__( 'Edit event', 'events-made-easy' ) . "'>" . esc_html( eme_translate( $event['event_name'] ) ) . '</a></strong>';
         }
         if ( $event['event_rsvp'] ) {
             if ( $add_event_info ) {
@@ -5978,19 +5978,19 @@ function eme_ajax_bookings_list() {
                         $available_seats_string = $available_seats;
                     }
                     $event_name_info[ $event_id ] .= esc_html__( 'Free:', 'events-made-easy' ) .' '. $available_seats_string;
-                    $event_name_info[ $event_id ] .= ', ' . "<a href='" . admin_url( 'admin.php?page=eme-registration-seats&amp;event_id=' . $event['event_id'] ) . "'>$booked_string $booked_seats_string</a>";
+                    $event_name_info[ $event_id ] .= ', ' . "<a href='" . esc_url( admin_url( 'admin.php?page=eme-registration-seats&event_id=' . $event['event_id'] ) ) . "'>$booked_string $booked_seats_string</a>";
                 } else {
                     $total_seats_string                    = '&infin;';
-                    $event_name_info[ $event_id ] .= "<a href='" . admin_url( 'admin.php?page=eme-registration-seats&amp;event_id=' . $event['event_id'] ) . "'>$booked_string $booked_seats_string</a>";
+                    $event_name_info[ $event_id ] .= "<a href='" . esc_url( admin_url( 'admin.php?page=eme-registration-seats&event_id=' . $event['event_id'] ) ) . "'>$booked_string $booked_seats_string</a>";
                 }
 
                 if ( $pending_seats > 0 ) {
-                    $event_name_info[ $event_id ] .= ', ' . "<a href='" . admin_url( 'admin.php?page=eme-registration-approval&amp;event_id=' . $event['event_id'] ) . "'>" . __( 'Pending:', 'events-made-easy' ) . " $pending_seats_string</a>";
+                    $event_name_info[ $event_id ] .= ', ' . "<a href='" . esc_url( admin_url( 'admin.php?page=eme-registration-approval&event_id=' . $event['event_id'] ) ) . "'>" . __( 'Pending:', 'events-made-easy' ) . " $pending_seats_string</a>";
                 }
                 if ( $event['event_properties']['take_attendance'] ) {
                     $absent_bookings = eme_get_absent_bookings( $event['event_id'] );
                     if ( $absent_bookings > 0 ) {
-                        $event_name_info[ $event_id ] .= ', ' . "<a href='" . admin_url( 'admin.php?page=eme-registration-seats&amp;event_id=' . $event['event_id'] ) . "'>" . __( 'Absent:', 'events-made-easy' ) . " $absent_bookings</a>";
+                        $event_name_info[ $event_id ] .= ', ' . "<a href='" . esc_url( admin_url( 'admin.php?page=eme-registration-seats&event_id=' . $event['event_id'] ) ) . "'>" . __( 'Absent:', 'events-made-easy' ) . " $absent_bookings</a>";
                     }
                 }
                 if (!empty($location) && $location['location_properties']['max_capacity'] && $location['location_properties']['max_capacity']<$total_seats) {
@@ -6006,8 +6006,8 @@ function eme_ajax_bookings_list() {
                 }
 
                 if ( $booked_seats > 0 || $pending_seats > 0 ) {
-                    $printable_address            = admin_url( 'admin.php?page=eme-people&amp;eme_admin_action=booking_printable&amp;event_id=' . $event['event_id'] );
-                    $csv_address                  = admin_url( 'admin.php?page=eme-people&amp;eme_admin_action=booking_csv&amp;event_id=' . $event['event_id'] );
+                    $printable_address            = admin_url( 'admin.php?page=eme-people&eme_admin_action=booking_printable&event_id=' . $event['event_id'] );
+                    $csv_address                  = admin_url( 'admin.php?page=eme-people&eme_admin_action=booking_csv&event_id=' . $event['event_id'] );
                     $event_name_info[ $event_id ] .= " <br>(<a id='booking_printable_" . $event['event_id'] . "' href='".esc_url($printable_address)."'>" . __( 'Printable view', 'events-made-easy' ) . '</a>)';
                     $event_name_info[ $event_id ] .= " (<a id='booking_csv_" . $event['event_id'] . "' href='".esc_url($csv_address)."'>" . __( 'CSV export', 'events-made-easy' ) . '</a>)';
                 }
@@ -6019,7 +6019,7 @@ function eme_ajax_bookings_list() {
                 $page = 'eme-registration-seats';
             }
 
-            $line['rsvp'] = "<a href='" . wp_nonce_url( admin_url( "admin.php?page=$page&amp;eme_admin_action=newBooking&amp;event_id=" . $event['event_id'] ), 'eme_admin', 'eme_admin_nonce' ) . "' title='" . esc_attr__( 'Add booking for this event', 'events-made-easy' ) . "'>" . esc_html__( 'RSVP', 'events-made-easy' ) . '</a>';
+            $line['rsvp'] = "<a href='" . esc_url( wp_nonce_url( admin_url( "admin.php?page=$page&eme_admin_action=newBooking&event_id=" . $event['event_id'] ), 'eme_admin', 'eme_admin_nonce' ) ) . "' title='" . esc_attr__( 'Add booking for this event', 'events-made-easy' ) . "'>" . esc_html__( 'RSVP', 'events-made-easy' ) . '</a>';
             if ( ! empty( $event['event_properties']['rsvp_password'] ) ) {
                 $line['rsvp'] .= '<br>(' . esc_html__( 'Password protected', 'events-made-easy' ) . ')';
             }
@@ -6044,9 +6044,9 @@ function eme_ajax_bookings_list() {
                 #$event_name_info[ $event_id ] .= '<br>' . esc_html__( sprintf( 'Task Info: %d tasks, %d/%d/%d free/used/total slots', 'events-made-easy' ), $task_count, $free_spaces, $used_spaces, $total_spaces );
                 $event_name_info[ $event_id ] .= '<br>' . sprintf( __('Task Info: %d tasks', 'events-made-easy' ), $task_count );
                 if ( $pending_spaces >0 ) {
-                    $event_name_info[ $event_id ] .= ', ' . "<a href='" . admin_url( 'admin.php?page=eme-task-signups&amp;status=0&amp;event_id=' . $event['event_id'] ) . "'>" . __( 'Pending:', 'events-made-easy' ) . " $pending_spaces</a>";
+                    $event_name_info[ $event_id ] .= ', ' . "<a href='" . esc_url( admin_url( 'admin.php?page=eme-task-signups&status=0&event_id=' . $event['event_id'] ) ) . "'>" . __( 'Pending:', 'events-made-easy' ) . " $pending_spaces</a>";
                 }
-                $event_name_info[ $event_id ] .= ', ' . "<a href='" . admin_url( 'admin.php?page=eme-task-signups&amp;status=1&amp;event_id=' . $event['event_id'] ) . "'>" . __( 'Approved:', 'events-made-easy' ) . " $used_spaces</a>";
+                $event_name_info[ $event_id ] .= ', ' . "<a href='" . esc_url( admin_url( 'admin.php?page=eme-task-signups&status=1&event_id=' . $event['event_id'] ) ) . "'>" . __( 'Approved:', 'events-made-easy' ) . " $used_spaces</a>";
             }
         }
 

--- a/eme-tasks.php
+++ b/eme-tasks.php
@@ -1295,7 +1295,7 @@ function eme_tasks_signups_shortcode( $atts ) {
         $result .= eme_replace_event_placeholders( $header, $event );
         foreach ( $tasks as $task ) {
             if ( $task['spaces'] == 0 ) {
-                $result .= '<br><span class="eme_task_section_header">'.eme_trans_esc_html( $task['name'], $lang ).'</span><br>';
+                $result .= '<br><span class="eme_task_section_header">'.esc_html( eme_translate( $task['name'], $lang ) ).'</span><br>';
             } else {
                 $signups = eme_get_task_signups( $task['task_id'] );
                 foreach ( $signups as $signup ) {
@@ -1584,7 +1584,7 @@ function eme_tasks_signupform_shortcode( $atts ) {
                 ++$open_tasks_found;
             }
             if ( $task['spaces'] == 0 ) {
-                $result .= '<br><span class="eme_task_section_header">'.eme_trans_esc_html( $task['name'], $lang ).'</span><br>';
+                $result .= '<br><span class="eme_task_section_header">'.esc_html( eme_translate( $task['name'], $lang ) ).'</span><br>';
             } elseif ( ! $skip ) {
                 $result .= eme_replace_eventtaskformfields_placeholders( $format, $task, $event );
             }
@@ -2142,8 +2142,8 @@ function eme_ajax_task_signups_list() {
             $localized_taskstart_date    = eme_localized_datetime( $row['task_start'], EME_TIMEZONE, 1 );
             $localized_taskend_date      = eme_localized_datetime( $row['task_end'], EME_TIMEZONE, 1 );
             $localized_signup_date       = eme_localized_datetime( $row['signup_date'], EME_TIMEZONE, 1 );
-            $row['event_name']  = "<strong><a href='" . admin_url( 'admin.php?page=eme-manager&amp;eme_admin_action=edit_event&amp;event_id=' . $row['event_id'] ) . "' title='" . __( 'Edit event', 'events-made-easy' ) . "'>" . eme_trans_esc_html( $row['event_name'] ) . '</a></strong><br>' . $localized_start_date . ' - ' . $localized_end_date;
-            $csv_address = admin_url( 'admin.php?page=eme-people&amp;eme_admin_action=tasksignups_csv&amp;event_id=' . $row['event_id'] );
+            $row['event_name']  = "<strong><a href='" . esc_url( admin_url( 'admin.php?page=eme-manager&eme_admin_action=edit_event&event_id=' . $row['event_id'] ) ) . "' title='" . __( 'Edit event', 'events-made-easy' ) . "'>" . esc_html( eme_translate( $row['event_name'] ) ) . '</a></strong><br>' . $localized_start_date . ' - ' . $localized_end_date;
+            $csv_address = esc_url( admin_url( 'admin.php?page=eme-people&eme_admin_action=tasksignups_csv&event_id=' . $row['event_id'] ) );
             $row['event_name'] .= " (<a id='tasksignups_csv_" . $row['event_id'] . "' href='".esc_url($csv_address)."'>" . __( 'CSV export', 'events-made-easy' ) . '</a>)';
             $row['task_name']   = eme_esc_html( $row['task_name'] );
             $row['comment']     = nl2br(eme_esc_html( $row['comment'] ));
@@ -2155,7 +2155,7 @@ function eme_ajax_task_signups_list() {
             } else {
                 $row['signup_status'] = __('Pending', 'events-made-easy');
             }
-            $row['person_info'] = "<a href='" . admin_url( 'admin.php?page=eme-people&amp;eme_admin_action=edit_person&amp;person_id=' . $row['person_id'] ) . "' title='" . __( 'Edit person', 'events-made-easy' ) . "'>" . eme_esc_html( eme_format_full_name( $row['firstname'], $row['lastname'], $row['email'] ) ) . '</a>' . ' (' . eme_esc_html( $row['email'] ) . ')';
+            $row['person_info'] = "<a href='" . esc_url( admin_url( 'admin.php?page=eme-people&eme_admin_action=edit_person&person_id=' . $row['person_id'] ) ) . "' title='" . __( 'Edit person', 'events-made-easy' ) . "'>" . eme_esc_html( eme_format_full_name( $row['firstname'], $row['lastname'], $row['email'] ) ) . '</a>' . ' (' . eme_esc_html( $row['email'] ) . ')';
 
             foreach ( $formfields as $formfield ) {
                 foreach ( $answers as $answer ) {

--- a/eme-templates.php
+++ b/eme-templates.php
@@ -150,7 +150,7 @@ function eme_templates_table_layout( $message = '' ) {
     global $plugin_page;
 
     $template_types = eme_template_types();
-    $destination    = admin_url( "admin.php?page=$plugin_page" );
+    $destination    = esc_url( admin_url( "admin.php?page=$plugin_page" ) );
     if ( empty( $message ) ) {
         $hidden_class = 'eme-hidden';
     } else {
@@ -480,8 +480,8 @@ function eme_ajax_templates_list() {
             $row['id'] = $val['id'];
             $row['description'] = $val['description'];
             $row[ 'type'] = $template_types[ $val['type'] ];
-            $row[ 'name'] = "<a href='" . admin_url( 'admin.php?page=eme-templates&amp;eme_admin_action=edit_template&amp;id=' . $val['id'] ) . "'>" . $val['name'] . '</a>';
-            $copy_link='window.location.href="'.admin_url( 'admin.php?page=eme-templates&amp;eme_admin_action=copy_template&amp;id=' . $val['id'] ).'";';
+            $row[ 'name'] = "<a href='" . esc_url( admin_url( 'admin.php?page=eme-templates&eme_admin_action=edit_template&id=' . $val['id'] ) ) . "'>" . esc_html( $val['name'] ) . '</a>';
+            $copy_link='window.location.href="'.esc_url( admin_url( 'admin.php?page=eme-templates&eme_admin_action=copy_template&id=' . $val['id'] ) ).'";';
             $row[ 'copy'] = "<button onclick='$copy_link' title='" . __( 'Duplicate this template', 'events-made-easy' ) . "' class='ftable-command-button eme-copy-button'><span>copy</span></a>";
             $rows[] = $row;
         }


### PR DESCRIPTION
## Summary

- Replace all ~209 `eme_trans_esc_html()` calls with PHPCS-recognized WP core functions:
  - `esc_html(eme_translate())` for HTML text content
  - `esc_attr(eme_translate())` for HTML attribute values (value=, alt=, placeholder=, title=)
- Wrap all ~148 `admin_url()` calls in output context with `esc_url()` for proper URL escaping
- Where `admin_url()` was inside `wp_nonce_url()`, the outer `wp_nonce_url()` is wrapped instead
- Cleaned up `&amp;` to `&` inside `admin_url()` parameters where `esc_url()` now handles the encoding
- Function definition in eme-translate.php preserved for backwards compatibility

21 files changed, 347 insertions, 365 deletions.

## Test plan

- [x] PHP syntax check on all 21 modified files — all pass
- [x] Full test suite: 73/76 pass (3 pre-existing CSRF nonce failures unrelated to this PR)
- [x] Verified zero remaining `eme_trans_esc_html()` calls outside eme-translate.php
- [x] Verified all `admin_url()` in output context properly escaped
- [ ] Manual verification of admin pages (events, locations, members, formfields, etc.)
- [ ] Verify translated strings still display correctly