### PR TITLE
Add phpcs:ignore for UI helpers & wp_nonce_field, fix canonical URL escaping

### DIFF
--- a/eme-cleanup.php
+++ b/eme-cleanup.php
@@ -283,7 +283,7 @@ function eme_cleanup_form( $message = '' ) {
 <h1><?php esc_html_e( 'Cleanup actions', 'events-made-easy' ); ?></h1>
 	<form action="" method="post">
 	<label for="eme_number"><?php esc_html_e( 'Remove events older than', 'events-made-easy' ); ?></label>
-	<?php echo wp_nonce_field( 'eme_admin', 'eme_admin_nonce', false, false ); ?>
+	<?php echo wp_nonce_field( 'eme_admin', 'eme_admin_nonce', false, false ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- wp_nonce_field() returns safe HTML ?>
 	<input type='hidden' name='page' value='eme-cleanup'>
 	<input type='hidden' name='eme_admin_action' value='eme_cleanup_events'>
 	<input type="number" id="eme_number" name="eme_number" size="3" maxlength="3" min="1" max="999" step="1" >
@@ -298,7 +298,7 @@ function eme_cleanup_form( $message = '' ) {
 <br><br>
 	<form action="" method="post">
 	<label for="eme_number"><?php esc_html_e( 'Remove unpaid pending bookings older than', 'events-made-easy' ); ?></label>
-	<?php echo wp_nonce_field( 'eme_admin', 'eme_admin_nonce', false, false ); ?>
+	<?php echo wp_nonce_field( 'eme_admin', 'eme_admin_nonce', false, false ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- wp_nonce_field() returns safe HTML ?>
 	<input type='hidden' name='page' value='eme-cleanup'>
 	<input type='hidden' name='eme_admin_action' value='eme_cleanup_unpaid'>
 	<input type="number" id="eme_number" name="eme_number" size="6" maxlength="6" min="5" max="999999" step="1">
@@ -309,7 +309,7 @@ function eme_cleanup_form( $message = '' ) {
 <br><br>
 	<form action="" method="post">
 	<label for="eme_number"><?php esc_html_e( 'Remove unconfirmed bookings older than', 'events-made-easy' ); ?></label>
-	<?php echo wp_nonce_field( 'eme_admin', 'eme_admin_nonce', false, false ); ?>
+	<?php echo wp_nonce_field( 'eme_admin', 'eme_admin_nonce', false, false ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- wp_nonce_field() returns safe HTML ?>
 	<input type='hidden' name='page' value='eme-cleanup'>
 	<input type='hidden' name='eme_admin_action' value='eme_cleanup_unconfirmed'>
 	<input type="number" id="eme_number" name="eme_number" size="6" maxlength="6" min="5" max="999999" step="1">
@@ -320,7 +320,7 @@ function eme_cleanup_form( $message = '' ) {
 <br><br>
 	<form action="" method="post">
 	<?php esc_html_e( 'Move people who are no longer referenced in bookings, groups or memberships to the trash bin', 'events-made-easy' ); ?>
-	<?php echo wp_nonce_field( 'eme_admin', 'eme_admin_nonce', false, false ); ?>
+	<?php echo wp_nonce_field( 'eme_admin', 'eme_admin_nonce', false, false ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- wp_nonce_field() returns safe HTML ?>
 	<input type='hidden' name='page' value='eme-cleanup'>
 	<input type='hidden' name='eme_admin_action' value='eme_cleanup_people'>
 	<input type="submit" value="<?php esc_attr_e( 'Apply', 'events-made-easy' ); ?>" name="doaction" id="eme_doaction" class="button-primary action" onclick="return confirm('<?php echo esc_attr( $areyousure ); ?>');">
@@ -330,7 +330,7 @@ function eme_cleanup_form( $message = '' ) {
 <br><br>
 	<form action="" method="post">
 	<label for="eme_number"><?php esc_html_e( 'Remove people in thrash older than', 'events-made-easy' ); ?></label>
-	<?php echo wp_nonce_field( 'eme_admin', 'eme_admin_nonce', false, false ); ?>
+	<?php echo wp_nonce_field( 'eme_admin', 'eme_admin_nonce', false, false ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- wp_nonce_field() returns safe HTML ?>
 	<input type='hidden' name='page' value='eme-cleanup'>
 	<input type='hidden' name='eme_admin_action' value='eme_cleanup_trashed_people'>
 	<input type="number" id="eme_number" name="eme_number" size="3" maxlength="3" min="1" max="999" step="1" >
@@ -345,7 +345,7 @@ function eme_cleanup_form( $message = '' ) {
 <br><br>
 	<form action="" method="post">
 	<label for="eme_number"><?php esc_html_e( 'Remove bookings in thrash older than', 'events-made-easy' ); ?></label>
-	<?php echo wp_nonce_field( 'eme_admin', 'eme_admin_nonce', false, false ); ?>
+	<?php echo wp_nonce_field( 'eme_admin', 'eme_admin_nonce', false, false ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- wp_nonce_field() returns safe HTML ?>
 	<input type='hidden' name='page' value='eme-cleanup'>
 	<input type='hidden' name='eme_admin_action' value='eme_cleanup_trashed_bookings'>
 	<input type="number" id="eme_number" name="eme_number" size="3" maxlength="3" min="1" max="999" step="1" >
@@ -360,7 +360,7 @@ function eme_cleanup_form( $message = '' ) {
 <br><br>
 	<form action="" method="post">
 	<?php esc_html_e( 'Remove all data concerning events, locations, memberships, people and bookings', 'events-made-easy' ); ?>
-	<?php echo wp_nonce_field( 'eme_admin', 'eme_admin_nonce', false, false ); ?>
+	<?php echo wp_nonce_field( 'eme_admin', 'eme_admin_nonce', false, false ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- wp_nonce_field() returns safe HTML ?>
 	<input type='hidden' name='page' value='eme-cleanup'>
 	<input type='hidden' name='eme_admin_action' value='eme_cleanup_all_event_related_data'>
 	<input id="other_data" type="checkbox" value="1" name="other_data"> <?php esc_html_e( 'Also delete defined categories, templates, holidays, discounts, states, countries and custom form fields', 'events-made-easy' ); ?><br>
@@ -381,7 +381,7 @@ function eme_cleanup_form( $message = '' ) {
 		?>
 	<form action="" method="post">
 		<?php esc_html_e( 'Empty the mail queue', 'events-made-easy' ); ?>
-		<?php echo wp_nonce_field( 'eme_admin', 'eme_admin_nonce', false, false ); ?>
+		<?php echo wp_nonce_field( 'eme_admin', 'eme_admin_nonce', false, false ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- wp_nonce_field() returns safe HTML ?>
 	<input type='hidden' name='eme_admin_action' value='eme_empty_queue'>
 	<input type="submit" value="<?php esc_attr_e( 'Apply', 'events-made-easy' ); ?>" name="doaction" id="eme_doaction" class="button-primary action" onclick="return confirm('<?php echo esc_attr( $areyousure ); ?>');">
 	</form>

--- a/eme-cron.php
+++ b/eme-cron.php
@@ -346,7 +346,7 @@ function eme_cron_form( $message = '' ) {
     <form action="" method="post">
     <label for="eme_cron_cleanup_unpaid_minutes">
 <?php
-    echo wp_nonce_field( 'eme_admin', 'eme_admin_nonce', false, false );
+    echo wp_nonce_field( 'eme_admin', 'eme_admin_nonce', false, false ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- wp_nonce_field() returns safe HTML
     $minutes = intval( get_option( 'eme_cron_cleanup_unpaid_minutes' ) );
     esc_html_e( 'Schedule the automatic removal of unpaid pending bookings older than', 'events-made-easy' );
 ?>
@@ -359,7 +359,7 @@ function eme_cron_form( $message = '' ) {
     <form action="" method="post">
     <label for="eme_cron_cleanup_unconfirmed_minutes">
 <?php
-    echo wp_nonce_field( 'eme_admin', 'eme_admin_nonce', false, false );
+    echo wp_nonce_field( 'eme_admin', 'eme_admin_nonce', false, false ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- wp_nonce_field() returns safe HTML
     $minutes = intval( get_option( 'eme_cron_cleanup_unconfirmed_minutes' ) );
     esc_html_e( 'Schedule the automatic removal of unconfirmed bookings older than', 'events-made-easy' );
 ?>
@@ -414,7 +414,7 @@ function eme_cron_form( $message = '' ) {
     <h2><?php esc_html_e( 'Newsletter', 'events-made-easy' ); ?></h2>
     <form action="" method="post">
 <?php
-        echo wp_nonce_field( 'eme_admin', 'eme_admin_nonce', false, false );
+        echo wp_nonce_field( 'eme_admin', 'eme_admin_nonce', false, false ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- wp_nonce_field() returns safe HTML
         $days                = intval( get_option( 'eme_cron_new_events_days' ) );
         $subject             = intval( get_option( 'eme_cron_new_events_subject' ) );
         $header              = intval( get_option( 'eme_cron_new_events_header' ) );

--- a/eme-discounts.php
+++ b/eme-discounts.php
@@ -894,7 +894,7 @@ function eme_discounts_edit_layout( $discount_id = 0, $message = '' ) {
 		</tr>
 		<tr class='form-field'>
 			<th scope='row' style='vertical-align:top'><label for='value'><?php esc_html_e( 'Discount groups', 'events-made-easy' ); ?></label></th>
-			<td><?php echo eme_ui_multiselect_key_value( $selected_dgroup_arr, 'dgroup', $dgroups, 'id', 'name', 5, '', 0, 'eme_snapselect' ); ?>
+			<td><?php echo eme_ui_multiselect_key_value( $selected_dgroup_arr, 'dgroup', $dgroups, 'id', 'name', 5, '', 0, 'eme_snapselect' ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_multiselect_key_value() ?>
 			<br><?php esc_html_e( 'If wanted, you can make this discount a part of one or more discount groups, and then apply a discount group to your event', 'events-made-easy' ); ?>
 			</td>
 		</tr>
@@ -926,7 +926,7 @@ function eme_discounts_edit_layout( $discount_id = 0, $message = '' ) {
 		</tr>
 		<tr class='form-field'>
 			<th scope='row' style='vertical-align:top'><label for='properties[group_ids]'><?php esc_html_e( 'Require EME groups', 'events-made-easy' ); ?></label></th>
-			<td><?php echo eme_ui_multiselect_key_value( $discount['properties']['group_ids'], 'properties[group_ids]', $groups, 'group_id', 'name', 5, '', 0, 'eme_snapselect' ); ?>
+			<td><?php echo eme_ui_multiselect_key_value( $discount['properties']['group_ids'], 'properties[group_ids]', $groups, 'group_id', 'name', 5, '', 0, 'eme_snapselect' ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_multiselect_key_value() ?>
 			<br><p class='eme_smaller'><?php esc_html_e( 'Require logged-in user to be in of one of the selected EME groups for this discount to apply.', 'events-made-easy' ); ?></p>
 			</td>
 		</tr>
@@ -936,7 +936,7 @@ function eme_discounts_edit_layout( $discount_id = 0, $message = '' ) {
 			<?php
 			if ( ! empty( $memberships ) ) {
                 $extra_attributes = ' data-placeholder="' . esc_attr__( 'Select one or more memberships', 'events-made-easy' ) . '"';
-				echo eme_ui_multiselect_key_value( $discount['properties']['membership_ids'], 'properties[membership_ids]', $memberships, 'membership_id', 'name', 5, '', 0, 'eme_snapselect', $extra_attributes );
+				echo eme_ui_multiselect_key_value( $discount['properties']['membership_ids'], 'properties[membership_ids]', $memberships, 'membership_id', 'name', 5, '', 0, 'eme_snapselect', $extra_attributes ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_multiselect_key_value()
 			} else {
 				esc_html_e( 'No memberships defined yet!', 'events-made-easy' );
 			}

--- a/eme-events.php
+++ b/eme-events.php
@@ -6148,7 +6148,7 @@ function eme_events_table( $message = '' ) {
         echo '<input type="search" name="search_customfields" id="search_customfields" placeholder="' . esc_attr__( 'Custom field value to search', 'events-made-easy' ) . '" class="eme_searchfilter" size=20>';
         $label = __( 'Custom fields to filter on', 'events-made-easy' );
         $extra_attributes = 'aria-label="' . eme_esc_html( $label ) . '" data-placeholder="' . eme_esc_html( $label ) . '"';
-        echo eme_ui_multiselect_key_value( '', 'search_customfieldids', $formfields_searchable, 'field_id', 'field_name', 5, '', 0, 'eme_snapselect', $extra_attributes, 1 );
+        echo eme_ui_multiselect_key_value( '', 'search_customfieldids', $formfields_searchable, 'field_id', 'field_name', 5, '', 0, 'eme_snapselect', $extra_attributes, 1 ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_multiselect_key_value()
     }
 ?>
     </div>
@@ -6551,7 +6551,7 @@ function eme_event_form( $event, $info, $edit_recurrence = 0 ) {
     <div class="eme-tab-content" id="tab-tasks">
     <div class="inside">
         <p id='p_tasks'>
-        <?php echo eme_ui_checkbox_binary( $event['event_tasks'], 'event_tasks', __( 'Enable tasks for this event', 'events-made-easy' ) ); ?>
+        <?php echo eme_ui_checkbox_binary( $event['event_tasks'], 'event_tasks', __( 'Enable tasks for this event', 'events-made-easy' ) ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_checkbox_binary() ?>
         </p>
         <p>
         <?php  esc_html_e( "Tasks can be used to rally volunteers to help with an event (e.g. 5 people behind the bar per shift, cleanup duty, ...) or to allow people to subscribe for a certain timeframe for an event (appointment-like). While you can impose limits and ask for confirmation for tasks, there is no price per task so no payment is possible upon subscribing for a task.", 'events-made-easy' ); ?>
@@ -6608,7 +6608,7 @@ function eme_event_form( $event, $info, $edit_recurrence = 0 ) {
 <div class="eme-tab-content" id="tab-todos">
     <div class="inside">
     <p id='p_todos'>
-    <?php echo eme_ui_checkbox_binary( $event['event_todos'], 'event_todos', __( 'Enable todos for this event', 'events-made-easy' ) ); ?>
+    <?php echo eme_ui_checkbox_binary( $event['event_todos'], 'event_todos', __( 'Enable todos for this event', 'events-made-easy' ) ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_checkbox_binary() ?>
 </p>
     <p>
     <?php esc_html_e( "Each todo with a date in the past will send a mail to the contact person so you can use this to plan your event and not forget things. The date of the todo is based on the event start date and the todo offset parameter in days: an offset of 5 means 5 days before the event starts, an offset of -2 means 2 days after the event started.", 'events-made-easy' ); ?>
@@ -7145,7 +7145,7 @@ function eme_meta_box_div_event_datetime( $event, $recurrence, $edit_recurrence 
         </p>
         </div>
         <p>
-        <?php echo eme_ui_checkbox_binary( $event['event_properties']['all_day'], 'eme_prop_all_day', __( 'This event lasts all day', 'events-made-easy' ) ); ?>
+        <?php echo eme_ui_checkbox_binary( $event['event_properties']['all_day'], 'eme_prop_all_day', __( 'This event lasts all day', 'events-made-easy' ) ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_checkbox_binary() ?>
         </p>
 <?php
     if ( $show_recurrent_form == 1 ) {
@@ -7610,7 +7610,7 @@ function eme_meta_box_div_event_registration_approved_email( $event, $templates_
 <br><br><?php esc_html_e( 'PDF templates as attachments', 'events-made-easy' ); ?>
 <?php
     if (!empty($pdf_templates_array)) {
-        echo eme_ui_multiselect( $event['event_properties']['booking_attach_tmpl_ids'], 'eme_prop_booking_attach_tmpl_ids', $pdf_templates_array, 3, '', 0, 'eme_snapselect' );
+        echo eme_ui_multiselect( $event['event_properties']['booking_attach_tmpl_ids'], 'eme_prop_booking_attach_tmpl_ids', $pdf_templates_array, 3, '', 0, 'eme_snapselect' ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_multiselect()
         echo '<br>';
         esc_html_e( 'Optionally add PDF templates as attachments to the mail.', 'events-made-easy' );
         echo '<br>';
@@ -7811,7 +7811,7 @@ function eme_meta_box_div_event_registration_pending_email( $event, $templates_a
 <br><br><?php esc_html_e( 'PDF templates as attachments', 'events-made-easy' ); ?>
 <?php
     if (!empty($pdf_templates_array)) {
-        echo eme_ui_multiselect( $event['event_properties']['pending_attach_tmpl_ids'], 'eme_prop_pending_attach_tmpl_ids', $pdf_templates_array, 3, '', 0, 'eme_snapselect' );
+        echo eme_ui_multiselect( $event['event_properties']['pending_attach_tmpl_ids'], 'eme_prop_pending_attach_tmpl_ids', $pdf_templates_array, 3, '', 0, 'eme_snapselect' ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_multiselect()
         echo '<br>';
         esc_html_e( 'Optionally add PDF templates as attachments to the mail.', 'events-made-easy' );
         echo '<br>';
@@ -8195,7 +8195,7 @@ function eme_meta_box_div_event_registration_paid_email( $event, $templates_arra
 <br><br><?php esc_html_e( 'PDF templates as attachments', 'events-made-easy' ); ?>
 <?php
     if (!empty($pdf_templates_array)) {
-        echo eme_ui_multiselect( $event['event_properties']['paid_attach_tmpl_ids'], 'eme_prop_paid_attach_tmpl_ids', $pdf_templates_array, 3, '', 0, 'eme_snapselect' );
+        echo eme_ui_multiselect( $event['event_properties']['paid_attach_tmpl_ids'], 'eme_prop_paid_attach_tmpl_ids', $pdf_templates_array, 3, '', 0, 'eme_snapselect' ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_multiselect()
         echo '<br>';
         esc_html_e( 'Optionally add PDF templates as attachments to the mail.', 'events-made-easy' );
         echo '<br>';
@@ -8581,7 +8581,7 @@ function eme_meta_box_div_event_rsvp_enabled( $event ) {
 ?>
                     <div class="inside">
                         <p id='p_rsvp'>
-    <?php echo eme_ui_checkbox_binary( $event['event_rsvp'], 'event_rsvp', __( 'Enable bookings for this event', 'events-made-easy' ) ); ?>
+    <?php echo eme_ui_checkbox_binary( $event['event_rsvp'], 'event_rsvp', __( 'Enable bookings for this event', 'events-made-easy' ) ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_checkbox_binary() ?>
                         </p>
                     </div>
 <?php
@@ -8604,7 +8604,7 @@ function eme_meta_box_div_event_payment_methods( $event, $is_new_event ) {
         esc_html_e( 'No payment methods configured yet. Go in the EME payment settings and configure some.', 'events-made-easy' );
         echo "</b>";
     } else {
-        echo eme_ui_multiselect( $event['event_properties']['payment_gateways'], 'eme_prop_payment_gateways', $configured_pgs_descriptions, 5, '', 0, 'eme_snapselect', 'data-placeholder="'.esc_attr__('Select a payment method','events-made-easy') .'"' );
+        echo eme_ui_multiselect( $event['event_properties']['payment_gateways'], 'eme_prop_payment_gateways', $configured_pgs_descriptions, 5, '', 0, 'eme_snapselect', 'data-placeholder="'.esc_attr__('Select a payment method','events-made-easy') .'"' ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_multiselect()
     }
 ?>
                 </p>
@@ -8713,7 +8713,7 @@ function eme_meta_box_div_event_rsvp( $event, $pdf_templates_array ) {
 ?>
 <div id="div_event_rsvp">
     <p id='p_user_confirmation_required'>
-        <?php echo eme_ui_checkbox_binary( $event['event_properties']['require_user_confirmation'], 'eme_prop_require_user_confirmation', __( 'Require user confirmation after booking', 'events-made-easy' ) ); ?>
+        <?php echo eme_ui_checkbox_binary( $event['event_properties']['require_user_confirmation'], 'eme_prop_require_user_confirmation', __( 'Require user confirmation after booking', 'events-made-easy' ) ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_checkbox_binary() ?>
         <span class="eme_smaller"><br><?php esc_html_e( "If active, don't forget to use #_BOOKING_CONFIRM_URL in the mail being sent to a booker.", 'events-made-easy' ); ?></span>
     </p>
     <p id='p_approval_required'>
@@ -8729,9 +8729,9 @@ function eme_meta_box_div_event_rsvp( $event, $pdf_templates_array ) {
     <p id='p_approve_settings' style="background-color: lightgrey; padding: 5px;">
     <b><?php esc_html_e('Extra approval settings (also check out the mail templates)','events-made-easy'); ?></b>
         <br>
-        <?php echo eme_ui_checkbox_binary( $event['event_properties']['auto_approve'], 'eme_prop_auto_approve', __( 'Auto-approve booking upon payment', 'events-made-easy' ) ); ?>
+        <?php echo eme_ui_checkbox_binary( $event['event_properties']['auto_approve'], 'eme_prop_auto_approve', __( 'Auto-approve booking upon payment', 'events-made-easy' ) ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_checkbox_binary() ?>
         <br>
-        <?php echo eme_ui_checkbox_binary( $event['event_properties']['ignore_pending'], 'eme_prop_ignore_pending', __( 'Consider pending bookings as available seats for new bookings', 'events-made-easy' ) . '<br>' . __( 'In case online payments are possible, pending bookings younger than 5 minutes will count as occupied too, to be able to allow people to finish online payments.', 'events-made-easy' ) ); ?>
+        <?php echo eme_ui_checkbox_binary( $event['event_properties']['ignore_pending'], 'eme_prop_ignore_pending', __( 'Consider pending bookings as available seats for new bookings', 'events-made-easy' ) . '<br>' . __( 'In case online payments are possible, pending bookings younger than 5 minutes will count as occupied too, to be able to allow people to finish online payments.', 'events-made-easy' ) ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_checkbox_binary() ?>
         <br>
         <input id="eme_prop_rsvp_pending_reminder_days" name='eme_prop_rsvp_pending_reminder_days' type='text' value="<?php echo eme_esc_html( $eme_prop_rsvp_pending_reminder_days ); ?>">
         <label for="eme_prop_rsvp_pending_reminder_days"><?php esc_html_e( 'Set the number of days before reminder emails will be sent for pending bookings (counting from the start date of the event). If you want to send out multiple reminders, seperate the days here by commas. Leave empty for no reminder emails.', 'events-made-easy' ); ?></label>
@@ -8741,14 +8741,14 @@ function eme_meta_box_div_event_rsvp( $event, $pdf_templates_array ) {
         <label for="eme_prop_rsvp_approved_reminder_days"><?php esc_html_e( 'Set the number of days before reminder emails will be sent for approved bookings (counting from the start date of the event). If you want to send out multiple reminders, seperate the days here by commas. Leave empty for no reminder emails.', 'events-made-easy' ); ?></label>
     </p>
     <p id='p_create_wp_user'>
-        <?php echo eme_ui_checkbox_binary( $event['event_properties']['create_wp_user'], 'eme_prop_create_wp_user', __( 'Create WP user after succesful booking', 'events-made-easy' ) ); ?>
+        <?php echo eme_ui_checkbox_binary( $event['event_properties']['create_wp_user'], 'eme_prop_create_wp_user', __( 'Create WP user after succesful booking', 'events-made-easy' ) ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_checkbox_binary() ?>
         <span class="eme_smaller"><br><?php esc_html_e( 'This will create a WP user after the booking is completed, as if the person registered in WP itself. This will only create a user if the booker was not logged in and the email is not yet taken by another WP user.', 'events-made-easy' ); ?></span>
     </p>
     <p id='p_email_only_once'>
-        <?php echo eme_ui_checkbox_binary( $event['event_properties']['email_only_once'], 'eme_prop_email_only_once', __( 'Allow only 1 booking per unique email address', 'events-made-easy' ) ); ?>
+        <?php echo eme_ui_checkbox_binary( $event['event_properties']['email_only_once'], 'eme_prop_email_only_once', __( 'Allow only 1 booking per unique email address', 'events-made-easy' ) ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_checkbox_binary() ?>
     </p>
     <p id='p_person_only_once'>
-        <?php echo eme_ui_checkbox_binary( $event['event_properties']['person_only_once'], 'eme_prop_person_only_once', __( 'Allow only 1 booking per person (combo email/last name/first name)', 'events-made-easy' ) ); ?>
+        <?php echo eme_ui_checkbox_binary( $event['event_properties']['person_only_once'], 'eme_prop_person_only_once', __( 'Allow only 1 booking per person (combo email/last name/first name)', 'events-made-easy' ) ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_checkbox_binary() ?>
     </p>
     <table class="eme_event_admin_table">
     <tr id='row_seats'>
@@ -8807,7 +8807,7 @@ function eme_meta_box_div_event_rsvp( $event, $pdf_templates_array ) {
     </tr>
     <tr id='row_check_free_waiting'>
         <td><label for='eme_prop_check_free_waiting'><?php esc_html_e( 'Check waitinglist when seats become available', 'events-made-easy' ); ?></label></td>
-        <td><?php echo eme_ui_checkbox_binary( $event['event_properties']['check_free_waiting'], 'eme_prop_check_free_waiting' ); ?>
+        <td><?php echo eme_ui_checkbox_binary( $event['event_properties']['check_free_waiting'], 'eme_prop_check_free_waiting' ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_checkbox_binary() ?>
             <span class="eme_smaller"><br><?php esc_html_e( 'Automatically take a booking from the waiting list when seats become available again', 'events-made-easy' ); ?></span></td>
     </tr>
     <tr id='row_max_allowed'>
@@ -8820,30 +8820,30 @@ function eme_meta_box_div_event_rsvp( $event, $pdf_templates_array ) {
     </tr>
     <tr id='row_take_attendance'>
         <td><label for='eme_prop_take_attendance'><?php esc_html_e( 'Attendance-only event?', 'events-made-easy' ); ?></label></td>
-        <td><?php echo eme_ui_checkbox_binary( $event['event_properties']['take_attendance'], 'eme_prop_take_attendance', __( 'Only take attendance (0 or 1 seat) for this event', 'events-made-easy' ) ); ?>
+        <td><?php echo eme_ui_checkbox_binary( $event['event_properties']['take_attendance'], 'eme_prop_take_attendance', __( 'Only take attendance (0 or 1 seat) for this event', 'events-made-easy' ) ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_checkbox_binary() ?>
             <span class="eme_smaller"><br><?php esc_html_e( 'If this option is set and the setting "Min number of seats to book" is set to 0, then the field to choose the number of seats to book will be turned into a checkbox.', 'events-made-easy' ); ?></span><br>
             <span class="eme_smaller"><br><?php esc_html_e( 'If this option is set and the setting "Min number of seats to book" is set to a value greater than 0, then the field to choose the number of seats to book will be hidden and the number of seats booked will be forced to 1.', 'events-made-easy' ); ?></span>
         </td>
     </tr>
     <tr id='p_wp_member_required'>
         <td><label for='registration_wp_users_only'><?php esc_html_e( 'Require WP membership for booking', 'events-made-easy' ); ?></label></td>
-        <td><?php echo eme_ui_checkbox_binary($event['registration_wp_users_only'], 'registration_wp_users_only'); ?>
+        <td><?php echo eme_ui_checkbox_binary($event['registration_wp_users_only'], 'registration_wp_users_only'); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_checkbox_binary() ?>
         <span class="eme_smaller"><br><?php esc_html_e( "This will only show the booking form for logged in users and prefill the form with the personal data from their WordPress profile. That data can't be changed in the form then, so if you don't want this, you can deactivate this option and use #_ADDBOOKINGFORM_IF_LOGGED_IN to show the form to logged in users only.", 'events-made-easy' ); ?></span>
         </td>
     </tr>
     <tr id='row_require_eme_group'>
         <td><label for='eme_prop_rsvp_required_group_ids'><?php esc_html_e( 'Require EME groups', 'events-made-easy' ); ?></label></td>
-        <td><?php echo eme_ui_multiselect_key_value( $event['event_properties']['rsvp_required_group_ids'], 'eme_prop_rsvp_required_group_ids', eme_get_groups(), 'group_id', 'name', 5, '', 0, 'eme_snapselect', 'data-placeholder="' . esc_attr__( 'Select one or more groups', 'events-made-easy' ) . '"' ); ?><p class='eme_smaller'><?php esc_html_e( 'Require logged-in user to be in of one of the selected EME groups in order to be able to book for this event.', 'events-made-easy' ); ?></p>
+        <td><?php echo eme_ui_multiselect_key_value( $event['event_properties']['rsvp_required_group_ids'], 'eme_prop_rsvp_required_group_ids', eme_get_groups(), 'group_id', 'name', 5, '', 0, 'eme_snapselect', 'data-placeholder="' . esc_attr__( 'Select one or more groups', 'events-made-easy' ) . '"' ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_multiselect_key_value() ?><p class='eme_smaller'><?php esc_html_e( 'Require logged-in user to be in of one of the selected EME groups in order to be able to book for this event.', 'events-made-easy' ); ?></p>
         </td>
     </tr>
     <tr id='row_require_eme_memberships'>
         <td><label for='eme_prop_rsvp_required_membership_ids'><?php esc_html_e( 'Require EME membership', 'events-made-easy' ); ?></label></td>
-        <td><?php echo eme_ui_multiselect_key_value( $event['event_properties']['rsvp_required_membership_ids'], 'eme_prop_rsvp_required_membership_ids', eme_get_memberships(), 'membership_id', 'name', 5, '', 0, 'eme_snapselect', '" data-placeholder="' . esc_attr__( 'Select one or more memberships', 'events-made-easy' ) . '"' ); ?><p class='eme_smaller'><?php esc_html_e( 'Require logged-in user to be a member of one of the selected EME memberships in order to be able to book for this event.', 'events-made-easy' ); ?></p>
+        <td><?php echo eme_ui_multiselect_key_value( $event['event_properties']['rsvp_required_membership_ids'], 'eme_prop_rsvp_required_membership_ids', eme_get_memberships(), 'membership_id', 'name', 5, '', 0, 'eme_snapselect', '" data-placeholder="' . esc_attr__( 'Select one or more memberships', 'events-made-easy' ) . '"' ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_multiselect_key_value() ?><p class='eme_smaller'><?php esc_html_e( 'Require logged-in user to be a member of one of the selected EME memberships in order to be able to book for this event.', 'events-made-easy' ); ?></p>
         </td>
     </tr>
     <tr id='row_addpersontogroup'>
         <td><label for='eme_prop_rsvp_addpersontogroup'><?php esc_html_e( 'Group to add people to', 'events-made-easy' ); ?></label></td>
-        <td><?php echo eme_ui_multiselect_key_value( $event['event_properties']['rsvp_addpersontogroup'], 'eme_prop_rsvp_addpersontogroup', eme_get_static_groups(), 'group_id', 'name', 5, '', 0, 'eme_snapselect', 'data-placeholder="' . esc_attr__( 'Select one or more groups', 'events-made-easy' ) . '"' ); ?><p class="eme_smaller"><?php esc_html_e( 'The group you want people to automatically become a member of when they subscribe.', 'events-made-easy' ); ?></p></td>
+        <td><?php echo eme_ui_multiselect_key_value( $event['event_properties']['rsvp_addpersontogroup'], 'eme_prop_rsvp_addpersontogroup', eme_get_static_groups(), 'group_id', 'name', 5, '', 0, 'eme_snapselect', 'data-placeholder="' . esc_attr__( 'Select one or more groups', 'events-made-easy' ) . '"' ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_multiselect_key_value() ?><p class="eme_smaller"><?php esc_html_e( 'The group you want people to automatically become a member of when they subscribe.', 'events-made-easy' ); ?></p></td>
     </tr>
     <tr id='row_rsvppassword'>
         <td><label for='eme_prop_rsvp_password'><?php esc_html_e( 'RSVP Password', 'events-made-easy' ); ?></label></td>
@@ -8851,7 +8851,7 @@ function eme_meta_box_div_event_rsvp( $event, $pdf_templates_array ) {
     </tr>
     <tr id='row_inviteonly'>
         <td><label for='eme_prop_invite_only'><?php esc_html_e( 'Invite-only event?', 'events-made-easy' ); ?></label></td>
-        <td><?php echo eme_ui_checkbox_binary( $event['event_properties']['invite_only'], 'eme_prop_invite_only', __( 'Require an invitation', 'events-made-easy' ) ); ?>
+        <td><?php echo eme_ui_checkbox_binary( $event['event_properties']['invite_only'], 'eme_prop_invite_only', __( 'Require an invitation', 'events-made-easy' ) ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_checkbox_binary() ?>
             <span class="eme_smaller"><br><?php esc_html_e( 'Allow only bookings done if someone visits the event via the invite url generated by #_INVITEURL.', 'events-made-easy' ); ?></span>
         </td>
     </tr>
@@ -9124,7 +9124,7 @@ function eme_general_head() {
         }
         // I don't know if the canonical rel-link is needed, but since WP adds it by default ...
         $canon_url = eme_event_url( $event );
-        echo "<link rel=\"canonical\" href=\"$canon_url\">\n";
+        echo '<link rel="canonical" href="' . esc_url( $canon_url ) . '">' . "\n";
         $extra_headers_format = trim( get_option( 'eme_event_html_headers_format' ) );
         $extra_headers        = eme_extra_event_headers( $event );
         if ( eme_is_empty_string( $extra_headers_format ) ) {
@@ -9149,7 +9149,7 @@ function eme_general_head() {
             return;
         }
         $canon_url = eme_location_url( $location );
-        echo "<link rel=\"canonical\" href=\"$canon_url\">\n";
+        echo '<link rel="canonical" href="' . esc_url( $canon_url ) . '">' . "\n";
         $extra_headers_format = trim( get_option( 'eme_location_html_headers_format' ) );
         if ( ! eme_is_empty_string( $extra_headers_format ) ) {
             # we allow js in the header, so not too much escaping here

--- a/eme-locations.php
+++ b/eme-locations.php
@@ -876,7 +876,7 @@ function eme_locations_table( $message = '' ) {
         echo '<input type="search" name="search_customfields" id="search_customfields" placeholder="' . esc_attr__( 'Custom field value to search', 'events-made-easy' ) . '" size=20>';
         $label = __( 'Custom fields to filter on', 'events-made-easy' );
         $extra_attributes = 'aria-label="' . eme_esc_html( $label ) . '" data-placeholder="' . eme_esc_html( $label ) . '"';
-        echo eme_ui_multiselect_key_value( '', 'search_customfieldids', $formfields_searchable, 'field_id', 'field_name', 5, '', 0, 'eme_snapselect', $extra_attributes, 1 );
+        echo eme_ui_multiselect_key_value( '', 'search_customfieldids', $formfields_searchable, 'field_id', 'field_name', 5, '', 0, 'eme_snapselect', $extra_attributes, 1 ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_multiselect_key_value()
     }
 ?>
     <button id="LocationsLoadRecordsButton" class="button-secondary action"><?php esc_html_e( 'Filter location', 'events-made-easy' ); ?></button>

--- a/eme-mailer.php
+++ b/eme-mailer.php
@@ -2769,7 +2769,7 @@ function eme_emails_page() {
     echo $label; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- already escaped at assignment
 ?>
         </td>
-        <td><?php echo eme_ui_multiselect( $event_ids, 'event_ids', $myevents, 5, '', 0, 'eme_snapselect_events_class', $aria_label ); ?>
+        <td><?php echo eme_ui_multiselect( $event_ids, 'event_ids', $myevents, 5, '', 0, 'eme_snapselect_events_class', $aria_label ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_multiselect() ?>
         <br><label><input id="eventsearch_all" name='eventsearch_all' value='1' type='checkbox'> <?php esc_html_e( 'Check this box to search through all events and not just future ones.', 'events-made-easy' ); ?> </label>
             <p class='eme_smaller'><?php esc_html_e( 'Remark: if you select multiple events, a mailing will be created for each selected event', 'events-made-easy' ); ?></p>
         </td>
@@ -2822,7 +2822,7 @@ function eme_emails_page() {
     echo $label; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- already escaped at assignment
 ?>
         </td>
-        <td><?php echo eme_ui_multiselect( $person_ids, 'eme_eventmail_send_persons', $mygroups, 5, '', 0, 'eme_snapselect_people_class', $aria_label ); ?></td>
+        <td><?php echo eme_ui_multiselect( $person_ids, 'eme_eventmail_send_persons', $mygroups, 5, '', 0, 'eme_snapselect_people_class', $aria_label ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_multiselect() ?></td>
         </tr>
         <tr id="eme_groups_row">
         <td class="eme-wsnobreak">
@@ -2832,7 +2832,7 @@ function eme_emails_page() {
     echo $label; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- already escaped at assignment
 ?>
         </td>
-        <td><?php echo eme_ui_multiselect_key_value( $persongroup_ids, 'eme_eventmail_send_groups', $peoplegroups, 'group_id', 'name', 5, '', 0, 'eme_snapselect', $extra_attributes ); ?></td>
+        <td><?php echo eme_ui_multiselect_key_value( $persongroup_ids, 'eme_eventmail_send_groups', $peoplegroups, 'group_id', 'name', 5, '', 0, 'eme_snapselect', $extra_attributes ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_multiselect_key_value() ?></td>
         </tr>
     <tr id="eme_members_row1"><td class="eme-wsnobreak">
 <?php
@@ -2841,7 +2841,7 @@ function eme_emails_page() {
     echo $label; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- already escaped at assignment
 ?>
     </td>
-    <td><?php echo eme_ui_multiselect( $member_ids, 'eme_eventmail_send_members', $mymembergroups, 5, '', 0, 'eme_snapselect_members_class', $aria_label ); ?></td></tr>
+    <td><?php echo eme_ui_multiselect( $member_ids, 'eme_eventmail_send_members', $mymembergroups, 5, '', 0, 'eme_snapselect_members_class', $aria_label ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_multiselect() ?></td></tr>
     <tr id="eme_members_row2"><td class="eme-wsnobreak">
 <?php
     $label      = eme_esc_html( 'Send to a number of member groups', 'events-made-easy' );
@@ -2850,7 +2850,7 @@ function eme_emails_page() {
     echo $label; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- already escaped at assignment
 ?>
     </td>
-    <td><?php echo eme_ui_multiselect_key_value( $membergroup_ids, 'eme_eventmail_send_membergroups', $membergroups, 'group_id', 'name', 5, '', 0, 'eme_snapselect', $extra_attributes ); ?></td></tr>
+    <td><?php echo eme_ui_multiselect_key_value( $membergroup_ids, 'eme_eventmail_send_membergroups', $membergroups, 'group_id', 'name', 5, '', 0, 'eme_snapselect', $extra_attributes ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_multiselect_key_value() ?></td></tr>
     <tr id="eme_members_row3"><td class="eme-wsnobreak">
 <?php
     $label      = eme_esc_html( 'Send to active members belonging to', 'events-made-easy' );
@@ -2859,7 +2859,7 @@ function eme_emails_page() {
     echo $label; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- already escaped at assignment
 ?>
     </td>
-    <td><?php echo eme_ui_multiselect_key_value( $membership_ids, 'eme_eventmail_send_memberships', $memberships, 'membership_id', 'name', 5, '', 0, 'eme_snapselect', $extra_attributes ); ?></td></tr>
+    <td><?php echo eme_ui_multiselect_key_value( $membership_ids, 'eme_eventmail_send_memberships', $memberships, 'membership_id', 'name', 5, '', 0, 'eme_snapselect', $extra_attributes ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_multiselect_key_value() ?></td></tr>
         </table>
         <div class="form-field"><p>
         <b><?php esc_html_e( 'Subject', 'events-made-easy' ); ?></b><br>
@@ -2994,7 +2994,7 @@ function eme_emails_page() {
         echo $label; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- already escaped at assignment
 ?>
         </td>
-                <td><?php echo eme_ui_multiselect( $person_ids, 'eme_genericmail_send_persons', $mygroups, 5, '', 0, 'eme_snapselect_people_class', $aria_label ); ?></td></tr>
+                <td><?php echo eme_ui_multiselect( $person_ids, 'eme_genericmail_send_persons', $mygroups, 5, '', 0, 'eme_snapselect_people_class', $aria_label ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_multiselect() ?></td></tr>
         <tr><td class="eme-wsnobreak">
 <?php
         $label      = eme_esc_html( 'Send to a number of groups', 'events-made-easy' );
@@ -3003,7 +3003,7 @@ function eme_emails_page() {
         echo $label; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- already escaped at assignment
 ?>
         </td>
-        <td><?php echo eme_ui_multiselect_key_value( $persongroup_ids, 'eme_genericmail_send_peoplegroups', $peoplegroups, 'group_id', 'name', 5, '', 0, 'eme_snapselect', $extra_attributes ); ?></td></tr>
+        <td><?php echo eme_ui_multiselect_key_value( $persongroup_ids, 'eme_genericmail_send_peoplegroups', $peoplegroups, 'group_id', 'name', 5, '', 0, 'eme_snapselect', $extra_attributes ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_multiselect_key_value() ?></td></tr>
         <tr><td class="eme-wsnobreak">
 <?php
         $label      = eme_esc_html( 'Send to a number of members', 'events-made-easy' );
@@ -3011,7 +3011,7 @@ function eme_emails_page() {
         echo $label; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- already escaped at assignment
 ?>
         </td>
-        <td><?php echo eme_ui_multiselect( $member_ids, 'eme_send_members', $mymembergroups, 5, '', 0, 'eme_snapselect_members_class', $aria_label ); ?></td></tr>
+        <td><?php echo eme_ui_multiselect( $member_ids, 'eme_send_members', $mymembergroups, 5, '', 0, 'eme_snapselect_members_class', $aria_label ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_multiselect() ?></td></tr>
         <tr><td class="eme-wsnobreak">
 <?php
         $label      = eme_esc_html( 'Send to a number of member groups', 'events-made-easy' );
@@ -3020,7 +3020,7 @@ function eme_emails_page() {
         echo $label; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- already escaped at assignment
 ?>
         </td>
-        <td><?php echo eme_ui_multiselect_key_value( $membergroup_ids, 'eme_genericmail_send_membergroups', $membergroups, 'group_id', 'name', 5, '', 0, 'eme_snapselect', $extra_attributes ); ?></td></tr>
+        <td><?php echo eme_ui_multiselect_key_value( $membergroup_ids, 'eme_genericmail_send_membergroups', $membergroups, 'group_id', 'name', 5, '', 0, 'eme_snapselect', $extra_attributes ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_multiselect_key_value() ?></td></tr>
         <tr><td class="eme-wsnobreak">
 <?php
         $label      = eme_esc_html( 'Send to active members belonging to', 'events-made-easy' );
@@ -3029,7 +3029,7 @@ function eme_emails_page() {
         echo $label; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- already escaped at assignment
 ?>
         </td>
-        <td><?php echo eme_ui_multiselect_key_value( $membership_ids, 'eme_send_memberships', $memberships, 'membership_id', 'name', 5, '', 0, 'eme_snapselect', $extra_attributes ); ?></td></tr>
+        <td><?php echo eme_ui_multiselect_key_value( $membership_ids, 'eme_send_memberships', $memberships, 'membership_id', 'name', 5, '', 0, 'eme_snapselect', $extra_attributes ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_multiselect_key_value() ?></td></tr>
         </table>
         </div>
         </div>

--- a/eme-members.php
+++ b/eme-members.php
@@ -2173,7 +2173,7 @@ function eme_meta_box_div_membershipdetails( $membership, $is_new_membership ) {
     </tr>
     <tr>
     <td><label for='properties[addpersontogroup]'><?php esc_html_e( 'Group to add people to', 'events-made-easy' ); ?></label></td>
-    <td><?php echo eme_ui_multiselect_key_value( $membership['properties']['addpersontogroup'], 'properties[addpersontogroup]', eme_get_static_groups(), 'group_id', 'name', 5, '', 0, 'eme_snapselect' ); ?><br><p class='eme_smaller'><?php esc_html_e( 'The group you want people to automatically become a member of when they subscribe.', 'events-made-easy' ); ?></p></td>
+    <td><?php echo eme_ui_multiselect_key_value( $membership['properties']['addpersontogroup'], 'properties[addpersontogroup]', eme_get_static_groups(), 'group_id', 'name', 5, '', 0, 'eme_snapselect' ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_multiselect_key_value() ?><br><p class='eme_smaller'><?php esc_html_e( 'The group you want people to automatically become a member of when they subscribe.', 'events-made-easy' ); ?></p></td>
     </tr>
     <tr>
     <td><label for='properties[member_template_id]'><?php esc_html_e( 'Membership card PDF template', 'events-made-easy' ); ?></label></td>
@@ -2187,7 +2187,7 @@ function eme_meta_box_div_membershipdetails( $membership, $is_new_membership ) {
 <?php
     esc_html_e( 'If no payment method is selected, the "Member Added Message" will be shown. Otherwise the "Member Added Message" will be shown and after some seconds the user gets redirected to the payment page (see the generic EME settings on the redirection timeout and more payment settings).', 'events-made-easy' );
     echo '<br>';
-    echo eme_ui_multiselect( $membership['properties']['payment_gateways'], eme_get_field_name('properties','payment_gateways'), eme_configured_pgs_descriptions(), 5, '', 0, 'eme_snapselect' );
+    echo eme_ui_multiselect( $membership['properties']['payment_gateways'], eme_get_field_name('properties','payment_gateways'), eme_configured_pgs_descriptions(), 5, '', 0, 'eme_snapselect' ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_multiselect()
 
     $configured_pgs = eme_get_configured_pgs();
     if ( empty( $configured_pgs ) ) {
@@ -2217,7 +2217,7 @@ function eme_meta_box_div_membershipdetails( $membership, $is_new_membership ) {
     </tr>
     <tr id="tr_skippaymentoptions">
     <td><label for="properties[skippaymentoptions]"><?php esc_html_e( 'Skip payment methods after registration:', 'events-made-easy' ); ?></label></td>
-    <td><?php echo eme_ui_checkbox_binary( $membership['properties']['skippaymentoptions'], 'properties[skippaymentoptions]', __( 'Skip payment methods', 'events-made-easy' ) );
+    <td><?php echo eme_ui_checkbox_binary( $membership['properties']['skippaymentoptions'], 'properties[skippaymentoptions]', __( 'Skip payment methods', 'events-made-easy' ) ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_checkbox_binary()
     echo "<br>";
     esc_html_e( 'If you want to skip the possibility to pay immediately after registration, select this option. This might be useful if you for example want to approve unpaid members internally and only then send them the payment link using #_PAYMENT_URL (for example via the Reminder template).', 'events-made-easy' ); ?>
     </td>
@@ -2317,7 +2317,7 @@ function eme_meta_box_div_membershipmailformats( $membership ) {
     if ( ! empty( $pdftemplates ) ) {
         $name  = 'properties[newmember_attach_tmpl_ids]';
         $description = __( 'Optionally add PDF templates as attachments to the mail.', 'events-made-easy' );
-        echo eme_ui_multiselect( $membership['properties']['newmember_attach_tmpl_ids'],$name, $pdftemplates, 3,'', 0, 'eme_snapselect' );
+        echo eme_ui_multiselect( $membership['properties']['newmember_attach_tmpl_ids'],$name, $pdftemplates, 3,'', 0, 'eme_snapselect' ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_multiselect()
         echo '<br>';
         esc_html_e( 'Optionally add PDF templates as attachments to the mail.', 'events-made-easy' );
     } else {
@@ -2461,7 +2461,7 @@ function eme_meta_box_div_membershipmailformats( $membership ) {
     if ( ! empty( $pdftemplates ) ) {
         $name  = 'properties[extended_attach_tmpl_ids]';
         $description = __( 'Optionally add PDF templates as attachments to the mail.', 'events-made-easy' );
-        echo eme_ui_multiselect( $membership['properties']['extended_attach_tmpl_ids'],$name, $pdftemplates, 3,'', 0, 'eme_snapselect' );
+        echo eme_ui_multiselect( $membership['properties']['extended_attach_tmpl_ids'],$name, $pdftemplates, 3,'', 0, 'eme_snapselect' ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_multiselect()
         echo '<br>';
         esc_html_e( 'Optionally add PDF templates as attachments to the mail.', 'events-made-easy' );
     } else {
@@ -2540,7 +2540,7 @@ function eme_meta_box_div_membershipmailformats( $membership ) {
     if ( ! empty( $pdftemplates ) ) {
         $name  = 'properties[paid_attach_tmpl_ids]';
         $description = __( 'Optionally add PDF templates as attachments to the mail.', 'events-made-easy' );
-        echo eme_ui_multiselect( $membership['properties']['paid_attach_tmpl_ids'],$name, $pdftemplates, 3,'', 0, 'eme_snapselect' );
+        echo eme_ui_multiselect( $membership['properties']['paid_attach_tmpl_ids'],$name, $pdftemplates, 3,'', 0, 'eme_snapselect' ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_multiselect()
         echo '<br>';
         esc_html_e( 'Optionally add PDF templates as attachments to the mail.', 'events-made-easy' );
     } else {
@@ -2970,7 +2970,7 @@ function eme_render_members_searchfields( $limit_to_group = 0, $group_to_edit = 
         $value = '';
     }
     $extra_attributes = ' data-placeholder="' . esc_attr__( 'Filter on membership', 'events-made-easy' ) . '"';
-    echo eme_ui_multiselect_key_value( $value, 'search_membershipids', $memberships, 'membership_id', 'name', 5, '', 0, 'eme_snapselect', $extra_attributes, id_prefix: $id_prefix );
+    echo eme_ui_multiselect_key_value( $value, 'search_membershipids', $memberships, 'membership_id', 'name', 5, '', 0, 'eme_snapselect', $extra_attributes, id_prefix: $id_prefix ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_multiselect_key_value()
     if ( $edit_group ) {
         echo '</td></tr><tr><td>' . esc_html__( 'Select member status', 'events-made-easy' ) . '</td><td>';
     }
@@ -2980,7 +2980,7 @@ function eme_render_members_searchfields( $limit_to_group = 0, $group_to_edit = 
         $value = '';
     }
     $extra_attributes = ' data-placeholder="' . esc_attr__( 'Filter on member status', 'events-made-easy' ) . '"';
-    echo eme_ui_multiselect( $value, 'search_memberstatus', $eme_member_status_array, 5, '', 0, 'eme_snapselect', $extra_attributes, id_prefix: $id_prefix );
+    echo eme_ui_multiselect( $value, 'search_memberstatus', $eme_member_status_array, 5, '', 0, 'eme_snapselect', $extra_attributes, id_prefix: $id_prefix ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_multiselect()
     if ( $edit_group ) {
         echo '</td></tr><tr><td>' . esc_html__( 'Filter on person', 'events-made-easy' ) . '</td><td>';
     }
@@ -3024,7 +3024,7 @@ function eme_render_members_searchfields( $limit_to_group = 0, $group_to_edit = 
         }
         $label = __( 'Custom fields to filter on', 'events-made-easy' );
         $extra_attributes = 'aria-label="' . eme_esc_html( $label ) . '" data-placeholder="' . eme_esc_html( $label ) . '"';
-        echo eme_ui_multiselect_key_value( $value, 'search_customfieldids', $formfields_searchable, 'field_id', 'field_name', 5, '', 0, 'eme_snapselect', $extra_attributes, 1, id_prefix: $id_prefix );
+        echo eme_ui_multiselect_key_value( $value, 'search_customfieldids', $formfields_searchable, 'field_id', 'field_name', 5, '', 0, 'eme_snapselect', $extra_attributes, 1, id_prefix: $id_prefix ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_multiselect_key_value()
         if ( $edit_group ) {
             echo '</td></tr><tr><td>' . esc_html__( 'Exact custom field search match', 'events-made-easy' ) . '</td><td>';
         }
@@ -3039,7 +3039,7 @@ function eme_render_members_searchfields( $limit_to_group = 0, $group_to_edit = 
             $label = __( 'Exact?', 'events-made-easy' );
         }
         $title = esc_attr__( 'Exact custom field search match', 'events-made-easy' );
-        echo eme_nobreak_checkbox_binary( $value, 'search_exactmatch', $label, 0, '', "title='$title'");
+        echo eme_nobreak_checkbox_binary( $value, 'search_exactmatch', $label, 0, '', "title='$title'"); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_nobreak_checkbox_binary()
     }
 }
 
@@ -4983,7 +4983,7 @@ function eme_access_meta_box_cb( $post ) {
     foreach ( $all_memberships as $membership ) {
         $memberships_arr[ $membership['membership_id'] ] = $membership['name'];
     }
-    echo eme_ui_checkbox( $selected_membershipids_arr, 'eme_membershipids', $memberships_arr, false, 0 );
+    echo eme_ui_checkbox( $selected_membershipids_arr, 'eme_membershipids', $memberships_arr, false, 0 ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_checkbox()
     echo "<br><label for='eme_drip_counter'>" . esc_html__( 'Allow access after the membership has been active for this many days (drip content):', 'events-made-easy' ) . '</label>&nbsp;';
     echo "<input type='number' id='eme_drip_counter' name='eme_drip_counter' value='$drip_counter'>";
     echo '<br><br>';
@@ -4992,7 +4992,7 @@ function eme_access_meta_box_cb( $post ) {
     foreach ( $all_groups as $group ) {
         $groups_arr[ $group['group_id'] ] = $group['name'];
     }
-    echo eme_ui_checkbox( $selected_groupids_arr, 'eme_groupids', $groups_arr, false, 0 );
+    echo eme_ui_checkbox( $selected_groupids_arr, 'eme_groupids', $groups_arr, false, 0 ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_checkbox()
 
     echo "<br><label for='eme_access_denied'>" . esc_html__( 'Access denied message template', 'events-made-easy' ) . '</label>&nbsp;';
     #echo "<input type='text' name='eme_access_denied' id='eme_access_denied' value='$text'>";

--- a/eme-people.php
+++ b/eme-people.php
@@ -2131,7 +2131,7 @@ function eme_render_people_searchfields( $limit_to_group = 0, $group_to_edit = [
             $value = '';
         }
         $extra_attributes = ' data-placeholder="' . esc_attr__( 'Any group', 'events-made-easy' ) . '"';
-        echo eme_ui_multiselect_key_value( $value, 'search_groups', $groups, 'group_id', 'name', 5, '', 0, 'eme_snapselect', $extra_attributes, id_prefix: $id_prefix );
+        echo eme_ui_multiselect_key_value( $value, 'search_groups', $groups, 'group_id', 'name', 5, '', 0, 'eme_snapselect', $extra_attributes, id_prefix: $id_prefix ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_multiselect_key_value()
     }
 
     if ( $edit_group ) {
@@ -2143,7 +2143,7 @@ function eme_render_people_searchfields( $limit_to_group = 0, $group_to_edit = [
         $value = '';
     }
     $extra_attributes = ' data-placeholder="' . esc_attr__( 'Filter on membership', 'events-made-easy' ) . '"';
-    echo eme_ui_multiselect_key_value( $value, 'search_membershipids', $memberships, 'membership_id', 'name', 5, '', 0, 'eme_snapselect', $extra_attributes, id_prefix: $id_prefix );
+    echo eme_ui_multiselect_key_value( $value, 'search_membershipids', $memberships, 'membership_id', 'name', 5, '', 0, 'eme_snapselect', $extra_attributes, id_prefix: $id_prefix ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_multiselect_key_value()
 
     if ( $edit_group ) {
         echo '</td></tr><tr><td>' . esc_html__( 'Select member status', 'events-made-easy' ) . '</td><td>';
@@ -2154,7 +2154,7 @@ function eme_render_people_searchfields( $limit_to_group = 0, $group_to_edit = [
         $value = '';
     }
     $extra_attributes = ' data-placeholder="' . esc_attr__( 'Filter on member status', 'events-made-easy' ) . '"';
-    echo eme_ui_multiselect( $value, 'search_memberstatus', $eme_member_status_array, 5, '', 0, 'eme_snapselect', $extra_attributes, id_prefix: $id_prefix );
+    echo eme_ui_multiselect( $value, 'search_memberstatus', $eme_member_status_array, 5, '', 0, 'eme_snapselect', $extra_attributes, id_prefix: $id_prefix ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_multiselect()
 
     $formfields_searchable = eme_get_searchable_formfields( 'people' );
     if ( ! empty( $formfields_searchable ) ) {
@@ -2178,7 +2178,7 @@ function eme_render_people_searchfields( $limit_to_group = 0, $group_to_edit = [
         }
         $label = __( 'Custom fields to filter on', 'events-made-easy' );
         $extra_attributes = 'aria-label="' . eme_esc_html( $label ) . '" data-placeholder="' . eme_esc_html( $label ) . '"';
-        echo eme_ui_multiselect_key_value( $value, 'search_customfieldids', $formfields_searchable, 'field_id', 'field_name', 5, '', 0, 'eme_snapselect', $extra_attributes, 1, id_prefix: $id_prefix );
+        echo eme_ui_multiselect_key_value( $value, 'search_customfieldids', $formfields_searchable, 'field_id', 'field_name', 5, '', 0, 'eme_snapselect', $extra_attributes, 1, id_prefix: $id_prefix ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_multiselect_key_value()
         if ( $edit_group ) {
             echo '</td></tr><tr><td>' . esc_html__( 'Exact custom field search match', 'events-made-easy' ) . '</td><td>';
         }
@@ -2193,7 +2193,7 @@ function eme_render_people_searchfields( $limit_to_group = 0, $group_to_edit = [
             $label = __( 'Exact?', 'events-made-easy' );
         }
         $title = esc_attr__( 'Exact custom field search match', 'events-made-easy' );
-        echo eme_nobreak_checkbox_binary( $value, 'search_exactmatch', $label, 0, '', "title='$title'");
+        echo eme_nobreak_checkbox_binary( $value, 'search_exactmatch', $label, 0, '', "title='$title'"); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_nobreak_checkbox_binary()
     }
 }
 
@@ -2641,7 +2641,7 @@ function eme_person_edit_layout( $person_id = 0, $message = '' ) {
         <td><label for="groups"><?php esc_html_e( 'Groups', 'events-made-easy' ); ?></label></td>
         <td colspan=2><?php 
             $extra_attributes = ' data-placeholder="' . esc_attr__( 'Select one or more groups', 'events-made-easy' ) . '"';
-            echo eme_ui_multiselect_key_value( $persongroup_ids, 'groups', $groups, 'group_id', 'name', 5, '', 0, 'dyngroups eme_snapselect', $extra_attributes );
+            echo eme_ui_multiselect_key_value( $persongroup_ids, 'groups', $groups, 'group_id', 'name', 5, '', 0, 'dyngroups eme_snapselect', $extra_attributes ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_multiselect_key_value()
             ?><br>
         <?php esc_html_e( "Don't forget that you can define custom fields with purpose 'People' that will allow extra info based on the group the person is in.", 'events-made-easy' ); ?>
         </td>
@@ -2809,7 +2809,7 @@ function eme_group_edit_layout( $group_id = 0, $message = '', $group_type = 'sta
         </tr>
         <tr>
         <td><label for="People"><?php esc_html_e( 'People', 'events-made-easy' ); ?></label></td>
-        <td><?php echo eme_ui_multiselect( $grouppersons, 'persons', $mygroups, 5, '', 1, 'eme_snapselect_people_class' ); ?></td>
+        <td><?php echo eme_ui_multiselect( $grouppersons, 'persons', $mygroups, 5, '', 1, 'eme_snapselect_people_class' ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_multiselect() ?></td>
         </tr>
 <?php
             } elseif ( $group['type'] == 'dynamic_people' ) {

--- a/eme-rsvp.php
+++ b/eme-rsvp.php
@@ -5410,7 +5410,7 @@ function eme_registration_seats_form_table( $pending = 0 ) {
 <?php
     esc_html_e( 'Partial payment amount', 'events-made-easy' );
     $label = eme_esc_html('Partial payment amount', 'events-made-easy' );
-    echo eme_ui_number( 0, 'partial_amount', 0, '', 'aria-label="' . $label . '"' );
+    echo eme_ui_number( 0, 'partial_amount', 0, '', 'aria-label="' . $label . '"' ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_number()
 ?>
     </span>
     <span id="span_rsvpmailtemplate" class="eme-hidden">

--- a/eme-tasks.php
+++ b/eme-tasks.php
@@ -1009,14 +1009,12 @@ function eme_meta_box_div_event_task_settings( $event ) {
         <p id='p_task_addpersontogroup'>
             <label for='eme_prop_task_addpersontogroup'><?php esc_html_e( 'Group to add people to', 'events-made-easy' ); ?></label></td>
             <td><?php
-			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted UI helper HTML
-			echo eme_ui_multiselect_key_value( $event['event_properties']['task_addpersontogroup'], 'eme_prop_task_addpersontogroup', eme_get_static_groups(), 'group_id', 'name', 5, '', 0, 'eme_snapselect', $extra_attributes ); ?><p class="eme_smaller"><?php esc_html_e( 'The group you want people to automatically become a member of when they subscribe.', 'events-made-easy' ); ?></p>
+			echo eme_ui_multiselect_key_value( $event['event_properties']['task_addpersontogroup'], 'eme_prop_task_addpersontogroup', eme_get_static_groups(), 'group_id', 'name', 5, '', 0, 'eme_snapselect', $extra_attributes ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_multiselect_key_value() ?><p class="eme_smaller"><?php esc_html_e( 'The group you want people to automatically become a member of when they subscribe.', 'events-made-easy' ); ?></p>
         <p id='p_task_requires_approval'>
             <input id="eme_prop_task_requires_approval" name='eme_prop_task_requires_approval' value='1' type='checkbox' <?php checked( $event['event_properties']['task_requires_approval'] ); ?>>
             <label for="eme_prop_task_requires_approval"><?php esc_html_e( 'Require approval for task signups?', 'events-made-easy' ); ?></label>
             <br><?php
-			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted UI helper HTML
-			echo eme_ui_checkbox_binary( $event['event_properties']['ignore_pending_tasksignups'], 'eme_prop_ignore_pending_tasksignups', __( 'Consider pending (unapproved) task signups as available for new signups', 'events-made-easy' ) ); ?>
+			echo eme_ui_checkbox_binary( $event['event_properties']['ignore_pending_tasksignups'], 'eme_prop_ignore_pending_tasksignups', __( 'Consider pending (unapproved) task signups as available for new signups', 'events-made-easy' ) ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_checkbox_binary() ?>
         </p>
 
         <p id='p_task_only_one_signup_pp'>


### PR DESCRIPTION
## Summary

Three improvements for PHPCS compliance:

1. **~59 `eme_ui_*()` calls** annotated with `phpcs:ignore` — companion to PR #940
   which covered `eme_ui_select*()`. Covers `eme_ui_multiselect()`, `eme_ui_multiselect_key_value()`,
   `eme_ui_checkbox_binary()`, `eme_ui_checkbox()`, `eme_ui_number()`, and
   `eme_nobreak_checkbox_binary()`
2. **11 `wp_nonce_field()` calls** annotated with `phpcs:ignore` — called with
   `(false, false)` so they return instead of echo, PHPCS doesn't recognize them
3. **2 canonical URL fixes** — `eme_event_url()` and `eme_location_url()` don't always
   call `esc_url()` internally (only for external URLs), so the canonical `<link>` tags
   now properly wrap with `esc_url()`

## Why this is safe

- All `eme_ui_*()` functions (eme-ui-helpers.php) escape values with `eme_esc_html()`
  and sanitize names with `wp_strip_all_tags()`. They return fully constructed HTML.
- `wp_nonce_field()` is a WordPress core function that returns safe HTML hidden inputs.
- The canonical URL fix adds proper `esc_url()` escaping that was missing.

## What's NOT in this PR

Variable assignments like `$replacement = eme_ui_checkbox_binary(...)` don't trigger PHPCS
and were not annotated. Only direct `echo` output statements were modified.

## Test plan

- [x] php -l syntax check on all 10 modified files
- [x] Runtime tests: 73/76 passed (3 pre-existing CSRF)
- [x] code-checks.sh: eme_ui_* metric → 0, wp_nonce_field metric → 0
- [x] Visual check of admin pages with multiselect/checkbox elements
- [x] Verify canonical URLs render correctly on event/location pages