### PR TITLE
Use esc_attr for values in HTML attribute contexts

### DIFF
--- a/eme-discounts.php
+++ b/eme-discounts.php
@@ -464,11 +464,11 @@ function eme_manage_discounts_layout( $message = '' ) {
 	</span>
 	<span id="span_newvalidfrom" class="eme-hidden">
 	<input id="new_validfrom" type="hidden" name="new_validfrom" value="">
-	<input id="eme_localized_new_validfrom" type="text" name="eme_localized_new_validfrom" value="" readonly="readonly" placeholder="<?php esc_html_e( 'Select new "valid from" date/time', 'events-made-easy' ); ?>" size=15 data-date='' data-alt-field='new_validfrom' class='eme_formfield_fdatetime'>
+	<input id="eme_localized_new_validfrom" type="text" name="eme_localized_new_validfrom" value="" readonly="readonly" placeholder="<?php esc_attr_e( 'Select new "valid from" date/time', 'events-made-easy' ); ?>" size=15 data-date='' data-alt-field='new_validfrom' class='eme_formfield_fdatetime'>
 	</span>
 	<span id="span_newvalidto" class="eme-hidden">
 	<input id="new_validto" type="hidden" name="new_validto" value="">
-	<input id="eme_localized_new_validto" type="text" name="eme_localized_new_validto" value="" readonly="readonly" placeholder="<?php esc_html_e( 'Select new "valid until" date/time', 'events-made-easy' ); ?>" size=15 data-date='' data-alt-field='new_validto' class='eme_formfield_fdatetime'>
+	<input id="eme_localized_new_validto" type="text" name="eme_localized_new_validto" value="" readonly="readonly" placeholder="<?php esc_attr_e( 'Select new "valid until" date/time', 'events-made-easy' ); ?>" size=15 data-date='' data-alt-field='new_validto' class='eme_formfield_fdatetime'>
 	</span>
 	<button id="DiscountsActionsButton" class="button-secondary action"><?php esc_html_e( 'Apply', 'events-made-easy' ); ?></button>
     <?php eme_rightclickhint(); ?>

--- a/eme-formfields.php
+++ b/eme-formfields.php
@@ -229,7 +229,7 @@ function eme_formfields_table_layout( $message = '' ) {
     <form action="#" method="post">
     <?php echo eme_ui_select( '', 'search_type', $field_types, __( 'Any', 'events-made-easy' ) ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select() ?>
     <?php echo eme_ui_select( '', 'search_purpose', $field_purposes, __( 'Any', 'events-made-easy' ) ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select() ?>
-    <input type="search" name="search_name" id="search_name" placeholder="<?php esc_html_e( 'Field name', 'events-made-easy' ); ?>" class="eme_searchfilter" size=10>
+    <input type="search" name="search_name" id="search_name" placeholder="<?php esc_attr_e( 'Field name', 'events-made-easy' ); ?>" class="eme_searchfilter" size=10>
     <button id="FormfieldsLoadRecordsButton" class="button-secondary action"><?php esc_html_e( 'Filter fields', 'events-made-easy' ); ?></button>
     </form>
 

--- a/eme-locations.php
+++ b/eme-locations.php
@@ -2671,8 +2671,8 @@ function eme_add_directions_form( $location ) {
         $res .= '<form action="//maps.google.com/maps" method="get" target="_blank" style="text-align:left;">';
         $res .= '<div id="eme_direction_form"><label for="saddr">' . __( 'Your Street Address', 'events-made-easy' ) . '</label><br>';
         $res .= '<input type="text" name="saddr" id="saddr" value="">';
-        $res .= '<input type="hidden" name="daddr" value="' . $location['location_address1'] . ', ' . $location['location_city'] . '">';
-        $res .= '<input type="hidden" name="hl" value="' . $locale_code . '"></div>';
+        $res .= '<input type="hidden" name="daddr" value="' . esc_attr( $location['location_address1'] . ', ' . $location['location_city'] ) . '">';
+        $res .= '<input type="hidden" name="hl" value="' . esc_attr( $locale_code ) . '"></div>';
         $res .= '<input type="submit" value="' . esc_attr__( 'Get Directions', 'events-made-easy' ) . '">';
         $res .= '</form>';
     }

--- a/eme-mailer.php
+++ b/eme-mailer.php
@@ -2943,7 +2943,7 @@ function eme_emails_page() {
         </div>
         <hr>
         <?php esc_html_e( 'Enter a test recipient', 'events-made-easy' ); ?>
-        <select id="send_previeweventmailto_id" name="send_previeweventmailto_id" class="eme_snapselect_people_class" data-placeholder="<?php esc_html_e( 'Select a person', 'events-made-easy' ); ?>" aria-label="chooseperson"></select>
+        <select id="send_previeweventmailto_id" name="send_previeweventmailto_id" class="eme_snapselect_people_class" data-placeholder="<?php esc_attr_e( 'Select a person', 'events-made-easy' ); ?>" aria-label="chooseperson"></select>
         <button id='previeweventmailButton' class="button-primary action"> <?php esc_html_e( 'Send Preview Email', 'events-made-easy' ); ?></button>
         <div id="previeweventmail-result" class="eme-hidden" ></div>
         <hr>
@@ -3124,7 +3124,7 @@ function eme_emails_page() {
         </div>
         <hr>
         <?php esc_html_e( 'Enter a test recipient', 'events-made-easy' ); ?>
-        <select id="send_previewmailto_id" name="send_previewmailto_id" class="eme_snapselect_people_class" data-placeholder="<?php esc_html_e( 'Select a person', 'events-made-easy' ); ?>" aria-label="chooseperson"></select>
+        <select id="send_previewmailto_id" name="send_previewmailto_id" class="eme_snapselect_people_class" data-placeholder="<?php esc_attr_e( 'Select a person', 'events-made-easy' ); ?>" aria-label="chooseperson"></select>
         <button id='previewmailButton' class="button-primary action"> <?php esc_html_e( 'Send Preview Email', 'events-made-easy' ); ?></button>
         <br><?php esc_html_e( 'Small remark: the preview mail will not replace booking or attendee related placeholders.', 'events-made-easy' ); ?>
         <div id="previewmail-result" class="eme-hidden" ></div>
@@ -3159,7 +3159,7 @@ function eme_emails_page() {
     <?php esc_html_e( 'Use the below form to send a test mail', 'events-made-easy' ); ?>
     <form id='send_testmail' name='send_testmail' action="#" method="post" onsubmit="return false;">
     <label for='testmail_to'><?php esc_html_e( 'Enter the recipient', 'events-made-easy' ); ?></label>
-    <input type="email" name="testmail_to" id="testmail_to" value="" placeholder="<?php esc_html_e( 'Enter any valid mail address', 'events-made-easy' ); ?>">
+    <input type="email" name="testmail_to" id="testmail_to" value="" placeholder="<?php esc_attr_e( 'Enter any valid mail address', 'events-made-easy' ); ?>">
     <button id='testmailButton' class="button-primary action"> <?php esc_html_e( 'Send Email', 'events-made-easy' ); ?></button>
     </form>
 </div>

--- a/eme-members.php
+++ b/eme-members.php
@@ -2989,7 +2989,7 @@ function eme_render_members_searchfields( $limit_to_group = 0, $group_to_edit = 
     } else {
         $value = '';
     }
-    echo '<input type="search" value="' . esc_html($value) . '" name="search_person" id="'.$id_prefix.'search_person" placeholder="' . esc_attr__( 'Filter on person', 'events-made-easy' ) . '" class="eme_searchfilter" size=15>';
+    echo '<input type="search" value="' . esc_attr($value) . '" name="search_person" id="'.$id_prefix.'search_person" placeholder="' . esc_attr__( 'Filter on person', 'events-made-easy' ) . '" class="eme_searchfilter" size=15>';
 
     if ( $edit_group ) {
         echo '</td></tr><tr><td>' . esc_html__( 'Filter on member ID', 'events-made-easy' ) . '</td><td>';
@@ -2999,7 +2999,7 @@ function eme_render_members_searchfields( $limit_to_group = 0, $group_to_edit = 
     } else {
         $value = '';
     }
-    echo '<input type="number" value="' . esc_html($value) . '" name="search_memberid" id="'.$id_prefix.'search_memberid" placeholder="' . esc_attr__( 'Filter on member ID', 'events-made-easy' ) . '" class="eme_searchfilter" size=15>';
+    echo '<input type="number" value="' . esc_attr($value) . '" name="search_memberid" id="'.$id_prefix.'search_memberid" placeholder="' . esc_attr__( 'Filter on member ID', 'events-made-easy' ) . '" class="eme_searchfilter" size=15>';
     echo '<input type="search" name="search_paymentid" id="'.$id_prefix.'search_paymentid" placeholder="' . esc_attr__( 'Filter on payment id', 'events-made-easy' ) . '" class="eme_searchfilter">';
     echo '<input type="search" name="search_pg_pid" id="'.$id_prefix.'search_pg_pid" placeholder="' . esc_attr__( 'Filter on payment GW id', 'events-made-easy' ) . '" class="eme_searchfilter" size=15>';
 
@@ -3013,7 +3013,7 @@ function eme_render_members_searchfields( $limit_to_group = 0, $group_to_edit = 
         } else {
             $value = '';
         }
-        echo '<input type="search" value="' . esc_html($value) . '" name="search_customfields" id="search_customfields" placeholder="' . esc_attr__( 'Custom field value to search', 'events-made-easy' ) . '" class="eme_searchfilter" size=20>';
+        echo '<input type="search" value="' . esc_attr($value) . '" name="search_customfields" id="search_customfields" placeholder="' . esc_attr__( 'Custom field value to search', 'events-made-easy' ) . '" class="eme_searchfilter" size=20>';
         if ( $edit_group ) {
             echo '</td></tr><tr><td>' . esc_html__( 'Custom field to search', 'events-made-easy' ) . '</td><td>';
         }
@@ -3325,7 +3325,7 @@ function eme_manage_memberships_layout( $message ) {
     $extrafieldnames      = join( ',', $extrafieldnames_arr );
     $extrafieldsearchable = join( ',', $extrafieldsearchable_arr );
 ?>
-    <div id="MembershipsTableContainer" data-extrafields='<?php echo esc_attr( $extrafields ); ?>' data-extrafieldnames='<?php echo $extrafieldnames; ?>' data-extrafieldsearchable='<?php echo $extrafieldsearchable; ?>'></div>
+    <div id="MembershipsTableContainer" data-extrafields='<?php echo esc_attr( $extrafields ); ?>' data-extrafieldnames='<?php echo esc_attr( $extrafieldnames ); ?>' data-extrafieldsearchable='<?php echo esc_attr( $extrafieldsearchable ); ?>'></div>
     </div>
     </div>
 <?php

--- a/eme-people.php
+++ b/eme-people.php
@@ -2166,7 +2166,7 @@ function eme_render_people_searchfields( $limit_to_group = 0, $group_to_edit = [
         } else {
             $value = '';
         }
-        echo '<input type="search" value="' . esc_attr($value) . '" name="search_customfields" id="'.$id_prefix.'search_customfields" placeholder="' . esc_html__( 'Custom field value to search', 'events-made-easy' ) . '" class="eme_searchfilter" size=20>';
+        echo '<input type="search" value="' . esc_attr($value) . '" name="search_customfields" id="'.$id_prefix.'search_customfields" placeholder="' . esc_attr__( 'Custom field value to search', 'events-made-easy' ) . '" class="eme_searchfilter" size=20>';
 
         if ( $edit_group ) {
             echo '</td></tr><tr><td>' . esc_html__( 'Custom field to search', 'events-made-easy' ) . '</td><td>';
@@ -2536,7 +2536,7 @@ function eme_person_edit_layout( $person_id = 0, $message = '' ) {
     }
 ?>
         <select id='related_person_id' name='related_person_id'
-            data-placeholder="<?php esc_html_e( 'Select a person', 'events-made-easy' ); ?>"
+            data-placeholder="<?php esc_attr_e( 'Select a person', 'events-made-easy' ); ?>"
             data-person-id="<?php echo intval( $person['person_id'] ); ?>"
             class="eme_snapselect_chooserelatedperson">
             <?php echo $preselected_option; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML option element ?>


### PR DESCRIPTION
## Summary

Fix attribute escaping in 6 files — use `esc_attr` instead of `esc_html` for values
inside HTML attributes, and add missing `esc_attr()` for bare variables.

Three types of fixes:

1. **8x `esc_html__()` / `esc_html_e()` → `esc_attr__()` / `esc_attr_e()`** in
   `placeholder` and `data-placeholder` attributes — follow-up to PR #937 which
   covered `__()` in attributes but missed these `esc_html_e()` instances
2. **3x `esc_html($value)` → `esc_attr($value)`** in search input `value=` attributes
   in eme-members.php
3. **3x missing `esc_attr()`** for bare variables in attribute values:
   - `$extrafieldnames` and `$extrafieldsearchable` in MembershipsTableContainer
     `data-*` attributes (eme-members.php) — the only instance not yet fixed after
     liedekef's data-attribute escaping fix in other files
   - `$location['location_address1']`, `$location['location_city']` and `$locale_code`
     in Google Maps direction form hidden inputs (eme-locations.php)

## Changes

| File | Lines | Fix |
|---|---|---|
| eme-people.php | 2169, 2539 | esc_html__ → esc_attr__, esc_html_e → esc_attr_e |
| eme-mailer.php | 2946, 3127, 3162 | esc_html_e → esc_attr_e |
| eme-formfields.php | 232 | esc_html_e → esc_attr_e |
| eme-discounts.php | 467, 471 | esc_html_e → esc_attr_e |
| eme-members.php | 2992, 3002, 3016, 3328 | esc_html → esc_attr, add esc_attr() |
| eme-locations.php | 2674, 2675 | add esc_attr() |

## Test plan

- [x] php -l syntax check: all 6 files clean
- [x] Runtime tests: 73/76 passed (3 pre-existing CSRF)
- [ ] Verify search filters still work on members admin page
- [ ] Verify Google Maps direction form on location pages
- [ ] Verify placeholder text renders correctly on affected admin pages