### PR TITLE
Add phpcs:ignore for trusted eme_ui_select() output

### DIFF
--- a/eme-attendances.php
+++ b/eme-attendances.php
@@ -127,7 +127,7 @@ function eme_attendances_table_layout( $message = '' ) {
          <input type='hidden' name='eme_admin_action' value='add_attendance'>
          <input type='hidden' name='person_id' value=''>
          "
-         . eme_ui_select( '', 'person_id', [], '', 1, 'eme_snapselect_people_class', $snapselect_attributes )
+         . eme_ui_select( '', 'person_id', [], '', 1, 'eme_snapselect_people_class', $snapselect_attributes ) //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select()
          . ' '. esc_html__( 'Optional attendance date and time: ', 'events-made-easy' ) . "
          <input type='hidden' name='attendance_actualdate' id='attendance_actualdate' value=''>
          <input type='text' readonly='readonly' name='attendance_date' id='attendance_date' data-date='' data-alt-field='attendance_actualdate' data-multiple='false' class='eme_formfield_fdatetime'><br>

--- a/eme-categories.php
+++ b/eme-categories.php
@@ -175,7 +175,7 @@ function eme_categories_edit_layout() {
 						$categories_prefixes_arr[ $categories_prefix ] = eme_permalink_convert( $categories_prefix );
 					}
 					$prefix = $category['category_prefix'] ? $category['category_prefix'] : '';
-					echo eme_ui_select( $prefix, 'category_prefix', $categories_prefixes_arr );
+					echo eme_ui_select( $prefix, 'category_prefix', $categories_prefixes_arr ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select()
 				} else {
 					echo eme_permalink_convert( $categories_prefixes );
 				}

--- a/eme-cron.php
+++ b/eme-cron.php
@@ -426,22 +426,22 @@ function eme_cron_form( $message = '' ) {
         <?php $templates_array = eme_get_templates_array_by_id( 'rsvpmail' ); ?>
 <?php
         esc_html_e( 'Email subject template', 'events-made-easy' );
-        echo eme_ui_select( $subject, 'eme_cron_new_events_subject', $templates_array );
+        echo eme_ui_select( $subject, 'eme_cron_new_events_subject', $templates_array ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select()
 ?>
         <br>
 <?php
         esc_html_e( 'Email body header', 'events-made-easy' );
-        echo eme_ui_select( $header, 'eme_cron_new_events_header', $templates_array );
+        echo eme_ui_select( $header, 'eme_cron_new_events_header', $templates_array ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select()
 ?>
         <br>
 <?php
         esc_html_e( 'Email body single event entry', 'events-made-easy' );
-        echo eme_ui_select( $entry, 'eme_cron_new_events_entry', $templates_array );
+        echo eme_ui_select( $entry, 'eme_cron_new_events_entry', $templates_array ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select()
 ?>
         <br>
 <?php
         esc_html_e( 'Email body footer', 'events-made-easy' );
-        echo eme_ui_select( $footer, 'eme_cron_new_events_footer', $templates_array );
+        echo eme_ui_select( $footer, 'eme_cron_new_events_footer', $templates_array ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select()
 ?>
         <br>
     <input type='hidden' name='eme_admin_action' value='eme_cron_send_new_events'>

--- a/eme-discounts.php
+++ b/eme-discounts.php
@@ -457,10 +457,10 @@ function eme_manage_discounts_layout( $message = '' ) {
 	<option value="changeValidTo"><?php esc_html_e( 'Change "valid until" date', 'events-made-easy' ); ?></option>
 	</select>
 	<span id="span_addtogroup" class="eme-hidden">
-	<?php echo eme_ui_select_key_value( '', 'addtogroup', $dgroups, 'id', 'name', __( 'Select a group', 'events-made-easy' ), 1 ); ?>
+	<?php echo eme_ui_select_key_value( '', 'addtogroup', $dgroups, 'id', 'name', __( 'Select a group', 'events-made-easy' ), 1 ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select() ?>
 	</span>
 	<span id="span_removefromgroup" class="eme-hidden">
-	<?php echo eme_ui_select_key_value( '', 'removefromgroup', $dgroups, 'id', 'name', __( 'Select a group', 'events-made-easy' ), 1 ); ?>
+	<?php echo eme_ui_select_key_value( '', 'removefromgroup', $dgroups, 'id', 'name', __( 'Select a group', 'events-made-easy' ), 1 ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select() ?>
 	</span>
 	<span id="span_newvalidfrom" class="eme-hidden">
 	<input id="new_validfrom" type="hidden" name="new_validfrom" value="">
@@ -869,7 +869,7 @@ function eme_discounts_edit_layout( $discount_id = 0, $message = '' ) {
 		</tr>
 		<tr class='form-field'>
 			<th scope='row' style='vertical-align:top'><label for='type'><?php esc_html_e( 'Type', 'events-made-easy' ); ?></label></th>
-			<td><?php echo eme_ui_select( $discount['type'], 'type', $discount_types ); ?>
+			<td><?php echo eme_ui_select( $discount['type'], 'type', $discount_types ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select() ?>
 			<br><?php esc_html_e( 'For type "Code" you have to create your own discount filters, please read the documention for this', 'events-made-easy' ); ?>
 		</tr>
 		<tr class='form-field'>
@@ -888,7 +888,7 @@ function eme_discounts_edit_layout( $discount_id = 0, $message = '' ) {
 		</tr>
 		<tr class='form-field'>
 			<th scope='row' style='vertical-align:top'><label for='properties[voucher]'><?php esc_html_e( 'Credit Voucher', 'events-made-easy' ); ?></label></th>
-			<td><?php echo eme_ui_select_binary( $discount['properties']['voucher'], 'properties[voucher]' ); ?>
+			<td><?php echo eme_ui_select_binary( $discount['properties']['voucher'], 'properties[voucher]' ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select() ?>
 			<br><p class='eme_smaller'><?php esc_html_e( 'Applies to fixed discounts only. When used as a credit voucher, the discount can be redeemed multiple times until the full value is consumed. The discount value will always show the remaining voucher balance.', 'events-made-easy' ); ?></p>
 			</td>
 		</tr>
@@ -914,13 +914,13 @@ function eme_discounts_edit_layout( $discount_id = 0, $message = '' ) {
 		</tr>
 		<tr class='form-field'>
 			<th scope='row' style='vertical-align:top'><label for='properties[invite_only]'><?php esc_html_e( 'Invited people only', 'events-made-easy' ); ?></label></th>
-			<td><?php echo eme_ui_select_binary( $discount['properties']['invite_only'], 'properties[invite_only]' ); ?>
+			<td><?php echo eme_ui_select_binary( $discount['properties']['invite_only'], 'properties[invite_only]' ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select() ?>
 			<br><p class='eme_smaller'><?php esc_html_e( 'People need to be invited and click on the invitation URL for this discount to apply.', 'events-made-easy' ); ?></p>
 			</td>
 		</tr>
 		<tr class='form-field'>
 			<th scope='row' style='vertical-align:top'><label for='properties[wp_users_only]'><?php esc_html_e( 'Logged-in users only', 'events-made-easy' ); ?></label></th>
-			<td><?php echo eme_ui_select_binary( $discount['properties']['wp_users_only'], 'properties[wp_users_only]' ); ?>
+			<td><?php echo eme_ui_select_binary( $discount['properties']['wp_users_only'], 'properties[wp_users_only]' ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select() ?>
 			<br><p class='eme_smaller'><?php esc_html_e( 'Require users to be logged-in for this discount to apply.', 'events-made-easy' ); ?></p>
 			</td>
 		</tr>
@@ -952,7 +952,7 @@ function eme_discounts_edit_layout( $discount_id = 0, $message = '' ) {
 		</tr>
 		<tr class='form-field'>
 			<th scope='row' style='vertical-align:top'><label for='strcase'><?php esc_html_e( 'Case sensitive?', 'events-made-easy' ); ?></label></th>
-			<td><?php echo eme_ui_select_binary( $discount['strcase'], 'strcase' ); ?></td>
+			<td><?php echo eme_ui_select_binary( $discount['strcase'], 'strcase' ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select() ?></td>
 		</tr>
 		<tr class='form-field'>
 			<th scope='row' style='vertical-align:top'><label for='maxcount'><?php esc_html_e( 'Maximum usage count', 'events-made-easy' ); ?></label></th>
@@ -988,7 +988,7 @@ function eme_discounts_edit_layout( $discount_id = 0, $message = '' ) {
 	<?php } ?>
 		<tr class='form-field'>
 			<th scope='row' style='vertical-align:top'><label for='use_per_seat'><?php esc_html_e( 'Count usage per seat?', 'events-made-easy' ); ?></label></th>
-			<td><?php echo eme_ui_select_binary( $discount['use_per_seat'], 'use_per_seat' ); ?>
+			<td><?php echo eme_ui_select_binary( $discount['use_per_seat'], 'use_per_seat' ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select() ?>
 			<br><?php esc_html_e( 'By default the coupon usage count is counted per form submit. If you want, you can augment the usage count by the number of seats booked instead.', 'events-made-easy' ); ?>
 			</td>
 		</tr>

--- a/eme-events.php
+++ b/eme-events.php
@@ -6199,11 +6199,11 @@ function eme_events_table( $message = '' ) {
     <span id="span_sendtrashmails" class="eme-hidden">
 <?php
         esc_html_e( 'Send emails for cancelled bookings too?', 'events-made-easy' );
-        echo eme_ui_select_binary( 0, 'send_trashmails' );
+        echo eme_ui_select_binary( 0, 'send_trashmails' ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select()
 ?>
     </span>
     <span id="span_addtocategory" class="eme-hidden">
-        <?php echo eme_ui_select_key_value( '', 'addtocategory', $categories, 'category_id', 'category_name', __( 'Please select a category', 'events-made-easy' ), 1 ); ?>
+        <?php echo eme_ui_select_key_value( '', 'addtocategory', $categories, 'category_id', 'category_name', __( 'Please select a category', 'events-made-easy' ), 1 ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select() ?>
     </span>
     <button id="EventsActionsButton" class="button-secondary action"><?php esc_html_e( 'Apply', 'events-made-easy' ); ?></button>
     <?php eme_rightclickhint(); ?>
@@ -6833,7 +6833,7 @@ function eme_event_form( $event, $info, $edit_recurrence = 0 ) {
             if ($user_info !== false)
                 $eme_wp_user_arr[ $event_author ] = $user_info->display_name;
         }
-        echo eme_ui_select( $event_author, 'event_author', $eme_wp_user_arr, '', 0, 'eme_snapselect_wpuser_class' );
+        echo eme_ui_select( $event_author, 'event_author', $eme_wp_user_arr, '', 0, 'eme_snapselect_wpuser_class' ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select()
 ?>
         </p>
         </div>
@@ -6852,7 +6852,7 @@ function eme_event_form( $event, $info, $edit_recurrence = 0 ) {
             if ($user_info !== false)
                 $eme_wp_user_arr[ $event['event_contactperson_id'] ] = $user_info->display_name;
         }
-        echo eme_ui_select( $event['event_contactperson_id'], 'event_contactperson_id', $eme_wp_user_arr, '', 0, 'eme_snapselect_wpuser_class' );
+        echo eme_ui_select( $event['event_contactperson_id'], 'event_contactperson_id', $eme_wp_user_arr, '', 0, 'eme_snapselect_wpuser_class' ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select()
         // if it is not a new event and there's no contact person defined, then the event author becomes contact person
         // So let's display a warning what this means if there's no author (like when submitting via the frontend submission form)
         if ( ! $is_new_event && $event['event_contactperson_id'] < 1 && $event['event_author'] < 1 ) {
@@ -6893,7 +6893,7 @@ function eme_event_form( $event, $info, $edit_recurrence = 0 ) {
                     <div class="inside">
 <?php
         $templates = get_page_templates();
-        print eme_ui_select_inverted( $event['event_properties']['wp_page_template'], 'eme_prop_wp_page_template', $templates, __( 'Default Template' ) );
+        print eme_ui_select_inverted( $event['event_properties']['wp_page_template'], 'eme_prop_wp_page_template', $templates, __( 'Default Template' ) ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select()
         print '<br>' . __( 'By default the event uses the same WP page template as the defined special events page. If your theme provides several different page templates, chose another one if wanted.', 'events-made-easy' );
 ?>
                     </div>
@@ -7076,7 +7076,7 @@ function eme_meta_box_div_event_name( $event, $edit_recurrence = 0 ) {
             $events_prefixes_arr[ $events_prefix ] = eme_permalink_convert( $events_prefix );
         }
         $prefix = $event['event_prefix'] ? $event['event_prefix'] : '';
-        echo eme_ui_select( $prefix, 'event_prefix', $events_prefixes_arr );
+        echo eme_ui_select( $prefix, 'event_prefix', $events_prefixes_arr ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select()
     } else {
         echo eme_permalink_convert( $events_prefixes );
     }
@@ -7307,7 +7307,7 @@ function eme_meta_box_div_recurrence_info( $recurrence, $edit_recurrence = 0 ) {
     if ( ! empty( $holidays_array_by_id ) ) {
         echo "<br>";
         esc_html_e( 'Holidays: ', 'events-made-easy' );
-        echo eme_ui_select( $recurrence['holidays_id'], 'holidays_id', $holidays_array_by_id );
+        echo eme_ui_select( $recurrence['holidays_id'], 'holidays_id', $holidays_array_by_id ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select()
 ?>
             <p class="eme_smaller">
 <?php
@@ -7337,7 +7337,7 @@ function eme_meta_box_div_event_page_title_format( $event, $templates_array ) {
     </p>
 <?php
     esc_html_e( 'Either choose from a template: ', 'events-made-easy' );
-    echo eme_ui_select( $event['event_properties']['event_page_title_format_tpl'], 'eme_prop_event_page_title_format_tpl', $templates_array );
+    echo eme_ui_select( $event['event_properties']['event_page_title_format_tpl'], 'eme_prop_event_page_title_format_tpl', $templates_array ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select()
 ?>
     <br>
     <?php esc_html_e( 'Or enter your own (if anything is entered here, it takes precedence over the selected template): ', 'events-made-easy' ); ?>
@@ -7371,7 +7371,7 @@ function eme_meta_box_div_event_single_event_format( $event, $templates_array ) 
     </p>
 <?php
     esc_html_e( 'Either choose from a template: ', 'events-made-easy' );
-    echo eme_ui_select( $event['event_properties']['event_single_event_format_tpl'], 'eme_prop_event_single_event_format_tpl', $templates_array );
+    echo eme_ui_select( $event['event_properties']['event_single_event_format_tpl'], 'eme_prop_event_single_event_format_tpl', $templates_array ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select()
 ?>
     <br>
     <?php esc_html_e( 'Or enter your own (if anything is entered here, it takes precedence over the selected template): ', 'events-made-easy' ); ?>
@@ -7407,7 +7407,7 @@ function eme_meta_box_div_event_contactperson_ipn_email( $event, $templates_arra
     </p>
 <?php
     esc_html_e( 'Either choose from a template: ', 'events-made-easy' );
-    echo eme_ui_select( $event['event_properties']['contactperson_registration_ipn_email_subject_tpl'], 'eme_prop_contactperson_registration_ipn_email_subject_tpl', $templates_array );
+    echo eme_ui_select( $event['event_properties']['contactperson_registration_ipn_email_subject_tpl'], 'eme_prop_contactperson_registration_ipn_email_subject_tpl', $templates_array ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select()
 ?>
     <br>
     <?php esc_html_e( 'Or enter your own (if anything is entered here, it takes precedence over the selected template): ', 'events-made-easy' ); ?>
@@ -7429,7 +7429,7 @@ function eme_meta_box_div_event_contactperson_ipn_email( $event, $templates_arra
     </p>
 <?php
     esc_html_e( 'Either choose from a template: ', 'events-made-easy' );
-    echo eme_ui_select( $event['event_properties']['contactperson_registration_ipn_email_body_tpl'], 'eme_prop_contactperson_registration_ipn_email_body_tpl', $templates_array );
+    echo eme_ui_select( $event['event_properties']['contactperson_registration_ipn_email_body_tpl'], 'eme_prop_contactperson_registration_ipn_email_body_tpl', $templates_array ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select()
 ?>
     <br>
     <?php esc_html_e( 'Or enter your own (if anything is entered here, it takes precedence over the selected template): ', 'events-made-easy' ); ?>
@@ -7473,7 +7473,7 @@ function eme_meta_box_div_event_registration_recorded_ok_html( $event, $template
     </p>
 <?php
     esc_html_e( 'Either choose from a template: ', 'events-made-easy' );
-    echo eme_ui_select( $event['event_properties']['event_registration_recorded_ok_html_tpl'], 'eme_prop_event_registration_recorded_ok_html_tpl', $templates_array );
+    echo eme_ui_select( $event['event_properties']['event_registration_recorded_ok_html_tpl'], 'eme_prop_event_registration_recorded_ok_html_tpl', $templates_array ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select()
 ?>
     <br>
     <?php esc_html_e( 'Or enter your own (if anything is entered here, it takes precedence over the selected template): ', 'events-made-easy' ); ?>
@@ -7515,7 +7515,7 @@ function eme_meta_box_div_event_registration_approved_email( $event, $templates_
     </p>
 <?php
     esc_html_e( 'Either choose from a template: ', 'events-made-easy' );
-    echo eme_ui_select( $event['event_properties']['event_respondent_email_subject_tpl'], 'eme_prop_event_respondent_email_subject_tpl', $templates_array );
+    echo eme_ui_select( $event['event_properties']['event_respondent_email_subject_tpl'], 'eme_prop_event_respondent_email_subject_tpl', $templates_array ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select()
 ?>
     <br>
     <?php esc_html_e( 'Or enter your own (if anything is entered here, it takes precedence over the selected template): ', 'events-made-easy' ); ?>
@@ -7537,7 +7537,7 @@ function eme_meta_box_div_event_registration_approved_email( $event, $templates_
     </p>
 <?php
     esc_html_e( 'Either choose from a template: ', 'events-made-easy' );
-    echo eme_ui_select( $event['event_properties']['event_respondent_email_body_tpl'], 'eme_prop_event_respondent_email_body_tpl', $templates_array );
+    echo eme_ui_select( $event['event_properties']['event_respondent_email_body_tpl'], 'eme_prop_event_respondent_email_body_tpl', $templates_array ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select()
 ?>
     <br>
     <?php esc_html_e( 'Or enter your own (if anything is entered here, it takes precedence over the selected template): ', 'events-made-easy' ); ?>
@@ -7563,7 +7563,7 @@ function eme_meta_box_div_event_registration_approved_email( $event, $templates_
     </p>
 <?php
     esc_html_e( 'Either choose from a template: ', 'events-made-easy' );
-    echo eme_ui_select( $event['event_properties']['event_contactperson_email_subject_tpl'], 'eme_prop_event_contactperson_email_subject_tpl', $templates_array );
+    echo eme_ui_select( $event['event_properties']['event_contactperson_email_subject_tpl'], 'eme_prop_event_contactperson_email_subject_tpl', $templates_array ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select()
 ?>
     <br>
     <?php esc_html_e( 'Or enter your own (if anything is entered here, it takes precedence over the selected template): ', 'events-made-easy' ); ?>
@@ -7585,7 +7585,7 @@ function eme_meta_box_div_event_registration_approved_email( $event, $templates_
     </p>
 <?php
     esc_html_e( 'Either choose from a template: ', 'events-made-easy' );
-    echo eme_ui_select( $event['event_properties']['event_contactperson_email_body_tpl'], 'eme_prop_event_contactperson_email_body_tpl', $templates_array );
+    echo eme_ui_select( $event['event_properties']['event_contactperson_email_body_tpl'], 'eme_prop_event_contactperson_email_body_tpl', $templates_array ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select()
 ?>
     <br>
     <?php esc_html_e( 'Or enter your own (if anything is entered here, it takes precedence over the selected template): ', 'events-made-easy' ); ?>
@@ -7658,7 +7658,7 @@ function eme_meta_box_div_event_registration_userpending_email( $event, $templat
     </p>
 <?php
     esc_html_e( 'Either choose from a template: ', 'events-made-easy' );
-    echo eme_ui_select( $event['event_properties']['event_registration_userpending_email_subject_tpl'], 'eme_prop_event_registration_userpending_email_subject_tpl', $templates_array );
+    echo eme_ui_select( $event['event_properties']['event_registration_userpending_email_subject_tpl'], 'eme_prop_event_registration_userpending_email_subject_tpl', $templates_array ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select()
 ?>
     <br>
     <?php esc_html_e( 'Or enter your own (if anything is entered here, it takes precedence over the selected template): ', 'events-made-easy' ); ?>
@@ -7680,7 +7680,7 @@ function eme_meta_box_div_event_registration_userpending_email( $event, $templat
     </p>
 <?php
     esc_html_e( 'Either choose from a template: ', 'events-made-easy' );
-    echo eme_ui_select( $event['event_properties']['event_registration_userpending_email_body_tpl'], 'eme_prop_event_registration_userpending_email_body_tpl', $templates_array );
+    echo eme_ui_select( $event['event_properties']['event_registration_userpending_email_body_tpl'], 'eme_prop_event_registration_userpending_email_body_tpl', $templates_array ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select()
 ?>
     <br>
     <?php esc_html_e( 'Or enter your own (if anything is entered here, it takes precedence over the selected template): ', 'events-made-easy' ); ?>
@@ -7716,7 +7716,7 @@ function eme_meta_box_div_event_registration_pending_email( $event, $templates_a
     </p>
 <?php
     esc_html_e( 'Either choose from a template: ', 'events-made-easy' );
-    echo eme_ui_select( $event['event_properties']['event_registration_pending_email_subject_tpl'], 'eme_prop_event_registration_pending_email_subject_tpl', $templates_array );
+    echo eme_ui_select( $event['event_properties']['event_registration_pending_email_subject_tpl'], 'eme_prop_event_registration_pending_email_subject_tpl', $templates_array ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select()
 ?>
     <br>
     <?php esc_html_e( 'Or enter your own (if anything is entered here, it takes precedence over the selected template): ', 'events-made-easy' ); ?>
@@ -7738,7 +7738,7 @@ function eme_meta_box_div_event_registration_pending_email( $event, $templates_a
     </p>
 <?php
     esc_html_e( 'Either choose from a template: ', 'events-made-easy' );
-    echo eme_ui_select( $event['event_properties']['event_registration_pending_email_body_tpl'], 'eme_prop_event_registration_pending_email_body_tpl', $templates_array );
+    echo eme_ui_select( $event['event_properties']['event_registration_pending_email_body_tpl'], 'eme_prop_event_registration_pending_email_body_tpl', $templates_array ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select()
 ?>
     <br>
     <?php esc_html_e( 'Or enter your own (if anything is entered here, it takes precedence over the selected template): ', 'events-made-easy' ); ?>
@@ -7764,7 +7764,7 @@ function eme_meta_box_div_event_registration_pending_email( $event, $templates_a
     </p>
 <?php
     esc_html_e( 'Either choose from a template: ', 'events-made-easy' );
-    echo eme_ui_select( $event['event_properties']['contactperson_registration_pending_email_subject_tpl'], 'eme_prop_contactperson_registration_pending_email_subject_tpl', $templates_array );
+    echo eme_ui_select( $event['event_properties']['contactperson_registration_pending_email_subject_tpl'], 'eme_prop_contactperson_registration_pending_email_subject_tpl', $templates_array ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select()
 ?>
     <br>
     <?php esc_html_e( 'Or enter your own (if anything is entered here, it takes precedence over the selected template): ', 'events-made-easy' ); ?>
@@ -7786,7 +7786,7 @@ function eme_meta_box_div_event_registration_pending_email( $event, $templates_a
     </p>
 <?php
     esc_html_e( 'Either choose from a template: ', 'events-made-easy' );
-    echo eme_ui_select( $event['event_properties']['contactperson_registration_pending_email_body_tpl'], 'eme_prop_contactperson_registration_pending_email_body_tpl', $templates_array );
+    echo eme_ui_select( $event['event_properties']['contactperson_registration_pending_email_body_tpl'], 'eme_prop_contactperson_registration_pending_email_body_tpl', $templates_array ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select()
 ?>
     <br>
     <?php esc_html_e( 'Or enter your own (if anything is entered here, it takes precedence over the selected template): ', 'events-made-easy' ); ?>
@@ -7853,7 +7853,7 @@ function eme_meta_box_div_event_registration_updated_email( $event, $templates_a
     </p>
 <?php
     esc_html_e( 'Either choose from a template: ', 'events-made-easy' );
-    echo eme_ui_select( $event['event_properties']['event_registration_updated_email_subject_tpl'], 'eme_prop_event_registration_updated_email_subject_tpl', $templates_array );
+    echo eme_ui_select( $event['event_properties']['event_registration_updated_email_subject_tpl'], 'eme_prop_event_registration_updated_email_subject_tpl', $templates_array ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select()
 ?>
     <br>
     <?php esc_html_e( 'Or enter your own (if anything is entered here, it takes precedence over the selected template): ', 'events-made-easy' ); ?>
@@ -7875,7 +7875,7 @@ function eme_meta_box_div_event_registration_updated_email( $event, $templates_a
     </p>
 <?php
     esc_html_e( 'Either choose from a template: ', 'events-made-easy' );
-    echo eme_ui_select( $event['event_properties']['event_registration_updated_email_body_tpl'], 'eme_prop_event_registration_updated_email_body_tpl', $templates_array );
+    echo eme_ui_select( $event['event_properties']['event_registration_updated_email_body_tpl'], 'eme_prop_event_registration_updated_email_body_tpl', $templates_array ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select()
 ?>
     <br>
     <?php esc_html_e( 'Or enter your own (if anything is entered here, it takes precedence over the selected template): ', 'events-made-easy' ); ?>
@@ -7904,7 +7904,7 @@ function eme_meta_box_div_event_registration_reminder_email( $event, $templates_
     </p>
 <?php
     esc_html_e( 'Either choose from a template: ', 'events-made-easy' );
-    echo eme_ui_select( $event['event_properties']['event_registration_pending_reminder_email_subject_tpl'], 'eme_prop_event_registration_pending_reminder_email_subject_tpl', $templates_array );
+    echo eme_ui_select( $event['event_properties']['event_registration_pending_reminder_email_subject_tpl'], 'eme_prop_event_registration_pending_reminder_email_subject_tpl', $templates_array ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select()
 ?>
     <br>
     <?php esc_html_e( 'Or enter your own (if anything is entered here, it takes precedence over the selected template): ', 'events-made-easy' ); ?>
@@ -7926,7 +7926,7 @@ function eme_meta_box_div_event_registration_reminder_email( $event, $templates_
     </p>
 <?php
     esc_html_e( 'Either choose from a template: ', 'events-made-easy' );
-    echo eme_ui_select( $event['event_properties']['event_registration_pending_reminder_email_body_tpl'], 'eme_prop_event_registration_pending_reminder_email_body_tpl', $templates_array );
+    echo eme_ui_select( $event['event_properties']['event_registration_pending_reminder_email_body_tpl'], 'eme_prop_event_registration_pending_reminder_email_body_tpl', $templates_array ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select()
 ?>
     <br>
     <?php esc_html_e( 'Or enter your own (if anything is entered here, it takes precedence over the selected template): ', 'events-made-easy' ); ?>
@@ -7945,7 +7945,7 @@ function eme_meta_box_div_event_registration_reminder_email( $event, $templates_
     </p>
 <?php
     esc_html_e( 'Either choose from a template: ', 'events-made-easy' );
-    echo eme_ui_select( $event['event_properties']['event_registration_reminder_email_subject_tpl'], 'eme_prop_event_registration_reminder_email_subject_tpl', $templates_array );
+    echo eme_ui_select( $event['event_properties']['event_registration_reminder_email_subject_tpl'], 'eme_prop_event_registration_reminder_email_subject_tpl', $templates_array ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select()
 ?>
     <br>
     <?php esc_html_e( 'Or enter your own (if anything is entered here, it takes precedence over the selected template): ', 'events-made-easy' ); ?>
@@ -7967,7 +7967,7 @@ function eme_meta_box_div_event_registration_reminder_email( $event, $templates_
     </p>
 <?php
     esc_html_e( 'Either choose from a template: ', 'events-made-easy' );
-    echo eme_ui_select( $event['event_properties']['event_registration_reminder_email_body_tpl'], 'eme_prop_event_registration_reminder_email_body_tpl', $templates_array );
+    echo eme_ui_select( $event['event_properties']['event_registration_reminder_email_body_tpl'], 'eme_prop_event_registration_reminder_email_body_tpl', $templates_array ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select()
 ?>
     <br>
     <?php esc_html_e( 'Or enter your own (if anything is entered here, it takes precedence over the selected template): ', 'events-made-easy' ); ?>
@@ -7996,7 +7996,7 @@ function eme_meta_box_div_event_registration_cancelled_email( $event, $templates
     </p>
 <?php
     esc_html_e( 'Either choose from a template: ', 'events-made-easy' );
-    echo eme_ui_select( $event['event_properties']['event_registration_cancelled_email_subject_tpl'], 'eme_prop_event_registration_cancelled_email_subject_tpl', $templates_array );
+    echo eme_ui_select( $event['event_properties']['event_registration_cancelled_email_subject_tpl'], 'eme_prop_event_registration_cancelled_email_subject_tpl', $templates_array ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select()
 ?>
     <br>
     <?php esc_html_e( 'Or enter your own (if anything is entered here, it takes precedence over the selected template): ', 'events-made-easy' ); ?>
@@ -8018,7 +8018,7 @@ function eme_meta_box_div_event_registration_cancelled_email( $event, $templates
     </p>
 <?php
     esc_html_e( 'Either choose from a template: ', 'events-made-easy' );
-    echo eme_ui_select( $event['event_properties']['event_registration_cancelled_email_body_tpl'], 'eme_prop_event_registration_cancelled_email_body_tpl', $templates_array );
+    echo eme_ui_select( $event['event_properties']['event_registration_cancelled_email_body_tpl'], 'eme_prop_event_registration_cancelled_email_body_tpl', $templates_array ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select()
 ?>
     <br>
     <?php esc_html_e( 'Or enter your own (if anything is entered here, it takes precedence over the selected template): ', 'events-made-easy' ); ?>
@@ -8044,7 +8044,7 @@ function eme_meta_box_div_event_registration_cancelled_email( $event, $templates
     </p>
 <?php
     esc_html_e( 'Either choose from a template: ', 'events-made-easy' );
-    echo eme_ui_select( $event['event_properties']['contactperson_registration_cancelled_email_subject_tpl'], 'eme_prop_contactperson_registration_cancelled_email_subject_tpl', $templates_array );
+    echo eme_ui_select( $event['event_properties']['contactperson_registration_cancelled_email_subject_tpl'], 'eme_prop_contactperson_registration_cancelled_email_subject_tpl', $templates_array ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select()
 ?>
     <br>
     <?php esc_html_e( 'Or enter your own (if anything is entered here, it takes precedence over the selected template): ', 'events-made-easy' ); ?>
@@ -8066,7 +8066,7 @@ function eme_meta_box_div_event_registration_cancelled_email( $event, $templates
     </p>
 <?php
     esc_html_e( 'Either choose from a template: ', 'events-made-easy' );
-    echo eme_ui_select( $event['event_properties']['contactperson_registration_cancelled_email_body_tpl'], 'eme_prop_contactperson_registration_cancelled_email_body_tpl', $templates_array );
+    echo eme_ui_select( $event['event_properties']['contactperson_registration_cancelled_email_body_tpl'], 'eme_prop_contactperson_registration_cancelled_email_body_tpl', $templates_array ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select()
 ?>
     <br>
     <?php esc_html_e( 'Or enter your own (if anything is entered here, it takes precedence over the selected template): ', 'events-made-easy' ); ?>
@@ -8100,7 +8100,7 @@ function eme_meta_box_div_event_registration_paid_email( $event, $templates_arra
     </p>
 <?php
     esc_html_e( 'Either choose from a template: ', 'events-made-easy' );
-    echo eme_ui_select( $event['event_properties']['event_registration_paid_email_subject_tpl'], 'eme_prop_event_registration_paid_email_subject_tpl', $templates_array );
+    echo eme_ui_select( $event['event_properties']['event_registration_paid_email_subject_tpl'], 'eme_prop_event_registration_paid_email_subject_tpl', $templates_array ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select()
 ?>
     <br>
     <?php esc_html_e( 'Or enter your own (if anything is entered here, it takes precedence over the selected template): ', 'events-made-easy' ); ?>
@@ -8122,7 +8122,7 @@ function eme_meta_box_div_event_registration_paid_email( $event, $templates_arra
     </p>
 <?php
     esc_html_e( 'Either choose from a template: ', 'events-made-easy' );
-    echo eme_ui_select( $event['event_properties']['event_registration_paid_email_body_tpl'], 'eme_prop_event_registration_paid_email_body_tpl', $templates_array );
+    echo eme_ui_select( $event['event_properties']['event_registration_paid_email_body_tpl'], 'eme_prop_event_registration_paid_email_body_tpl', $templates_array ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select()
 ?>
     <br>
     <?php esc_html_e( 'Or enter your own (if anything is entered here, it takes precedence over the selected template): ', 'events-made-easy' ); ?>
@@ -8148,7 +8148,7 @@ function eme_meta_box_div_event_registration_paid_email( $event, $templates_arra
     </p>
 <?php
     esc_html_e( 'Either choose from a template: ', 'events-made-easy' );
-    echo eme_ui_select( $event['event_properties']['contactperson_registration_paid_email_subject_tpl'], 'eme_prop_contactperson_registration_paid_email_subject_tpl', $templates_array );
+    echo eme_ui_select( $event['event_properties']['contactperson_registration_paid_email_subject_tpl'], 'eme_prop_contactperson_registration_paid_email_subject_tpl', $templates_array ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select()
 ?>
     <br>
     <?php esc_html_e( 'Or enter your own (if anything is entered here, it takes precedence over the selected template): ', 'events-made-easy' ); ?>
@@ -8170,7 +8170,7 @@ function eme_meta_box_div_event_registration_paid_email( $event, $templates_arra
     </p>
 <?php
     esc_html_e( 'Either choose from a template: ', 'events-made-easy' );
-    echo eme_ui_select( $event['event_properties']['contactperson_registration_paid_email_body_tpl'], 'eme_prop_contactperson_registration_paid_email_body_tpl', $templates_array );
+    echo eme_ui_select( $event['event_properties']['contactperson_registration_paid_email_body_tpl'], 'eme_prop_contactperson_registration_paid_email_body_tpl', $templates_array ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select()
 ?>
     <br>
     <?php esc_html_e( 'Or enter your own (if anything is entered here, it takes precedence over the selected template): ', 'events-made-easy' ); ?>
@@ -8237,7 +8237,7 @@ function eme_meta_box_div_event_registration_trashed_email( $event, $templates_a
     </p>
 <?php
     esc_html_e( 'Either choose from a template: ', 'events-made-easy' );
-    echo eme_ui_select( $event['event_properties']['event_registration_trashed_email_subject_tpl'], 'eme_prop_event_registration_trashed_email_subject_tpl', $templates_array );
+    echo eme_ui_select( $event['event_properties']['event_registration_trashed_email_subject_tpl'], 'eme_prop_event_registration_trashed_email_subject_tpl', $templates_array ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select()
 ?>
     <br>
     <?php esc_html_e( 'Or enter your own (if anything is entered here, it takes precedence over the selected template): ', 'events-made-easy' ); ?>
@@ -8259,7 +8259,7 @@ function eme_meta_box_div_event_registration_trashed_email( $event, $templates_a
     </p>
 <?php
     esc_html_e( 'Either choose from a template: ', 'events-made-easy' );
-    echo eme_ui_select( $event['event_properties']['event_registration_trashed_email_body_tpl'], 'eme_prop_event_registration_trashed_email_body_tpl', $templates_array );
+    echo eme_ui_select( $event['event_properties']['event_registration_trashed_email_body_tpl'], 'eme_prop_event_registration_trashed_email_body_tpl', $templates_array ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select()
 ?>
     <br>
     <?php esc_html_e( 'Or enter your own (if anything is entered here, it takes precedence over the selected template): ', 'events-made-easy' ); ?>
@@ -8287,7 +8287,7 @@ function eme_meta_box_div_event_registration_form_format( $event, $templates_arr
     </p>
 <?php
     esc_html_e( 'Either choose from a template: ', 'events-made-easy' );
-    echo eme_ui_select( $event['event_properties']['event_registration_form_format_tpl'], 'eme_prop_event_registration_form_format_tpl', $templates_array );
+    echo eme_ui_select( $event['event_properties']['event_registration_form_format_tpl'], 'eme_prop_event_registration_form_format_tpl', $templates_array ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select()
 ?>
     <br>
     <?php esc_html_e( 'Or enter your own (if anything is entered here, it takes precedence over the selected template): ', 'events-made-easy' ); ?>
@@ -8316,7 +8316,7 @@ function eme_meta_box_div_event_cancel_form_format( $event, $templates_array ) {
     </p>
 <?php
     esc_html_e( 'Either choose from a template: ', 'events-made-easy' );
-    echo eme_ui_select( $event['event_properties']['event_cancel_form_format_tpl'], 'eme_prop_event_cancel_form_format_tpl', $templates_array );
+    echo eme_ui_select( $event['event_properties']['event_cancel_form_format_tpl'], 'eme_prop_event_cancel_form_format_tpl', $templates_array ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select()
 ?>
     <br>
     <?php esc_html_e( 'Or enter your own (if anything is entered here, it takes precedence over the selected template): ', 'events-made-easy' ); ?>
@@ -8340,7 +8340,7 @@ function eme_meta_box_div_event_captcha_settings( $event ) {
     <?php if ( ! empty( $configured_captchas ) ) : ?>
     <p id='p_select_captcha'>
 <?php
-    echo eme_ui_select($selected_captcha,'eme_prop_selected_captcha',$configured_captchas,__('None','events-made-easy'));
+    echo eme_ui_select($selected_captcha,'eme_prop_selected_captcha',$configured_captchas,__('None','events-made-easy')); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select()
 ?>
     <label for="eme_prop_selected_captcha"><?php esc_html_e( 'Select a captcha to use', 'events-made-easy' ); ?></label>
     </p>
@@ -8666,7 +8666,7 @@ function eme_meta_box_div_attendance_info( $event, $templates_array, $pdf_templa
                 <br><span class="eme_smaller"><?php esc_html_e( 'When the URL generated by #_QRCODE or #_ATTENDANCE_URL is scanned by a not authorized user, only info concerning the payment status is shown. If you want to show extra info (like the event name or some booking info), you can define that in this template. All event and RSVP placeholders are allowed.', 'events-made-easy' ); ?></span><br>
 <?php
     esc_html_e( 'Either choose from a template: ', 'events-made-easy' );
-    echo eme_ui_select( $event['event_properties']['attendance_unauth_scan_tpl'], 'eme_prop_attendance_unauth_scan_tpl', $templates_array );
+    echo eme_ui_select( $event['event_properties']['attendance_unauth_scan_tpl'], 'eme_prop_attendance_unauth_scan_tpl', $templates_array ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select()
 ?>
                 <br>
                 <?php esc_html_e( 'Or enter your own (if anything is entered here, it takes precedence over the selected template): ', 'events-made-easy' ); ?>
@@ -8681,7 +8681,7 @@ function eme_meta_box_div_attendance_info( $event, $templates_array, $pdf_templa
                 <br><span class="eme_smaller"><?php esc_html_e( 'When the URL generated by #_QRCODE or #_ATTENDANCE_URL is scanned by a authorized user, only info concerning the payment status is shown, next to attendance count info if configured to do so. If you want to show extra info (like the event name or some booking info), you can define that in this template. All event and RSVP placeholders are allowed.', 'events-made-easy' ); ?></span><br>
 <?php
     esc_html_e( 'Either choose from a template: ', 'events-made-easy' );
-    echo eme_ui_select( $event['event_properties']['attendance_auth_scan_tpl'], 'eme_prop_attendance_auth_scan_tpl', $templates_array );
+    echo eme_ui_select( $event['event_properties']['attendance_auth_scan_tpl'], 'eme_prop_attendance_auth_scan_tpl', $templates_array ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select()
 ?>
                 <br>
                 <?php esc_html_e( 'Or enter your own (if anything is entered here, it takes precedence over the selected template): ', 'events-made-easy' ); ?>
@@ -8697,7 +8697,7 @@ function eme_meta_box_div_attendance_info( $event, $templates_array, $pdf_templa
                 <br><span class="eme_smaller"><?php esc_html_e( 'When the URL generated by #_ATTENDANCEPROOF_URL is visited, the selected PDF template will be used to generate a PDF for the user that can serve as proof of attendance. All event and RSVP placeholders are allowed.', 'events-made-easy' ); ?></span><br>
 <?php
     esc_html_e( 'Choose from a template: ', 'events-made-easy' );
-    echo eme_ui_select( $event['event_properties']['attendance_proof_tpl'], 'eme_prop_attendance_proof_tpl', $pdf_templates_array );
+    echo eme_ui_select( $event['event_properties']['attendance_proof_tpl'], 'eme_prop_attendance_proof_tpl', $pdf_templates_array ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select()
 ?>
                 </div>
             </div>
@@ -8808,11 +8808,11 @@ function eme_meta_box_div_event_rsvp( $event, $pdf_templates_array ) {
     </tr>
     <tr id='row_discount'>
         <td><label for='eme_prop_rsvp_discount'><?php esc_html_e( 'Discount to apply', 'events-made-easy' ); ?></label></td>
-        <td><?php echo eme_ui_select( $event['event_properties']['rsvp_discount'], 'eme_prop_rsvp_discount', $discount_arr, '', 0, 'eme_snapselect_discounts_class' ); ?><p class="eme_smaller"><?php esc_html_e( 'The discount name you want to apply (is overridden by discount group if used).', 'events-made-easy' ); ?></p></td>
+        <td><?php echo eme_ui_select( $event['event_properties']['rsvp_discount'], 'eme_prop_rsvp_discount', $discount_arr, '', 0, 'eme_snapselect_discounts_class' ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select() ?><p class="eme_smaller"><?php esc_html_e( 'The discount name you want to apply (is overridden by discount group if used).', 'events-made-easy' ); ?></p></td>
     </tr>
     <tr id='row_discountgroup'>
         <td><label for='eme_prop_rsvp_discountgroup'><?php esc_html_e( 'Discount group to apply', 'events-made-easy' ); ?></label></td>
-        <td><?php echo eme_ui_select( $event['event_properties']['rsvp_discountgroup'], 'eme_prop_rsvp_discountgroup', $dgroup_arr, '', 0, 'eme_snapselect_dgroups_class' ); ?><p class="eme_smaller"><?php esc_html_e( 'The discount group name you want applied (overrides the discount).', 'events-made-easy' ); ?></p></td>
+        <td><?php echo eme_ui_select( $event['event_properties']['rsvp_discountgroup'], 'eme_prop_rsvp_discountgroup', $dgroup_arr, '', 0, 'eme_snapselect_dgroups_class' ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select() ?><p class="eme_smaller"><?php esc_html_e( 'The discount group name you want applied (overrides the discount).', 'events-made-easy' ); ?></p></td>
     </tr>
     <tr id='row_waitinglist_seats'>
         <td><label for='eme_prop_waitinglist_seats'><?php esc_html_e( 'Waitinglist seats', 'events-made-easy' ); ?></label></td>
@@ -8871,14 +8871,14 @@ function eme_meta_box_div_event_rsvp( $event, $pdf_templates_array ) {
     <tr><td colspan="2">&nbsp;</td></tr>
     <tr id='row_ticket'>
         <td><label for='eme_prop_ticket_template_id'><?php esc_html_e( 'Ticket PDF template', 'events-made-easy' ); ?></label></td>
-        <td><?php echo eme_ui_select( $event['event_properties']['ticket_template_id'], 'eme_prop_ticket_template_id', $pdf_templates_array, '&nbsp;' ); ?>
+        <td><?php echo eme_ui_select( $event['event_properties']['ticket_template_id'], 'eme_prop_ticket_template_id', $pdf_templates_array, '&nbsp;' ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select() ?>
             <p class="eme_smaller"><?php esc_html_e( 'This optional template is used to send a PDF attachment in the mail when the booking is approved or paid (see the next seting to configure when the attachment should be included).', 'events-made-easy' ); ?><br>
             <?php esc_html_e( 'No template shown in the list? Then go in the section Templates and create a PDF template.', 'events-made-easy' ); ?></p>
         </td>
     </tr>
     <tr id='row_ticketmail'>
         <td><label for='eme_prop_ticket_mail'><?php esc_html_e( 'Ticket mail preference', 'events-made-easy' ); ?></td>
-        <td> <?php echo eme_ui_select( $event['event_properties']['ticket_mail'], 'eme_prop_ticket_mail', [ 'booking'  => __( 'At booking time', 'events-made-easy' ), 'approval' => __( 'Upon approval', 'events-made-easy' ), 'payment'  => __( 'Upon payment', 'events-made-easy' ), 'always'   => __( 'All of the above', 'events-made-easy'), ]); ?>
+        <td> <?php echo eme_ui_select( $event['event_properties']['ticket_mail'], 'eme_prop_ticket_mail', [ 'booking'  => __( 'At booking time', 'events-made-easy' ), 'approval' => __( 'Upon approval', 'events-made-easy' ), 'payment'  => __( 'Upon payment', 'events-made-easy' ), 'always'   => __( 'All of the above', 'events-made-easy'), ]); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select() ?>
             <p class="eme_smaller"><?php esc_html_e( 'Configure in which mail you want the optional PDF attachment to be included: when the booking is made, when it is approved or when the booking is paid for.', 'events-made-easy' ); ?>
         </td>
     </tr>
@@ -8892,7 +8892,7 @@ function eme_meta_box_div_event_rsvp( $event, $pdf_templates_array ) {
         <?php esc_html_e( 'hours', 'events-made-easy' );
               echo " ";
               esc_html_e( 'before the event ', 'events-made-easy' ); $eme_rsvp_start_target_list = [ 'start' => __( 'starts', 'events-made-easy' ), 'end'   => __( 'ends', 'events-made-easy' ), ];
-              echo eme_ui_select( $event['event_properties']['rsvp_start_target'], 'eme_prop_rsvp_start_target', $eme_rsvp_start_target_list );
+              echo eme_ui_select( $event['event_properties']['rsvp_start_target'], 'eme_prop_rsvp_start_target', $eme_rsvp_start_target_list ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select()
         ?>
         &nbsp;<?php esc_html_e( '(Leave empty or 0 to disable this limit. Negative numbers are allowed and for hours you can use decimals too.)', 'events-made-easy' ); ?>
         <span id="rsvp-start-display" style="background-color: lightgrey;"></span>
@@ -8905,7 +8905,7 @@ function eme_meta_box_div_event_rsvp( $event, $pdf_templates_array ) {
         <?php esc_html_e( 'hours', 'events-made-easy' );
               echo " ";
               esc_html_e( 'before the event ', 'events-made-easy' ); $eme_rsvp_end_target_list = [ 'start' => __( 'starts', 'events-made-easy' ), 'end'   => __( 'ends', 'events-made-easy' ), ];
-              echo eme_ui_select( $event['event_properties']['rsvp_end_target'], 'eme_prop_rsvp_end_target', $eme_rsvp_end_target_list );
+              echo eme_ui_select( $event['event_properties']['rsvp_end_target'], 'eme_prop_rsvp_end_target', $eme_rsvp_end_target_list ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select()
         ?>
         <span id="rsvp-end-display" style="background-color: lightgrey;"></span>
     </p>

--- a/eme-formfields.php
+++ b/eme-formfields.php
@@ -227,8 +227,8 @@ function eme_formfields_table_layout( $message = '' ) {
     </div>
     <h1><?php esc_html_e( 'Manage custom fields', 'events-made-easy' ); ?></h1>
     <form action="#" method="post">
-    <?php echo eme_ui_select( '', 'search_type', $field_types, __( 'Any', 'events-made-easy' ) ); ?>
-    <?php echo eme_ui_select( '', 'search_purpose', $field_purposes, __( 'Any', 'events-made-easy' ) ); ?>
+    <?php echo eme_ui_select( '', 'search_type', $field_types, __( 'Any', 'events-made-easy' ) ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select() ?>
+    <?php echo eme_ui_select( '', 'search_purpose', $field_purposes, __( 'Any', 'events-made-easy' ) ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select() ?>
     <input type="search" name="search_name" id="search_name" placeholder="<?php esc_html_e( 'Field name', 'events-made-easy' ); ?>" class="eme_searchfilter" size=10>
     <button id="FormfieldsLoadRecordsButton" class="button-secondary action"><?php esc_html_e( 'Filter fields', 'events-made-easy' ); ?></button>
     </form>
@@ -5029,18 +5029,18 @@ function eme_dyndata_adminform( $eme_data, $templates_array, $used_groupingids )
                     </td>
                     <td><table style="">
                         <tr><td><?php esc_html_e( 'Field', 'events-made-easy' ); ?></td><td><input <?php echo $required; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- hardcoded attribute ?> id="eme_dyndata[<?php echo esc_attr( $count ); ?>][field]" name="eme_dyndata[<?php echo esc_attr( $count ); ?>][field]" size="12" aria-label="field" value="<?php echo esc_attr( $info['field'] ); ?>"></td></tr>
-                        <tr><td><?php esc_html_e( 'Condition', 'events-made-easy' ); ?></td><td><?php echo eme_ui_select( $info['condition'], 'eme_dyndata[' . $count . '][condition]', $eme_dyndata_conditions, '', 0, '', "aria-label='condition'" ); ?></td></tr>
+                        <tr><td><?php esc_html_e( 'Condition', 'events-made-easy' ); ?></td><td><?php echo eme_ui_select( $info['condition'], 'eme_dyndata[' . $count . '][condition]', $eme_dyndata_conditions, '', 0, '', "aria-label='condition'" ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select() ?></td></tr>
                         <tr><td><?php esc_html_e( 'Condition value', 'events-made-easy' ); ?></td><td><input <?php echo $required; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- hardcoded attribute ?> id="eme_dyndata[<?php echo esc_attr( $count ); ?>][condval]" name="eme_dyndata[<?php echo esc_attr( $count ); ?>][condval]" aria-label="condition value" size="12" value="<?php echo esc_attr( $info['condval'] ); ?>"></td></tr>
                     </table>
                     </td>
                     <td><table style="">
-                        <tr><td><?php esc_html_e( 'Header template', 'events-made-easy' ); ?></td><td><?php echo eme_ui_select( $info['template_id_header'], 'eme_dyndata[' . $count . '][template_id_header]', $templates_array, '', 0, '', "aria-label='template_id_header'" ); ?></td></tr>
-                        <tr><td><?php esc_html_e( 'Template', 'events-made-easy' ); ?></td><td><?php echo eme_ui_select( $info['template_id'], 'eme_dyndata[' . $count . '][template_id]', $templates_array, '', 0, '', "aria-label='template_id'" ); ?></td></tr>
-                        <tr><td><?php esc_html_e( 'Footer template', 'events-made-easy' ); ?></td><td><?php echo eme_ui_select( $info['template_id_footer'], 'eme_dyndata[' . $count . '][template_id_footer]', $templates_array, '', 0, '', "aria-label='template_id_footer'" ); ?></td></tr>
+                        <tr><td><?php esc_html_e( 'Header template', 'events-made-easy' ); ?></td><td><?php echo eme_ui_select( $info['template_id_header'], 'eme_dyndata[' . $count . '][template_id_header]', $templates_array, '', 0, '', "aria-label='template_id_header'" ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select() ?></td></tr>
+                        <tr><td><?php esc_html_e( 'Template', 'events-made-easy' ); ?></td><td><?php echo eme_ui_select( $info['template_id'], 'eme_dyndata[' . $count . '][template_id]', $templates_array, '', 0, '', "aria-label='template_id'" ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select() ?></td></tr>
+                        <tr><td><?php esc_html_e( 'Footer template', 'events-made-easy' ); ?></td><td><?php echo eme_ui_select( $info['template_id_footer'], 'eme_dyndata[' . $count . '][template_id_footer]', $templates_array, '', 0, '', "aria-label='template_id_footer'" ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select() ?></td></tr>
                     </table>
                     </td>
                     <td>
-                <?php echo eme_ui_select_binary( $info['repeat'], 'eme_dyndata[' . $count . '][repeat]', 0, '', "aria-label='repeat'" ); ?>
+                <?php echo eme_ui_select_binary( $info['repeat'], 'eme_dyndata[' . $count . '][repeat]', 0, '', "aria-label='repeat'" ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select() ?>
                     </td>
                     <td>
                         <a href="#" class='eme_remove_dyndatacondition'><?php echo "<img class='eme_remove_dyndatacondition' src='" . esc_url(EME_PLUGIN_URL) . "images/cross.png' alt='" . esc_attr__( 'Remove', 'events-made-easy' ) . "' title='" . esc_attr__( 'Remove', 'events-made-easy' ) . "'>"; ?></a><a href="#" class="eme_dyndata_add_tag"><?php echo "<img class='eme_dyndata_add_tag' src='" . esc_url(EME_PLUGIN_URL) . "images/plus_16.png' alt='" . esc_attr__( 'Add new condition', 'events-made-easy' ) . "' title='" . esc_attr__( 'Add new condition', 'events-made-easy' ) . "'>"; ?></a>

--- a/eme-locations.php
+++ b/eme-locations.php
@@ -507,7 +507,7 @@ function eme_meta_box_div_location_name( $location ) {
             $locations_prefixes_arr[ $locations_prefix ] = eme_permalink_convert( $locations_prefix );
         }
         $prefix = $location['location_prefix'] ? $location['location_prefix'] : '';
-        echo eme_ui_select( $prefix, 'location_prefix', $locations_prefixes_arr );
+        echo eme_ui_select( $prefix, 'location_prefix', $locations_prefixes_arr ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select()
     } else {
         echo eme_permalink_convert( $locations_prefixes );
     }

--- a/eme-mailer.php
+++ b/eme-mailer.php
@@ -2785,7 +2785,7 @@ function eme_emails_page() {
         'people_and_groups' => __('Email to people and/or groups registered in EME', 'events-made-easy'),
         'all_wp' => __('Email to all WP users', 'events-made-easy'),
     ];
-    echo eme_ui_select( $eme_mail_type, 'eme_mail_type', $eme_mail_type_arr, '&nbsp;', 1);
+    echo eme_ui_select( $eme_mail_type, 'eme_mail_type', $eme_mail_type_arr, '&nbsp;', 1); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select()
 ?>
         </td>
         </tr>
@@ -2865,7 +2865,7 @@ function eme_emails_page() {
         <b><?php esc_html_e( 'Subject', 'events-made-easy' ); ?></b><br>
 <?php
     esc_html_e( 'Either choose from a template: ', 'events-made-easy' );
-    echo eme_ui_select( 0, 'event_subject_template', $templates_array );
+    echo eme_ui_select( 0, 'event_subject_template', $templates_array ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select()
 ?>
         <br>
         <?php esc_html_e( 'Or enter your own: ', 'events-made-easy' ); ?>
@@ -2875,7 +2875,7 @@ function eme_emails_page() {
         <b><?php esc_html_e( 'Message', 'events-made-easy' ); ?></b><br>
 <?php
     esc_html_e( 'Either choose from a template: ', 'events-made-easy' );
-    echo eme_ui_select( 0, 'event_message_template', $templates_array );
+    echo eme_ui_select( 0, 'event_message_template', $templates_array ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select()
 ?>
         <br>
 <?php
@@ -3059,7 +3059,7 @@ function eme_emails_page() {
         <?php $templates_array = eme_get_templates_array_by_id( 'mail' ); ?>
 <?php
         esc_html_e( 'Either choose from a template: ', 'events-made-easy' );
-        echo eme_ui_select( 0, 'generic_message_template', $templates_array );
+        echo eme_ui_select( 0, 'generic_message_template', $templates_array ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select()
 ?>
         <br>
 <?php

--- a/eme-members.php
+++ b/eme-members.php
@@ -1536,7 +1536,7 @@ function eme_admin_edit_memberform( $member, $membership_id, $limited = 0 ) {
 ?>
         <tr><td><?php esc_html_e( 'Send mail to new member?', 'events-made-easy' ); ?>
         </td><td>
-        <?php echo eme_ui_select_binary( 1, 'send_mail', 0, 'nodynamicupdates' ); ?>
+        <?php echo eme_ui_select_binary( 1, 'send_mail', 0, 'nodynamicupdates' ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select() ?>
         </td></tr>
         <?php } ?>
         <tr><td>
@@ -1560,7 +1560,7 @@ function eme_admin_edit_memberform( $member, $membership_id, $limited = 0 ) {
 ?>
         <tr><td><?php esc_html_e( 'Send mail for changed member?', 'events-made-easy' ); ?>
         </td><td>
-        <?php echo eme_ui_select_binary( 1, 'send_mail', 0, 'nodynamicupdates' ); ?>
+        <?php echo eme_ui_select_binary( 1, 'send_mail', 0, 'nodynamicupdates' ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select() ?>
         </td></tr>
         <?php } ?>
         <?php if ( empty( $membership['properties']['family_membership'] ) || ( ! empty( $membership['properties']['family_membership'] ) && empty( $member['related_member_id'] ) ) ) { ?>
@@ -1580,7 +1580,7 @@ function eme_admin_edit_memberform( $member, $membership_id, $limited = 0 ) {
         </td><td>
 <?php
                     $memberships = eme_get_memberships( $membership['membership_id'] );
-                    echo eme_ui_select_key_value( '', 'transferto_membershipid', $memberships, 'membership_id', 'name', '&nbsp;', 0, 'nodynamicupdates' );
+                    echo eme_ui_select_key_value( '', 'transferto_membershipid', $memberships, 'membership_id', 'name', '&nbsp;', 0, 'nodynamicupdates' ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select()
 ?>
         <br>
 <?php
@@ -1687,7 +1687,7 @@ function eme_admin_edit_memberform( $member, $membership_id, $limited = 0 ) {
     </tr>
 <?php } ?>
     <tr><td><?php esc_html_e( 'Member status calculated automatically', 'events-made-easy' ); ?></td>
-    <td><?php echo eme_ui_select_binary( $member['status_automatic'], 'status_automatic', 0, 'nodynamicupdates', $disabled ); ?>
+    <td><?php echo eme_ui_select_binary( $member['status_automatic'], 'status_automatic', 0, 'nodynamicupdates', $disabled ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select() ?>
 <?php
         if ( $member['status_automatic'] && ! $member['paid'] && $action == 'edit' && empty( $member['related_member_id'] ) ) {
             echo "<img style='vertical-align: middle;' src='" . esc_url(EME_PLUGIN_URL) . "images/warning.png' alt='warning'>" . esc_html__( 'Warning: membership is not paid for, so automatic status calculation will not happen!', 'events-made-easy' );
@@ -1696,10 +1696,10 @@ function eme_admin_edit_memberform( $member, $membership_id, $limited = 0 ) {
         <?php echo "<p class='eme_smaller'>" . esc_html__( 'If set to automatic and the membership is paid for, the status will be recalculated on a daily basis.', 'events-made-easy' ) . '</p>'; ?>
         </td></tr>
         <tr><td><?php esc_html_e( 'Member status', 'events-made-easy' ); ?></td>
-    <td><?php echo eme_ui_select( $member['status'], 'status', $eme_member_status_array, '', 0, 'nodynamicupdates', $disabled ); ?>
+    <td><?php echo eme_ui_select( $member['status'], 'status', $eme_member_status_array, '', 0, 'nodynamicupdates', $disabled ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select() ?>
     </td></tr>
         <tr><td><?php esc_html_e( 'Has the member paid?', 'events-made-easy' ); ?></td>
-    <td><?php echo eme_ui_select_binary( $member['paid'], 'paid', 0, 'nodynamicupdates', $disabled ); ?>
+    <td><?php echo eme_ui_select_binary( $member['paid'], 'paid', 0, 'nodynamicupdates', $disabled ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select() ?>
     </td></tr>
     <tr><td><?php esc_html_e( 'Last payment received date', 'events-made-easy' ); ?></td>
         <td>
@@ -1910,11 +1910,11 @@ function eme_meta_box_div_membershipdetails( $membership, $is_new_membership ) {
     </tr>
     <tr>
     <td><label for="type"><?php esc_html_e( 'Type', 'events-made-easy' ); ?></label></td>
-    <td><?php echo eme_ui_select( $membership['type'], 'type', $type_array ); ?></td>
+    <td><?php echo eme_ui_select( $membership['type'], 'type', $type_array ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select() ?></td>
     </tr>
     <tr>
     <td><label for="status"><?php esc_html_e( 'Status', 'events-made-easy' ); ?></label></td>
-    <td><?php echo eme_ui_select( $membership['status'], 'status', $status_array ); ?>
+    <td><?php echo eme_ui_select( $membership['status'], 'status', $status_array ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select() ?>
         <br><p class='eme_smaller'><?php esc_html_e( 'Inactive memberships will not be shown in membership selection lists.', 'events-made-easy' ); ?></p>
     </td>
     </tr>
@@ -1932,7 +1932,7 @@ function eme_meta_box_div_membershipdetails( $membership, $is_new_membership ) {
     </tr>
     <tr id='freeperiod'>
     <td><label for="properties[one_free_period]"><?php esc_html_e( 'One extra free period', 'events-made-easy' ); ?></label></td>
-    <td><?php echo eme_ui_select_binary( $membership['properties']['one_free_period'], 'properties[one_free_period]', 0 ); ?>
+    <td><?php echo eme_ui_select_binary( $membership['properties']['one_free_period'], 'properties[one_free_period]', 0 ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select() ?>
         <br><p class='eme_smaller'><?php esc_html_e( 'When someone becomes a member, the end date is the end date of the current period calculated for this membership.', 'events-made-easy' ); ?>
         <br><?php esc_html_e( 'If you want new members to get one extra membership period for free, set this option.', 'events-made-easy' ); ?></p>
     </td>
@@ -2006,7 +2006,7 @@ function eme_meta_box_div_membershipdetails( $membership, $is_new_membership ) {
     </tr>
     <tr>
     <td><label for="properties[currency]"><?php esc_html_e( 'Currency', 'events-made-easy' ); ?></label></td>
-    <td><?php echo eme_ui_select( $membership['properties']['currency'], 'properties[currency]', $currency_array ); ?></td>
+    <td><?php echo eme_ui_select( $membership['properties']['currency'], 'properties[currency]', $currency_array ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select() ?></td>
     </tr>
     <tr>
     <td><label for="vat_pct"><?php esc_html_e( 'VAT percentage', 'events-made-easy' ); ?></label></td>
@@ -2016,11 +2016,11 @@ function eme_meta_box_div_membershipdetails( $membership, $is_new_membership ) {
     </tr>
     <tr id='row_discount'>
     <td><label for='properties[discount]'><?php esc_html_e( 'Discount to apply', 'events-made-easy' ); ?></label></td>
-    <td><?php echo eme_ui_select( $membership['properties']['discount'], 'properties[discount]', $discount_arr, '', 0, 'eme_snapselect_discounts_class' ); ?><p class="eme_smaller"><?php esc_html_e( 'The discount name you want to apply (is overridden by discount group if used).', 'events-made-easy' ); ?></p></td>
+    <td><?php echo eme_ui_select( $membership['properties']['discount'], 'properties[discount]', $discount_arr, '', 0, 'eme_snapselect_discounts_class' ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select() ?><p class="eme_smaller"><?php esc_html_e( 'The discount name you want to apply (is overridden by discount group if used).', 'events-made-easy' ); ?></p></td>
     </tr>
     <tr id='row_discountgroup'>
     <td><label for='properties[discountgroup]'><?php esc_html_e( 'Discount group to apply', 'events-made-easy' ); ?></label></td>
-    <td><?php echo eme_ui_select( $membership['properties']['discountgroup'], 'properties[discountgroup]', $dgroup_arr, '', 0, 'eme_snapselect_dgroups_class' ); ?><p class="eme_smaller"><?php esc_html_e( 'The discount group name you want applied (overrides the discount).', 'events-made-easy' ); ?></p></td>
+    <td><?php echo eme_ui_select( $membership['properties']['discountgroup'], 'properties[discountgroup]', $dgroup_arr, '', 0, 'eme_snapselect_dgroups_class' ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select() ?><p class="eme_smaller"><?php esc_html_e( 'The discount group name you want applied (overrides the discount).', 'events-made-easy' ); ?></p></td>
     </tr>
     <tr>
     <td><label for="properties[contact_id]"><?php esc_html_e( 'Contact person', 'events-made-easy' ); ?></label></td>
@@ -2050,7 +2050,7 @@ function eme_meta_box_div_membershipdetails( $membership, $is_new_membership ) {
     </tr>
     <tr id="tr_member_form_tpl">
     <td><label for="properties[member_form_tpl]"><?php esc_html_e( 'Member Form:', 'events-made-easy' ); ?></label></td>
-    <td><?php echo eme_ui_select_key_value( $membership['properties']['member_form_tpl'], 'properties[member_form_tpl]', $templates_array2, 'id', 'name', __( 'Please select a template', 'events-made-easy' ) ); ?>
+    <td><?php echo eme_ui_select_key_value( $membership['properties']['member_form_tpl'], 'properties[member_form_tpl]', $templates_array2, 'id', 'name', __( 'Please select a template', 'events-made-easy' ) ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select() ?>
         <br><p class='eme_smaller'><?php esc_html_e( 'This is the form that will be shown when a new member wants to sign up for this membership.', 'events-made-easy' ); ?>
         <br><?php esc_html_e( 'The template should at least contain the placeholders #_LASTNAME, #_FIRSTNAME, #_EMAIL and #_SUBMIT. If not, the form will not be shown. If empty, a simple default will be used.', 'events-made-easy' ); ?></p>
         <?php esc_html_e( 'Or enter your own (if anything is entered here, it takes precedence over the selected template): ', 'events-made-easy' ); ?>
@@ -2081,7 +2081,7 @@ function eme_meta_box_div_membershipdetails( $membership, $is_new_membership ) {
     </tr>
     <tr id="tr_familymember_form_tpl">
     <td><label for="properties[familymember_form_tpl]"><?php esc_html_e( 'Family Member Form:', 'events-made-easy' ); ?></label></td>
-    <td><?php echo eme_ui_select_key_value( $membership['properties']['familymember_form_tpl'], 'properties[familymember_form_tpl]', $templates_array2, 'id', 'name', __( 'Please select a template', 'events-made-easy' ) ); ?>
+    <td><?php echo eme_ui_select_key_value( $membership['properties']['familymember_form_tpl'], 'properties[familymember_form_tpl]', $templates_array2, 'id', 'name', __( 'Please select a template', 'events-made-easy' ) ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select() ?>
         <br><p class='eme_smaller'><?php esc_html_e( 'This is the form that will be shown/repeated for the family members when a new member wants to sign up for this membership.', 'events-made-easy' ); ?>
         <br><?php esc_html_e( 'The template should at least contain the placeholders #_LASTNAME, #_FIRSTNAME, #_EMAIL. If not, the form will not be shown. If empty, a simple default will be used.', 'events-made-easy' ); ?>
         <br><?php esc_html_e( 'The template may contain the person placeholders #_LASTNAME, #_FIRSTNAME, #_EMAIL, #_OPT_IN (or #_OPT_OUT), #_BIRTHDATE, #_BIRTHPLACE, #_PHONE and placeholders referring to custom person fields, nothing else. #_LASTNAME, #_FIRSTNAME are required. If #_EMAIL, #_PHONE, #_OPT_IN (or #_OPT_OUT) is not set, it is copied over from the person signing up. The address info is always copied over from the person signing up.', 'events-made-easy' ); ?></p>
@@ -2101,7 +2101,7 @@ function eme_meta_box_div_membershipdetails( $membership, $is_new_membership ) {
     </tr>
     <tr>
     <td><label for="properties[member_added_tpl]"><?php esc_html_e( 'Member Added Message:', 'events-made-easy' ); ?></label></td>
-    <td><?php echo eme_ui_select( $membership['properties']['member_added_tpl'], 'properties[member_added_tpl]', $templates_array ); ?>
+    <td><?php echo eme_ui_select( $membership['properties']['member_added_tpl'], 'properties[member_added_tpl]', $templates_array ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select() ?>
         <br><p class='eme_smaller'><?php echo esc_html__( 'The format of the text shown after someone subscribed. If left empty, a default message will be shown.', 'events-made-easy' ) . '<br>' . esc_html__( 'For all possible placeholders, see ', 'events-made-easy' ) . "<a target='_blank' href='//www.e-dynamics.be/wordpress/category/documentation/7-placeholders/7-14-members/'>" . esc_html__( 'the documentation', 'events-made-easy' ) . '</a>'; ?></p>
         <?php esc_html_e( 'Or enter your own (if anything is entered here, it takes precedence over the selected template): ', 'events-made-easy' ); ?>
         <img src="<?php echo esc_url(EME_PLUGIN_URL); ?>images/showhide.png" class="showhidebutton" alt="show/hide" data-showhide="div_membership_properties_member_added_text" style="cursor: pointer; vertical-align: middle; ">
@@ -2119,7 +2119,7 @@ function eme_meta_box_div_membershipdetails( $membership, $is_new_membership ) {
     </tr>
     <tr>
     <td><label for="properties[payment_form_header_tpl]"><?php esc_html_e( 'Payment Form Header:', 'events-made-easy' ); ?></label></td>
-    <td><?php echo eme_ui_select( $membership['properties']['payment_form_header_tpl'], 'properties[payment_form_header_tpl]', $templates_array ); ?>
+    <td><?php echo eme_ui_select( $membership['properties']['payment_form_header_tpl'], 'properties[payment_form_header_tpl]', $templates_array ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select() ?>
         <br><p class='eme_smaller'><?php echo esc_html__( 'The format of the text shown above the payment buttons. If left empty, a default message will be shown.', 'events-made-easy' ) . '<br>' . esc_html__( 'For all possible placeholders, see ', 'events-made-easy' ) . "<a target='_blank' href='//www.e-dynamics.be/wordpress/category/documentation/7-placeholders/7-14-members/'>" . esc_html__( 'the documentation', 'events-made-easy' ) . '</a>'; ?></p>
         <?php esc_html_e( 'Or enter your own (if anything is entered here, it takes precedence over the selected template): ', 'events-made-easy' ); ?>
         <img src="<?php echo esc_url(EME_PLUGIN_URL); ?>images/showhide.png" class="showhidebutton" alt="show/hide" data-showhide="div_membership_properties_payment_form_header_text" style="cursor: pointer; vertical-align: middle; ">
@@ -2137,7 +2137,7 @@ function eme_meta_box_div_membershipdetails( $membership, $is_new_membership ) {
     </tr>
     <tr>
     <td><label for="properties[payment_form_footer_tpl]"><?php esc_html_e( 'Payment Form Footer:', 'events-made-easy' ); ?></label></td>
-    <td><?php echo eme_ui_select( $membership['properties']['payment_form_footer_tpl'], 'properties[payment_form_footer_tpl]', $templates_array ); ?>
+    <td><?php echo eme_ui_select( $membership['properties']['payment_form_footer_tpl'], 'properties[payment_form_footer_tpl]', $templates_array ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select() ?>
         <br><p class='eme_smaller'><?php echo esc_html__( 'The format of the text shown below the payment buttons. Default: empty.', 'events-made-easy' ) . '<br>' . esc_html__( 'For all possible placeholders, see ', 'events-made-easy' ) . "<a target='_blank' href='//www.e-dynamics.be/wordpress/category/documentation/7-placeholders/7-14-members/'>" . esc_html__( 'the documentation', 'events-made-easy' ) . '</a>'; ?></p>
         <?php esc_html_e( 'Or enter your own (if anything is entered here, it takes precedence over the selected template): ', 'events-made-easy' ); ?>
         <img src="<?php echo esc_url(EME_PLUGIN_URL); ?>images/showhide.png" class="showhidebutton" alt="show/hide" data-showhide="div_membership_properties_payment_form_footer_text" style="cursor: pointer; vertical-align: middle; ">
@@ -2155,7 +2155,7 @@ function eme_meta_box_div_membershipdetails( $membership, $is_new_membership ) {
     </tr>
     <tr>
     <td><label for="properties[payment_success_tpl]"><?php esc_html_e( 'Payment Success Message:', 'events-made-easy' ); ?></label></td>
-    <td><?php echo eme_ui_select( $membership['properties']['payment_success_tpl'], 'properties[payment_success_tpl]', $templates_array ); ?>
+    <td><?php echo eme_ui_select( $membership['properties']['payment_success_tpl'], 'properties[payment_success_tpl]', $templates_array ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select() ?>
         <br><p class='eme_smaller'><?php echo esc_html__( 'The message shown when the payment is succesfull for membership signup. Default: see global EME settings for payments, subsection "General options".', 'events-made-easy' ) . '<br>' . esc_html__( 'For all possible placeholders, see ', 'events-made-easy' ) . "<a target='_blank' href='//www.e-dynamics.be/wordpress/category/documentation/7-placeholders/7-14-members/'>" . esc_html__( 'the documentation', 'events-made-easy' ) . '</a>'; ?></p>
         <?php esc_html_e( 'Or enter your own (if anything is entered here, it takes precedence over the selected template): ', 'events-made-easy' ); ?>
         <img src="<?php echo esc_url(EME_PLUGIN_URL); ?>images/showhide.png" class="showhidebutton" alt="show/hide" data-showhide="div_membership_properties_payment_success_text" style="cursor: pointer; vertical-align: middle; ">
@@ -2177,7 +2177,7 @@ function eme_meta_box_div_membershipdetails( $membership, $is_new_membership ) {
     </tr>
     <tr>
     <td><label for='properties[member_template_id]'><?php esc_html_e( 'Membership card PDF template', 'events-made-easy' ); ?></label></td>
-    <td><?php echo eme_ui_select_key_value( $membership['properties']['member_template_id'], 'properties[member_template_id]', eme_get_templates( 'pdf', 1 ), 'id', 'name', '&nbsp;' ); ?><br>
+    <td><?php echo eme_ui_select_key_value( $membership['properties']['member_template_id'], 'properties[member_template_id]', eme_get_templates( 'pdf', 1 ), 'id', 'name', '&nbsp;' ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select() ?><br>
         <p class='eme_smaller'><?php esc_html_e( 'This optional template is used to send a PDF attachment in the mail when the membership is paid for.', 'events-made-easy' ); ?><br>
     </td>
     </tr>
@@ -2199,7 +2199,7 @@ function eme_meta_box_div_membershipdetails( $membership, $is_new_membership ) {
     </tr>
     <tr id="tr_offline">
     <td><label for="properties[offline_payment_tpl]"><?php esc_html_e( 'Offline Payment Format:', 'events-made-easy' ); ?></label></td>
-    <td><?php echo eme_ui_select( $membership['properties']['offline_payment_tpl'], 'properties[offline_payment_tpl]', $templates_array ); ?>
+    <td><?php echo eme_ui_select( $membership['properties']['offline_payment_tpl'], 'properties[offline_payment_tpl]', $templates_array ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select() ?>
         <br><p class='eme_smaller'><?php echo esc_html__( 'The format of the text shown for the offline payment method. Default: empty.', 'events-made-easy' ) . '<br>' . esc_html__( 'For all possible placeholders, see ', 'events-made-easy' ) . "<a target='_blank' href='//www.e-dynamics.be/wordpress/category/documentation/7-placeholders/7-14-members/'>" . esc_html__( 'the documentation', 'events-made-easy' ) . '</a>'; ?></p>
         <?php esc_html_e( 'Or enter your own (if anything is entered here, it takes precedence over the selected template): ', 'events-made-easy' ); ?>
         <img src="<?php echo esc_url(EME_PLUGIN_URL); ?>images/showhide.png" class="showhidebutton" alt="show/hide" data-showhide="div_membership_properties_offline_payment_text" style="cursor: pointer; vertical-align: middle; ">
@@ -2265,7 +2265,7 @@ function eme_meta_box_div_membershipmailformats( $membership ) {
     </tr>
     <tr>
     <td><label for="properties[new_body_format_tpl]"><?php esc_html_e( 'New member email body', 'events-made-easy' ); ?></label></td>
-    <td><?php echo eme_ui_select( $membership['properties']['new_body_format_tpl'], 'properties[new_body_format_tpl]', $templates_array ); ?>
+    <td><?php echo eme_ui_select( $membership['properties']['new_body_format_tpl'], 'properties[new_body_format_tpl]', $templates_array ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select() ?>
         <br><p class='eme_smaller'><?php esc_html_e( 'The body of the mail sent to the person signing up as a member.', 'events-made-easy' ); ?>
         </p>
         <?php esc_html_e( 'No template shown in the list? Then go in the section Templates and create a template of type "Membership related mail".', 'events-made-easy' ); ?>
@@ -2335,7 +2335,7 @@ function eme_meta_box_div_membershipmailformats( $membership ) {
     </tr>
     <tr>
     <td><label for="name"><?php esc_html_e( 'Contactperson new member email body', 'events-made-easy' ); ?></label></td>
-    <td><?php echo eme_ui_select( $membership['properties']['contact_new_body_format_tpl'], 'properties[contact_new_body_format_tpl]', $templates_array ); ?>
+    <td><?php echo eme_ui_select( $membership['properties']['contact_new_body_format_tpl'], 'properties[contact_new_body_format_tpl]', $templates_array ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select() ?>
         <br><p class='eme_smaller'><?php esc_html_e( 'The body of the mail sent to the contactperson when someone signes up as a member.', 'events-made-easy' ); ?><br>
         </p>
         <?php esc_html_e( 'No template shown in the list? Then go in the section Templates and create a template of type "Membership related mail".', 'events-made-easy' ); ?>
@@ -2371,7 +2371,7 @@ function eme_meta_box_div_membershipmailformats( $membership ) {
     </tr>
     <tr>
     <td><label for="name"><?php esc_html_e( 'Updated member email body', 'events-made-easy' ); ?></label></td>
-    <td><?php echo eme_ui_select( $membership['properties']['updated_body_format_tpl'], 'properties[updated_body_format_tpl]', $templates_array ); ?>
+    <td><?php echo eme_ui_select( $membership['properties']['updated_body_format_tpl'], 'properties[updated_body_format_tpl]', $templates_array ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select() ?>
         <br><p class='eme_smaller'><?php esc_html_e( 'The body of the mail sent to the member upon changes.', 'events-made-easy' ); ?>
         <br><?php esc_html_e( 'Currently only used when a member is manually marked as unpaid.', 'events-made-easy' ); ?><br>
         </p>
@@ -2409,7 +2409,7 @@ function eme_meta_box_div_membershipmailformats( $membership ) {
     </tr>
     <tr>
     <td><label for="name"><?php esc_html_e( 'Membership extended email body', 'events-made-easy' ); ?></label></td>
-    <td><?php echo eme_ui_select( $membership['properties']['extended_body_format_tpl'], 'properties[extended_body_format_tpl]', $templates_array ); ?>
+    <td><?php echo eme_ui_select( $membership['properties']['extended_body_format_tpl'], 'properties[extended_body_format_tpl]', $templates_array ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select() ?>
         <br><p class='eme_smaller'><?php esc_html_e( 'The body of the mail sent to the member when the membership is extended.', 'events-made-easy' ); ?><br>
         </p>
         <?php esc_html_e( 'No template shown in the list? Then go in the section Templates and create a template of type "Membership related mail".', 'events-made-easy' ); ?>
@@ -2488,7 +2488,7 @@ function eme_meta_box_div_membershipmailformats( $membership ) {
     </tr>
     <tr>
     <td><label for="name"><?php esc_html_e( 'Membership paid email body', 'events-made-easy' ); ?></label></td>
-    <td><?php echo eme_ui_select( $membership['properties']['paid_body_format_tpl'], 'properties[paid_body_format_tpl]', $templates_array ); ?>
+    <td><?php echo eme_ui_select( $membership['properties']['paid_body_format_tpl'], 'properties[paid_body_format_tpl]', $templates_array ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select() ?>
         <br><p class='eme_smaller'><?php esc_html_e( 'The body of the mail sent to the member when marked as paid.', 'events-made-easy' ); ?><br>
         </p>
         <?php esc_html_e( 'No template shown in the list? Then go in the section Templates and create a template of type "Membership related mail".', 'events-made-easy' ); ?>
@@ -2558,7 +2558,7 @@ function eme_meta_box_div_membershipmailformats( $membership ) {
     </tr>
     <tr>
     <td><label for="name"><?php esc_html_e( 'Contactperson membership paid email body', 'events-made-easy' ); ?></label></td>
-    <td><?php echo eme_ui_select( $membership['properties']['contact_paid_body_format_tpl'], 'properties[contact_paid_body_format_tpl]', $templates_array ); ?>
+    <td><?php echo eme_ui_select( $membership['properties']['contact_paid_body_format_tpl'], 'properties[contact_paid_body_format_tpl]', $templates_array ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select() ?>
         <br><p class='eme_smaller'><?php esc_html_e( 'The body of the mail sent to the contactperson after a member is marked as paid.', 'events-made-easy' ); ?><br>
         </p>
         <?php esc_html_e( 'No template shown in the list? Then go in the section Templates and create a template of type "Membership related mail".', 'events-made-easy' ); ?>
@@ -2597,7 +2597,7 @@ function eme_meta_box_div_membershipmailformats( $membership ) {
     </tr>
     <tr>
     <td><label for="name"><?php esc_html_e( 'Membership reminder email body', 'events-made-easy' ); ?></label></td>
-    <td><?php echo eme_ui_select( $membership['properties']['reminder_body_format_tpl'], 'properties[reminder_body_format_tpl]', $templates_array ); ?>
+    <td><?php echo eme_ui_select( $membership['properties']['reminder_body_format_tpl'], 'properties[reminder_body_format_tpl]', $templates_array ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select() ?>
         <br><p class='eme_smaller'><?php esc_html_e( 'The body of the mail sent to the member when membership is about to expire. These reminders will be sent once a day, based on the reminder settings of the defined membership.', 'events-made-easy' ); ?><br>
         <br><?php esc_html_e( 'This reminder email does NOT take into account an optional grace period.', 'events-made-easy' ); ?>
         </p>
@@ -2637,7 +2637,7 @@ function eme_meta_box_div_membershipmailformats( $membership ) {
     </tr>
     <tr>
     <td><label for="name"><?php esc_html_e( 'Membership stopped email body', 'events-made-easy' ); ?></label></td>
-    <td><?php echo eme_ui_select( $membership['properties']['stop_body_format_tpl'], 'properties[stop_body_format_tpl]', $templates_array ); ?>
+    <td><?php echo eme_ui_select( $membership['properties']['stop_body_format_tpl'], 'properties[stop_body_format_tpl]', $templates_array ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select() ?>
         <br><p class='eme_smaller'><?php esc_html_e( 'The body of the mail sent to the member when a membership has expired or is marked as stopped.', 'events-made-easy' ); ?>
         <br><?php esc_html_e( 'If a grace period is defined for the membership, the expiry email is only sent at the end of the grace period.', 'events-made-easy' ); ?>
         </p>
@@ -2668,7 +2668,7 @@ function eme_meta_box_div_membershipmailformats( $membership ) {
     </tr>
     <tr>
     <td><label for="name"><?php esc_html_e( 'Contactperson membership stopped email body', 'events-made-easy' ); ?></label></td>
-    <td><?php echo eme_ui_select( $membership['properties']['contact_stop_body_format_tpl'], 'properties[contact_stop_body_format_tpl]', $templates_array ); ?>
+    <td><?php echo eme_ui_select( $membership['properties']['contact_stop_body_format_tpl'], 'properties[contact_stop_body_format_tpl]', $templates_array ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select() ?>
         <br><p class='eme_smaller'><?php esc_html_e( 'The body of the mail sent to the contactperson when a membership has expired or is stopped.', 'events-made-easy' ); ?>
         <br><?php esc_html_e( 'If a grace period is defined for the membership, the expiry email is only sent at the end of the grace period.', 'events-made-easy' ); ?>
         </p>
@@ -2706,7 +2706,7 @@ function eme_meta_box_div_membershipmailformats( $membership ) {
     </tr>
     <tr>
     <td><label for="name"><?php esc_html_e( 'Contactperson member deleted email body', 'events-made-easy' ); ?></label></td>
-    <td><?php echo eme_ui_select( $membership['properties']['contact_deleted_body_format_tpl'], 'properties[contact_deleted_body_format_tpl]', $templates_array ); ?>
+    <td><?php echo eme_ui_select( $membership['properties']['contact_deleted_body_format_tpl'], 'properties[contact_deleted_body_format_tpl]', $templates_array ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select() ?>
         <br><p class='eme_smaller'><?php esc_html_e( 'The body of the mail sent to the contactperson just before a member is deleted.', 'events-made-easy' ); ?>
         </p>
         <br><?php esc_html_e( 'No template shown in the list? Then go in the section Templates and create a template of type "Membership related mail".', 'events-made-easy' ); ?>
@@ -2742,7 +2742,7 @@ function eme_meta_box_div_membershipmailformats( $membership ) {
     </tr>
     <tr>
     <td><label for="name"><?php esc_html_e( 'Contactperson payment notification email body', 'events-made-easy' ); ?></label></td>
-    <td><?php echo eme_ui_select( $membership['properties']['contact_ipn_body_format_tpl'], 'properties[contact_ipn_body_format_tpl]', $templates_array ); ?>
+    <td><?php echo eme_ui_select( $membership['properties']['contact_ipn_body_format_tpl'], 'properties[contact_ipn_body_format_tpl]', $templates_array ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select() ?>
         <br><p class='eme_smaller'><?php esc_html_e( 'The body of the email that will be sent to the contact person when a payment notification is received via a payment gateway.', 'events-made-easy' ); ?><br>
         </p>
         <?php esc_html_e( 'No template shown in the list? Then go in the section Templates and create a template of type "Membership related mail".', 'events-made-easy' ); ?>
@@ -2888,28 +2888,28 @@ function eme_render_member_table_and_filters ($limit_to_group = 0 ) {
     <span id="span_sendmails" class="eme-hidden">
 <?php
     esc_html_e( 'Send emails to members upon changes being made?', 'events-made-easy' );
-    echo eme_ui_select_binary( 1, 'send_mail' );
+    echo eme_ui_select_binary( 1, 'send_mail' ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select()
 ?>
     </span>
     <span id="span_trashperson" class="eme-hidden">
 <?php
     esc_html_e( 'Move corresponding persons to the trash bin?', 'events-made-easy' );
-    echo eme_ui_select_binary( 0, 'trash_person' );
+    echo eme_ui_select_binary( 0, 'trash_person' ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select()
 ?>
     </span>
     <span id="span_membermailtemplate" class="eme-hidden">
-    <?php echo eme_ui_select_key_value( '', 'membermail_template_subject', $membertemplates, 'id', 'name', __( 'Select a subject template', 'events-made-easy' ), 1 ); ?>
-    <?php echo eme_ui_select_key_value( '', 'membermail_template', $membertemplates, 'id', 'name', __( 'Please select a body template', 'events-made-easy' ), 1 ); ?>
+    <?php echo eme_ui_select_key_value( '', 'membermail_template_subject', $membertemplates, 'id', 'name', __( 'Select a subject template', 'events-made-easy' ), 1 ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select() ?>
+    <?php echo eme_ui_select_key_value( '', 'membermail_template', $membertemplates, 'id', 'name', __( 'Please select a body template', 'events-made-easy' ), 1 ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select() ?>
     </span>
     <span id="span_pdftemplate" class="eme-hidden">
-    <?php echo eme_ui_select_key_value( '', 'pdf_template_header', $pdftemplates, 'id', 'name', __( 'Select an optional header template', 'events-made-easy' ), 1 ); ?>
-    <?php echo eme_ui_select_key_value( '', 'pdf_template', $pdftemplates, 'id', 'name', __( 'Please select a template', 'events-made-easy' ), 1 ); ?>
-    <?php echo eme_ui_select_key_value( '', 'pdf_template_footer', $pdftemplates, 'id', 'name', __( 'Select an optional footer template', 'events-made-easy' ), 1 ); ?>
+    <?php echo eme_ui_select_key_value( '', 'pdf_template_header', $pdftemplates, 'id', 'name', __( 'Select an optional header template', 'events-made-easy' ), 1 ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select() ?>
+    <?php echo eme_ui_select_key_value( '', 'pdf_template', $pdftemplates, 'id', 'name', __( 'Please select a template', 'events-made-easy' ), 1 ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select() ?>
+    <?php echo eme_ui_select_key_value( '', 'pdf_template_footer', $pdftemplates, 'id', 'name', __( 'Select an optional footer template', 'events-made-easy' ), 1 ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select() ?>
     </span>
     <span id="span_htmltemplate" class="eme-hidden">
-    <?php echo eme_ui_select_key_value( '', 'html_template_header', $htmltemplates, 'id', 'name', __( 'Select an optional header template', 'events-made-easy' ), 1 ); ?>
-    <?php echo eme_ui_select_key_value( '', 'html_template', $htmltemplates, 'id', 'name', __( 'Please select a template', 'events-made-easy' ), 1 ); ?>
-    <?php echo eme_ui_select_key_value( '', 'html_template_footer', $htmltemplates, 'id', 'name', __( 'Select an optional footer template', 'events-made-easy' ), 1 ); ?>
+    <?php echo eme_ui_select_key_value( '', 'html_template_header', $htmltemplates, 'id', 'name', __( 'Select an optional header template', 'events-made-easy' ), 1 ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select() ?>
+    <?php echo eme_ui_select_key_value( '', 'html_template', $htmltemplates, 'id', 'name', __( 'Please select a template', 'events-made-easy' ), 1 ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select() ?>
+    <?php echo eme_ui_select_key_value( '', 'html_template_footer', $htmltemplates, 'id', 'name', __( 'Select an optional footer template', 'events-made-easy' ), 1 ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select() ?>
     </span>
     <button id="MembersActionsButton" class="button-secondary action"><?php esc_html_e( 'Apply', 'events-made-easy' ); ?></button>
     <?php eme_rightclickhint(); ?>
@@ -4997,7 +4997,7 @@ function eme_access_meta_box_cb( $post ) {
     echo "<br><label for='eme_access_denied'>" . esc_html__( 'Access denied message template', 'events-made-easy' ) . '</label>&nbsp;';
     #echo "<input type='text' name='eme_access_denied' id='eme_access_denied' value='$text'>";
     $templates_array = eme_get_templates_array_by_id();
-    echo eme_ui_select( $access_denied_tpl, 'eme_access_denied', $templates_array );
+    echo eme_ui_select( $access_denied_tpl, 'eme_access_denied', $templates_array ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select()
     echo "<br><p class='eme_smaller'>" . esc_html__( 'The format of the text shown if access to the page is denied. If left empty, a default message will be shown.', 'events-made-easy' ) . '</p>';
 
     wp_nonce_field( 'eme_meta_box', 'eme_meta_box_nonce' );

--- a/eme-options.php
+++ b/eme-options.php
@@ -1881,7 +1881,7 @@ function eme_options_page() {
                 'end'   => __( 'ends', 'events-made-easy' ),
             ];
             esc_html_e( 'before the event ', 'events-made-easy' );
-            echo eme_ui_select( $eme_rsvp_start_target, 'eme_rsvp_start_target', $eme_rsvp_start_target_list );
+            echo eme_ui_select( $eme_rsvp_start_target, 'eme_rsvp_start_target', $eme_rsvp_start_target_list ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select()
 ?>
         <br><?php esc_html_e( '(0 for both days and hours indicates no limit)', 'events-made-easy' ); ?>
         </td>
@@ -1897,7 +1897,7 @@ function eme_options_page() {
                 'end'   => __( 'ends', 'events-made-easy' ),
             ];
             esc_html_e( 'before the event ', 'events-made-easy' );
-            echo eme_ui_select( $eme_rsvp_end_target, 'eme_rsvp_end_target', $eme_rsvp_end_target_list );
+            echo eme_ui_select( $eme_rsvp_end_target, 'eme_rsvp_end_target', $eme_rsvp_end_target_list ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select()
 ?>
         <br><?php esc_html_e( '(0 for both days and hours indicates no limit)', 'events-made-easy' ); ?>
         </td>

--- a/eme-people.php
+++ b/eme-people.php
@@ -2049,20 +2049,20 @@ function eme_render_people_table_and_filters( $limit_to_group = 0) {
     </select>
     </span>
     <span id="span_addtogroup" class="eme-hidden">
-    <?php echo eme_ui_select_key_value( '', 'addtogroup', $groups, 'group_id', 'name', __( 'Select a group', 'events-made-easy' ), 1 ); ?>
+    <?php echo eme_ui_select_key_value( '', 'addtogroup', $groups, 'group_id', 'name', __( 'Select a group', 'events-made-easy' ), 1 ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select() ?>
     </span>
     <span id="span_removefromgroup" class="eme-hidden">
-    <?php echo eme_ui_select_key_value( '', 'removefromgroup', $groups, 'group_id', 'name', __( 'Select a group', 'events-made-easy' ), 1 ); ?>
+    <?php echo eme_ui_select_key_value( '', 'removefromgroup', $groups, 'group_id', 'name', __( 'Select a group', 'events-made-easy' ), 1 ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select() ?>
     </span>
     <span id="span_pdftemplate" class="eme-hidden">
-    <?php echo eme_ui_select_key_value( '', 'pdf_template_header', $pdftemplates, 'id', 'name', __( 'Select an optional header template', 'events-made-easy' ), 1 ); ?>
-    <?php echo eme_ui_select_key_value( '', 'pdf_template', $pdftemplates, 'id', 'name', __( 'Please select a template', 'events-made-easy' ), 1 ); ?>
-    <?php echo eme_ui_select_key_value( '', 'pdf_template_footer', $pdftemplates, 'id', 'name', __( 'Select an optional footer template', 'events-made-easy' ), 1 ); ?>
+    <?php echo eme_ui_select_key_value( '', 'pdf_template_header', $pdftemplates, 'id', 'name', __( 'Select an optional header template', 'events-made-easy' ), 1 ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select() ?>
+    <?php echo eme_ui_select_key_value( '', 'pdf_template', $pdftemplates, 'id', 'name', __( 'Please select a template', 'events-made-easy' ), 1 ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select() ?>
+    <?php echo eme_ui_select_key_value( '', 'pdf_template_footer', $pdftemplates, 'id', 'name', __( 'Select an optional footer template', 'events-made-easy' ), 1 ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select() ?>
     </span>
     <span id="span_htmltemplate" class="eme-hidden">
-    <?php echo eme_ui_select_key_value( '', 'html_template_header', $htmltemplates, 'id', 'name', __( 'Select an optional header template', 'events-made-easy' ), 1 ); ?>
-    <?php echo eme_ui_select_key_value( '', 'html_template', $htmltemplates, 'id', 'name', __( 'Please select a template', 'events-made-easy' ), 1 ); ?>
-    <?php echo eme_ui_select_key_value( '', 'html_template_footer', $htmltemplates, 'id', 'name', __( 'Select an optional footer template', 'events-made-easy' ), 1 ); ?>
+    <?php echo eme_ui_select_key_value( '', 'html_template_header', $htmltemplates, 'id', 'name', __( 'Select an optional header template', 'events-made-easy' ), 1 ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select() ?>
+    <?php echo eme_ui_select_key_value( '', 'html_template', $htmltemplates, 'id', 'name', __( 'Please select a template', 'events-made-easy' ), 1 ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select() ?>
+    <?php echo eme_ui_select_key_value( '', 'html_template_footer', $htmltemplates, 'id', 'name', __( 'Select an optional footer template', 'events-made-easy' ), 1 ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select() ?>
     </span>
     <button id="PeopleActionsButton" class="button-secondary action"><?php esc_html_e( 'Apply', 'events-made-easy' ); ?></button>
     <?php eme_rightclickhint(); ?>
@@ -2593,12 +2593,12 @@ function eme_person_edit_layout( $person_id = 0, $message = '' ) {
         </tr>
         <tr>
         <td><label for="country_code"><?php esc_html_e( 'Country', 'events-made-easy' ); ?></label></td>
-        <td><?php echo eme_ui_select( $person['country_code'], 'country_code', $country_arr, '', 0, 'eme_snapselect_country_class' ); ?></td>
+        <td><?php echo eme_ui_select( $person['country_code'], 'country_code', $country_arr, '', 0, 'eme_snapselect_country_class' ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select() ?></td>
         <td></td>
         </tr>
         <tr>
         <td><label for="state_code"><?php esc_html_e( 'State', 'events-made-easy' ); ?></label></td>
-        <td><?php echo eme_ui_select( $person['state_code'], 'state_code', $state_arr, '', 0, 'eme_snapselect_state_class' ); ?></td>
+        <td><?php echo eme_ui_select( $person['state_code'], 'state_code', $state_arr, '', 0, 'eme_snapselect_state_class' ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select() ?></td>
         <td></td>
         </tr>
         <tr>
@@ -2611,7 +2611,7 @@ function eme_person_edit_layout( $person_id = 0, $message = '' ) {
         <td><label for="bd_email"><?php esc_html_e( 'Birthday email', 'events-made-easy' ); ?></label></td>
         <td colspan=2>
 <?php
-    echo eme_ui_select_binary( $person['bd_email'], 'bd_email' );
+    echo eme_ui_select_binary( $person['bd_email'], 'bd_email' ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select()
     esc_html_e( 'If active, the person will receive a birthday email.', 'events-made-easy' );
 ?>
         </td>
@@ -2627,15 +2627,15 @@ function eme_person_edit_layout( $person_id = 0, $message = '' ) {
         <tr>
         <tr>
         <td><label for="massmail"><?php esc_html_e( 'MassMail', 'events-made-easy' ); ?></label></td>
-        <td colspan=2><?php echo eme_ui_select_binary( $person['massmail'], 'massmail' ); ?></td>
+        <td colspan=2><?php echo eme_ui_select_binary( $person['massmail'], 'massmail' ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select() ?></td>
         </tr>
         <tr>
         <td><label for="newsletter"><?php esc_html_e( 'Newsletter', 'events-made-easy' ); ?></label></td>
-        <td colspan=2><?php echo eme_ui_select_binary( $person['newsletter'], 'newsletter' ); ?></td>
+        <td colspan=2><?php echo eme_ui_select_binary( $person['newsletter'], 'newsletter' ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select() ?></td>
         </tr>
         <tr>
         <td><label for="gdpr"><?php esc_html_e( 'GDPR approval', 'events-made-easy' ); ?></label></td>
-        <td colspan=2><?php echo eme_ui_select_binary( $person['gdpr'], 'gdpr' ); ?></td>
+        <td colspan=2><?php echo eme_ui_select_binary( $person['gdpr'], 'gdpr' ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select() ?></td>
         </tr>
         <tr>
         <td><label for="groups"><?php esc_html_e( 'Groups', 'events-made-easy' ); ?></label></td>
@@ -2684,7 +2684,7 @@ function eme_person_edit_layout( $person_id = 0, $message = '' ) {
         </tr>
         <tr>
         <td style="vertical-align:top"><label for="properties[wp_delete_user]"><?php esc_html_e( 'Delete linked WP user?', 'events-made-easy' ); ?></label></td>
-        <td colspan=2><?php echo eme_ui_select_binary( $person['properties']['wp_delete_user'], "properties[wp_delete_user]" ); ?>
+        <td colspan=2><?php echo eme_ui_select_binary( $person['properties']['wp_delete_user'], "properties[wp_delete_user]" ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select() ?>
             <br>
             <?php esc_html_e( "Set this to yes if you want the linked WP user to be deleted when the EME person gets removed (moved to trash bin).", 'events-made-easy' ); ?><br>
             <?php esc_html_e( "By default, this is only set to true when a WP user is created by EME (when creating a member or doing a reservation for an event and the option to create a WP user is set). An admin will never be deleted.", 'events-made-easy' ); ?>
@@ -2803,7 +2803,7 @@ function eme_group_edit_layout( $group_id = 0, $message = '', $group_type = 'sta
         <?php if ( $group['type'] == 'static' ) { ?>
         <tr>
         <td><label for="public"><?php esc_html_e( 'Public?', 'events-made-easy' ); ?></label></td>
-        <td><?php echo eme_ui_select_binary( $group['public'], 'public' ); ?><br>
+        <td><?php echo eme_ui_select_binary( $group['public'], 'public' ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select() ?><br>
             <?php esc_html_e( 'If you chose for this group to be a public group, then this group will appear in the list of groups to subscribe/unsubscribe in the eme_subform and eme_unsubform shortcodes (and the form generated by #_UNSUB_URL).', 'events-made-easy' ); ?>
         </td>
         </tr>

--- a/eme-rsvp.php
+++ b/eme-rsvp.php
@@ -5389,20 +5389,20 @@ function eme_registration_seats_form_table( $pending = 0 ) {
     <span id="span_sendtocontact" class="eme-hidden">
 <?php
     esc_html_e( 'Send emails to contact person too?', 'events-made-easy' );
-    echo eme_ui_select_binary( 0, 'send_to_contact_too' );
+    echo eme_ui_select_binary( 0, 'send_to_contact_too' ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select()
 ?>
     </span>
     <span id="span_sendmails" class="eme-hidden">
 <?php
     esc_html_e( 'Send emails to attendees upon changes being made?', 'events-made-easy' );
-    echo eme_ui_select_binary( 1, 'send_mail' );
+    echo eme_ui_select_binary( 1, 'send_mail' ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select()
 ?>
     </span>
     <?php if ( get_option( 'eme_payment_refund_ok' ) ) : ?>
     <span id="span_refund" class="eme-hidden">
 <?php
     esc_html_e( 'Refund if possible?', 'events-made-easy' );
-    echo eme_ui_select_binary( 0, 'refund' );
+    echo eme_ui_select_binary( 0, 'refund' ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select()
 ?>
     </span>
     <?php endif; ?>
@@ -5414,24 +5414,24 @@ function eme_registration_seats_form_table( $pending = 0 ) {
 ?>
     </span>
     <span id="span_rsvpmailtemplate" class="eme-hidden">
-    <?php echo eme_ui_select_key_value( '', 'rsvpmail_template_subject', $rsvptemplates, 'id', 'name', __( 'Select a subject template', 'events-made-easy' ), 1 ); ?>
-    <?php echo eme_ui_select_key_value( '', 'rsvpmail_template', $rsvptemplates, 'id', 'name', __( 'Please select a body template', 'events-made-easy' ), 1 ); ?>
+    <?php echo eme_ui_select_key_value( '', 'rsvpmail_template_subject', $rsvptemplates, 'id', 'name', __( 'Select a subject template', 'events-made-easy' ), 1 ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select() ?>
+    <?php echo eme_ui_select_key_value( '', 'rsvpmail_template', $rsvptemplates, 'id', 'name', __( 'Please select a body template', 'events-made-easy' ), 1 ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select() ?>
     </span>
     <span id="span_pdftemplate" class="eme-hidden">
-    <?php echo eme_ui_select_key_value( '', 'pdf_template_header', $pdftemplates, 'id', 'name', __( 'Select an optional header template', 'events-made-easy' ), 1 ); ?>
-    <?php echo eme_ui_select_key_value( '', 'pdf_template', $pdftemplates, 'id', 'name', __( 'Please select a template', 'events-made-easy' ), 1 ); ?>
-    <?php echo eme_ui_select_key_value( '', 'pdf_template_footer', $pdftemplates, 'id', 'name', __( 'Select an optional footer template', 'events-made-easy' ), 1 ); ?>
+    <?php echo eme_ui_select_key_value( '', 'pdf_template_header', $pdftemplates, 'id', 'name', __( 'Select an optional header template', 'events-made-easy' ), 1 ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select() ?>
+    <?php echo eme_ui_select_key_value( '', 'pdf_template', $pdftemplates, 'id', 'name', __( 'Please select a template', 'events-made-easy' ), 1 ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select() ?>
+    <?php echo eme_ui_select_key_value( '', 'pdf_template_footer', $pdftemplates, 'id', 'name', __( 'Select an optional footer template', 'events-made-easy' ), 1 ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select() ?>
     </span>
     <span id="span_htmltemplate" class="eme-hidden">
-    <?php echo eme_ui_select_key_value( '', 'html_template_header', $htmltemplates, 'id', 'name', __( 'Select an optional header template', 'events-made-easy' ), 1 ); ?>
-    <?php echo eme_ui_select_key_value( '', 'html_template', $htmltemplates, 'id', 'name', __( 'Please select a template', 'events-made-easy' ), 1 ); ?>
-    <?php echo eme_ui_select_key_value( '', 'html_template_footer', $htmltemplates, 'id', 'name', __( 'Select an optional footer template', 'events-made-easy' ), 1 ); ?>
+    <?php echo eme_ui_select_key_value( '', 'html_template_header', $htmltemplates, 'id', 'name', __( 'Select an optional header template', 'events-made-easy' ), 1 ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select() ?>
+    <?php echo eme_ui_select_key_value( '', 'html_template', $htmltemplates, 'id', 'name', __( 'Please select a template', 'events-made-easy' ), 1 ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select() ?>
+    <?php echo eme_ui_select_key_value( '', 'html_template_footer', $htmltemplates, 'id', 'name', __( 'Select an optional footer template', 'events-made-easy' ), 1 ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select() ?>
     </span>
     <span id="span_addtogroup" class="eme-hidden">
-    <?php echo eme_ui_select_key_value( '', 'addtogroup', $groups, 'group_id', 'name', __( 'Select a group', 'events-made-easy' ), 1 ); ?>
+    <?php echo eme_ui_select_key_value( '', 'addtogroup', $groups, 'group_id', 'name', __( 'Select a group', 'events-made-easy' ), 1 ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select() ?>
     </span>
     <span id="span_removefromgroup" class="eme-hidden">
-    <?php echo eme_ui_select_key_value( '', 'removefromgroup', $groups, 'group_id', 'name', __( 'Select a group', 'events-made-easy' ), 1 ); ?>
+    <?php echo eme_ui_select_key_value( '', 'removefromgroup', $groups, 'group_id', 'name', __( 'Select a group', 'events-made-easy' ), 1 ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select() ?>
     </span>
     <button id="BookingsActionsButton" class="button-secondary action"><?php esc_html_e( 'Apply', 'events-made-easy' ); ?></button>
     <?php eme_rightclickhint(); ?>

--- a/eme-tasks.php
+++ b/eme-tasks.php
@@ -607,9 +607,9 @@ function eme_task_signups_table_layout( $message = '' ) {
             1 => __('Approved', 'events-made-easy')
         ];
         if (isset($_GET['status']))
-            echo eme_ui_select( intval($_GET['status']), 'search_signup_status', $eme_signup_status_array );
+            echo eme_ui_select( intval($_GET['status']), 'search_signup_status', $eme_signup_status_array ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select()
         else
-            echo eme_ui_select( -1, 'search_signup_status', $eme_signup_status_array );
+            echo eme_ui_select( -1, 'search_signup_status', $eme_signup_status_array ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select()
         ?>
 
         <input id="search_start_date" type="hidden" name="search_start_date" value="">
@@ -633,7 +633,7 @@ function eme_task_signups_table_layout( $message = '' ) {
         <span id="span_sendmails" class="eme-hidden">
         <?php
         esc_html_e( 'Send emails to people upon changes being made?', 'events-made-easy' );
-        echo eme_ui_select_binary( 1, 'send_mail' );
+        echo eme_ui_select_binary( 1, 'send_mail' ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select()
         ?>
         </span>
     <button id="TaskSignupsActionsButton" class="button-secondary action"><?php esc_html_e( 'Apply', 'events-made-easy' ); ?></button>
@@ -668,7 +668,7 @@ function eme_meta_box_div_event_task_signup_made_email( $event, $templates_array
     <br>
     <?php
     esc_html_e( 'Only choose a template if you want to override the default settings:', 'events-made-easy' );
-    echo eme_ui_select( $event['event_properties']['task_signup_email_subject_tpl'], 'eme_prop_task_signup_email_subject_tpl', $templates_array );
+    echo eme_ui_select( $event['event_properties']['task_signup_email_subject_tpl'], 'eme_prop_task_signup_email_subject_tpl', $templates_array ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select()
     ?>
     <br>
     <br>
@@ -677,7 +677,7 @@ function eme_meta_box_div_event_task_signup_made_email( $event, $templates_array
     <br>
     <?php
     esc_html_e( 'Only choose a template if you want to override the default settings:', 'events-made-easy' );
-    echo eme_ui_select( $event['event_properties']['task_signup_email_body_tpl'], 'eme_prop_task_signup_email_body_tpl', $templates_array );
+    echo eme_ui_select( $event['event_properties']['task_signup_email_body_tpl'], 'eme_prop_task_signup_email_body_tpl', $templates_array ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select()
     ?>
 </div>
 <br>
@@ -687,7 +687,7 @@ function eme_meta_box_div_event_task_signup_made_email( $event, $templates_array
     <br>
     <?php
     esc_html_e( 'Only choose a template if you want to override the default settings:', 'events-made-easy' );
-    echo eme_ui_select( $event['event_properties']['cp_task_signup_email_subject_tpl'], 'eme_prop_cp_task_signup_email_subject_tpl', $templates_array );
+    echo eme_ui_select( $event['event_properties']['cp_task_signup_email_subject_tpl'], 'eme_prop_cp_task_signup_email_subject_tpl', $templates_array ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select()
     ?>
     <br>
     <br>
@@ -696,7 +696,7 @@ function eme_meta_box_div_event_task_signup_made_email( $event, $templates_array
     <br>
     <?php
     esc_html_e( 'Only choose a template if you want to override the default settings:', 'events-made-easy' );
-    echo eme_ui_select( $event['event_properties']['cp_task_signup_email_body_tpl'], 'eme_prop_cp_task_signup_email_body_tpl', $templates_array );
+    echo eme_ui_select( $event['event_properties']['cp_task_signup_email_body_tpl'], 'eme_prop_cp_task_signup_email_body_tpl', $templates_array ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select()
     ?>
 </div>
     <?php
@@ -710,7 +710,7 @@ function eme_meta_box_div_event_task_signup_pending_email( $event, $templates_ar
     <br>
     <?php
     esc_html_e( 'Only choose a template if you want to override the default settings:', 'events-made-easy' );
-    echo eme_ui_select( $event['event_properties']['task_signup_pending_email_subject_tpl'], 'eme_prop_task_signup_pending_email_subject_tpl', $templates_array );
+    echo eme_ui_select( $event['event_properties']['task_signup_pending_email_subject_tpl'], 'eme_prop_task_signup_pending_email_subject_tpl', $templates_array ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select()
     ?>
     <br>
     <br>
@@ -719,7 +719,7 @@ function eme_meta_box_div_event_task_signup_pending_email( $event, $templates_ar
     <br>
     <?php
     esc_html_e( 'Only choose a template if you want to override the default settings:', 'events-made-easy' );
-    echo eme_ui_select( $event['event_properties']['task_signup_pending_email_body_tpl'], 'eme_prop_task_signup_pending_email_body_tpl', $templates_array );
+    echo eme_ui_select( $event['event_properties']['task_signup_pending_email_body_tpl'], 'eme_prop_task_signup_pending_email_body_tpl', $templates_array ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select()
     ?>
 </div>
 <br>
@@ -729,7 +729,7 @@ function eme_meta_box_div_event_task_signup_pending_email( $event, $templates_ar
     <br>
     <?php
     esc_html_e( 'Only choose a template if you want to override the default settings:', 'events-made-easy' );
-    echo eme_ui_select( $event['event_properties']['cp_task_signup_pending_email_subject_tpl'], 'eme_prop_cp_task_signup_pending_email_subject_tpl', $templates_array );
+    echo eme_ui_select( $event['event_properties']['cp_task_signup_pending_email_subject_tpl'], 'eme_prop_cp_task_signup_pending_email_subject_tpl', $templates_array ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select()
     ?>
     <br>
     <br>
@@ -738,7 +738,7 @@ function eme_meta_box_div_event_task_signup_pending_email( $event, $templates_ar
     <br>
     <?php
     esc_html_e( 'Only choose a template if you want to override the default settings:', 'events-made-easy' );
-    echo eme_ui_select( $event['event_properties']['cp_task_signup_pending_email_body_tpl'], 'eme_prop_cp_task_signup_pending_email_body_tpl', $templates_array );
+    echo eme_ui_select( $event['event_properties']['cp_task_signup_pending_email_body_tpl'], 'eme_prop_cp_task_signup_pending_email_body_tpl', $templates_array ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select()
     ?>
 </div>
     <?php
@@ -752,7 +752,7 @@ function eme_meta_box_div_event_task_signup_updated_email( $event, $templates_ar
     <br>
     <?php
     esc_html_e( 'Only choose a template if you want to override the default settings:', 'events-made-easy' );
-    echo eme_ui_select( $event['event_properties']['task_signup_updated_email_subject_tpl'], 'eme_prop_task_signup_updated_email_subject_tpl', $templates_array );
+    echo eme_ui_select( $event['event_properties']['task_signup_updated_email_subject_tpl'], 'eme_prop_task_signup_updated_email_subject_tpl', $templates_array ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select()
     ?>
     <br>
     <br>
@@ -761,7 +761,7 @@ function eme_meta_box_div_event_task_signup_updated_email( $event, $templates_ar
     <br>
     <?php
     esc_html_e( 'Only choose a template if you want to override the default settings:', 'events-made-easy' );
-    echo eme_ui_select( $event['event_properties']['task_signup_updated_email_body_tpl'], 'eme_prop_task_signup_updated_email_body_tpl', $templates_array );
+    echo eme_ui_select( $event['event_properties']['task_signup_updated_email_body_tpl'], 'eme_prop_task_signup_updated_email_body_tpl', $templates_array ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select()
     ?>
 </div>
     <?php
@@ -775,7 +775,7 @@ function eme_meta_box_div_event_task_signup_cancelled_email( $event, $templates_
     <br>
     <?php
     esc_html_e( 'Only choose a template if you want to override the default settings:', 'events-made-easy' );
-    echo eme_ui_select( $event['event_properties']['task_signup_cancelled_email_subject_tpl'], 'eme_prop_task_signup_cancelled_email_subject_tpl', $templates_array );
+    echo eme_ui_select( $event['event_properties']['task_signup_cancelled_email_subject_tpl'], 'eme_prop_task_signup_cancelled_email_subject_tpl', $templates_array ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select()
     ?>
     <br>
     <br>
@@ -784,7 +784,7 @@ function eme_meta_box_div_event_task_signup_cancelled_email( $event, $templates_
     <br>
     <?php
     esc_html_e( 'Only choose a template if you want to override the default settings:', 'events-made-easy' );
-    echo eme_ui_select( $event['event_properties']['task_signup_cancelled_email_body_tpl'], 'eme_prop_task_signup_cancelled_email_body_tpl', $templates_array );
+    echo eme_ui_select( $event['event_properties']['task_signup_cancelled_email_body_tpl'], 'eme_prop_task_signup_cancelled_email_body_tpl', $templates_array ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select()
     ?>
 </div>
 <br>
@@ -794,7 +794,7 @@ function eme_meta_box_div_event_task_signup_cancelled_email( $event, $templates_
     <br>
     <?php
     esc_html_e( 'Only choose a template if you want to override the default settings:', 'events-made-easy' );
-    echo eme_ui_select( $event['event_properties']['cp_task_signup_cancelled_email_subject_tpl'], 'eme_prop_cp_task_signup_cancelled_email_subject_tpl', $templates_array );
+    echo eme_ui_select( $event['event_properties']['cp_task_signup_cancelled_email_subject_tpl'], 'eme_prop_cp_task_signup_cancelled_email_subject_tpl', $templates_array ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select()
     ?>
     <br>
     <br>
@@ -803,7 +803,7 @@ function eme_meta_box_div_event_task_signup_cancelled_email( $event, $templates_
     <br>
     <?php
     esc_html_e( 'Only choose a template if you want to override the default settings:', 'events-made-easy' );
-    echo eme_ui_select( $event['event_properties']['cp_task_signup_cancelled_email_body_tpl'], 'eme_prop_cp_task_signup_cancelled_email_body_tpl', $templates_array );
+    echo eme_ui_select( $event['event_properties']['cp_task_signup_cancelled_email_body_tpl'], 'eme_prop_cp_task_signup_cancelled_email_body_tpl', $templates_array ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select()
     ?>
 </div>
     <?php
@@ -817,7 +817,7 @@ function eme_meta_box_div_event_task_signup_trashed_email( $event, $templates_ar
     <br>
     <?php
     esc_html_e( 'Only choose a template if you want to override the default settings:', 'events-made-easy' );
-    echo eme_ui_select( $event['event_properties']['task_signup_trashed_email_subject_tpl'], 'eme_prop_task_signup_trashed_email_subject_tpl', $templates_array );
+    echo eme_ui_select( $event['event_properties']['task_signup_trashed_email_subject_tpl'], 'eme_prop_task_signup_trashed_email_subject_tpl', $templates_array ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select()
     ?>
     <br>
     <br>
@@ -826,7 +826,7 @@ function eme_meta_box_div_event_task_signup_trashed_email( $event, $templates_ar
     <br>
     <?php
     esc_html_e( 'Only choose a template if you want to override the default settings:', 'events-made-easy' );
-    echo eme_ui_select( $event['event_properties']['task_signup_trashed_email_body_tpl'], 'eme_prop_task_signup_trashed_email_body_tpl', $templates_array );
+    echo eme_ui_select( $event['event_properties']['task_signup_trashed_email_body_tpl'], 'eme_prop_task_signup_trashed_email_body_tpl', $templates_array ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select()
     ?>
 </div>
     <?php
@@ -840,7 +840,7 @@ function eme_meta_box_div_event_task_signup_reminder_email( $event, $templates_a
     <br>
     <?php
     esc_html_e( 'Only choose a template if you want to override the default settings:', 'events-made-easy' );
-    echo eme_ui_select( $event['event_properties']['task_signup_reminder_email_subject_tpl'], 'eme_prop_task_signup_reminder_email_subject_tpl', $templates_array );
+    echo eme_ui_select( $event['event_properties']['task_signup_reminder_email_subject_tpl'], 'eme_prop_task_signup_reminder_email_subject_tpl', $templates_array ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select()
     ?>
     <br>
     <br>
@@ -849,7 +849,7 @@ function eme_meta_box_div_event_task_signup_reminder_email( $event, $templates_a
     <br>
     <?php
     esc_html_e( 'Only choose a template if you want to override the default settings:', 'events-made-easy' );
-    echo eme_ui_select( $event['event_properties']['task_signup_reminder_email_body_tpl'], 'eme_prop_task_signup_reminder_email_body_tpl', $templates_array );
+    echo eme_ui_select( $event['event_properties']['task_signup_reminder_email_body_tpl'], 'eme_prop_task_signup_reminder_email_body_tpl', $templates_array ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select()
     ?>
 </div>
     <?php
@@ -863,14 +863,14 @@ function eme_meta_box_div_event_task_signup_form_format( $event, $templates_arra
     <br>
     <?php esc_html_e( 'Only choose a template if you want to override the default settings:', 'events-made-easy' ); ?>
     <?php esc_html_e( 'Warning: this override will only be used when inside a single event, otherwise the generic setting will always be used!', 'events-made-easy' ); ?>
-    <?php echo eme_ui_select( $event['event_properties']['task_form_entry_format_tpl'], 'eme_prop_task_form_entry_format_tpl', $templates_array ); ?>
+    <?php echo eme_ui_select( $event['event_properties']['task_form_entry_format_tpl'], 'eme_prop_task_form_entry_format_tpl', $templates_array ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select() ?>
     </p><p>
     <b><?php esc_html_e( 'Task Signup Form (personal info section)', 'events-made-easy' ); ?></b>
     <p class="eme_smaller"><?php esc_html_e( 'The layout of the task signup form.', 'events-made-easy' ); ?></p>
     <br>
     <?php esc_html_e( 'Only choose a template if you want to override the default settings:', 'events-made-easy' ); ?>
     <?php esc_html_e( 'Warning: this override will only be used when inside a single event, otherwise the generic setting will always be used!', 'events-made-easy' ); ?>
-    <?php echo eme_ui_select( $event['event_properties']['task_signup_form_format_tpl'], 'eme_prop_task_signup_form_format_tpl', $templates_array ); ?>
+    <?php echo eme_ui_select( $event['event_properties']['task_signup_form_format_tpl'], 'eme_prop_task_signup_form_format_tpl', $templates_array ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select() ?>
     </p>
 </div>
     <?php
@@ -883,7 +883,7 @@ function eme_meta_box_div_event_task_signup_recorded_ok_html( $event, $templates
     <p class="eme_smaller"><?php esc_html_e( 'The text (html allowed) shown to the user when the task signup has been made successfully.', 'events-made-easy' ); ?></p>
     <br>
     <?php esc_html_e( 'Only choose a template if you want to override the default settings:', 'events-made-easy' ); ?>
-    <?php echo eme_ui_select( $event['event_properties']['task_signup_recorded_ok_html_tpl'], 'eme_prop_task_signup_recorded_ok_html_tpl', $templates_array ); ?>
+    <?php echo eme_ui_select( $event['event_properties']['task_signup_recorded_ok_html_tpl'], 'eme_prop_task_signup_recorded_ok_html_tpl', $templates_array ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select() ?>
 </div>
     <?php
 }

--- a/eme-templates.php
+++ b/eme-templates.php
@@ -178,7 +178,7 @@ function eme_templates_table_layout( $message = '' ) {
     </div>
     <br><br>
     <form action="#" method="post">
-    <?php echo eme_ui_select( '', 'search_type', $template_types ); ?>
+    <?php echo eme_ui_select( '', 'search_type', $template_types ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select() ?>
     <input type="search" name="search_name" id="search_name" placeholder="<?php esc_attr_e( 'Template name', 'events-made-easy' ); ?>" class="eme_searchfilter" size=20>
     <button id="TemplatesLoadRecordsButton" class="button-secondary action"><?php esc_html_e( 'Filter templates', 'events-made-easy' ); ?></button>
     </form>
@@ -278,7 +278,7 @@ function eme_templates_edit_layout( $template_id = 0, $message = '', $template =
             </tr>
             <tr>
             <td style='vertical-align:top'><?php esc_html_e( 'Type', 'events-made-easy' ); ?></label></td>
-            <td><?php echo eme_ui_select( $template['type'], 'type', $template_types ); ?>
+            <td><?php echo eme_ui_select( $template['type'], 'type', $template_types ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select() ?>
             <br><?php esc_html_e( 'The type allows you to indicate where you want to use this template. This helps to limit the dropdown list of templates to chose from in other parts of EME.', 'events-made-easy' ); ?>
             <br><?php esc_html_e( "The type 'All' means it can be selected anywhere where template selections are possible.", 'events-made-easy' ); ?>
             <br><?php esc_html_e( "The type 'PDF' is used for PDF templating and allows more settings concerning page size, orientation, ...", 'events-made-easy' ); ?>
@@ -290,12 +290,12 @@ function eme_templates_edit_layout( $template_id = 0, $message = '', $template =
         <table class='form-table' id='pdf_properties'>
             <tr class='form-field'>
             <th scope='row' style='vertical-align:top'><?php esc_html_e( 'PDF size', 'events-made-easy' ); ?></th>
-            <td><?php echo eme_ui_select( $template['properties']['pdf_size'], 'properties[pdf_size]', $size_array ); ?><br>
+            <td><?php echo eme_ui_select( $template['properties']['pdf_size'], 'properties[pdf_size]', $size_array ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select() ?><br>
             <?php esc_html_e( "If you select 'Custom', you can enter your own widht/height below.", 'events-made-easy' ); ?></td>
             </tr>
             <tr class='form-field'>
             <th scope='row' style='vertical-align:top'><?php esc_html_e( 'PDF orientation', 'events-made-easy' ); ?></th>
-            <td><?php echo eme_ui_select( $template['properties']['pdf_orientation'], 'properties[pdf_orientation]', $orientation_array ); ?></td>
+            <td><?php echo eme_ui_select( $template['properties']['pdf_orientation'], 'properties[pdf_orientation]', $orientation_array ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select() ?></td>
             </tr>
             <tr class='form-field'>
             <th scope='row' style='vertical-align:top'><?php esc_html_e( 'PDF margins', 'events-made-easy' ); ?></th>


### PR DESCRIPTION
## Summary

- ~143 `echo`/`print` statements outputting `eme_ui_select()`, `eme_ui_select_binary()`,
  `eme_ui_select_key_value()`, and `eme_ui_select_inverted()` annotated with
  `phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped`
- These functions return safe HTML (internally escape with `eme_esc_html()`)
  but PHPCS doesn't recognize plugin-internal escaping functions
- Follows the existing pattern already used in eme-members.php, eme-ui-helpers.php, eme-widgets.php

## Why this is safe

All `eme_ui_select*()` functions (eme-ui-helpers.php) build `<select>` elements with
`eme_esc_html()` on all option values and labels. They return fully escaped HTML.

## What's NOT in this PR

Variable assignments like `$replacement = eme_ui_select(...)` don't trigger PHPCS
and were not annotated. Only direct `echo`/`print` output statements were modified.

## Test plan

- [x] `php -l` syntax check on all modified files
- [x] Runtime tests: 73/76 passed (3 pre-existing CSRF)
- [x] code-checks.sh: `eme_ui_select echo without phpcs:ignore` → 0
- [ ] Visual check of admin pages with select elements