### PR TITLE
Fix OutputNotEscaped: eme_esc_html() + unescaped __() in output

### DIFF
--- a/eme-actions.php
+++ b/eme-actions.php
@@ -547,7 +547,7 @@ PayPal: <a href="https://www.paypal.com/donate/?business=SMGDS4GLCYWNG&no_recurr
 Github: <a href="https://github.com/sponsors/liedekef">Github sponsoring</a>
     <br><br>
 <?php
-            echo sprintf( '<a href="#" class="eme-dismiss-notice" data-notice="donate" title="%s">%s</a>', esc_attr__("Dismiss",'events-made-easy'), esc_attr__("Dismiss",'events-made-easy') );
+            printf( '<a href="#" class="eme-dismiss-notice" data-notice="donate" title="%s">%s</a>', esc_attr__("Dismiss",'events-made-easy'), esc_attr__("Dismiss",'events-made-easy') );
 ?>
     </div>
 </div>

--- a/eme-attendances.php
+++ b/eme-attendances.php
@@ -150,7 +150,7 @@ function eme_attendances_table_layout( $message = '' ) {
 	<select id="search_type" name="search_type">
 	<?php
 	foreach ( $att_types as $key => $value ) {
-		echo "<option value='" . eme_esc_html( $key ) . "'>" . eme_esc_html( $value ) . '</option>';
+		echo "<option value='" . esc_html( $key ) . "'>" . esc_html( $value ) . '</option>';
 	}
 	?>
 	</select>

--- a/eme-attributes.php
+++ b/eme-attributes.php
@@ -113,9 +113,9 @@ function eme_attributes_form( $eme_array ) {
 							}
 							foreach ( $attributes as $attribute ) {
 								if ( $attribute == $name ) {
-									echo "<option selected='selected'>" . eme_esc_html( $attribute ) . '</option>';
+									echo "<option selected='selected'>" . esc_html( $attribute ) . '</option>';
 								} else {
-									echo '<option>' . eme_esc_html( $attribute ) . '</option>';
+									echo '<option>' . esc_html( $attribute ) . '</option>';
 								}
 							}
 							?>
@@ -123,7 +123,7 @@ function eme_attributes_form( $eme_array ) {
 						<a href="#"><?php esc_html_e( 'Remove', 'events-made-easy' ); ?></a>
 					</td>
 					<td>
-			<textarea rows="2" cols="40" id="eme_attr_<?php echo esc_attr( $count ); ?>_id" name="eme_attr_<?php echo esc_attr( $count ); ?>_name"><?php echo eme_esc_html( $value ); ?></textarea>
+			<textarea rows="2" cols="40" id="eme_attr_<?php echo esc_attr( $count ); ?>_id" name="eme_attr_<?php echo esc_attr( $count ); ?>_name"><?php echo esc_html( $value ); ?></textarea>
 					</td>
 					</tr>
 					<?php
@@ -136,7 +136,7 @@ function eme_attributes_form( $eme_array ) {
 						<select name="eme_attr_<?php echo esc_attr( $count ); ?>_ref">
 							<?php
 							foreach ( $attributes as $attribute ) {
-								echo '<option>' . eme_esc_html( $attribute ) . '</option>';
+								echo '<option>' . esc_html( $attribute ) . '</option>';
 							}
 							?>
 						</select>

--- a/eme-cleanup.php
+++ b/eme-cleanup.php
@@ -424,9 +424,9 @@ function eme_cleanup_form( $message = '', $preview_people = null ) {
 	<?php
 	$eme_queued_count = eme_get_queued_count();
 	if ( $eme_queued_count > 1 ) {
-			echo sprintf( __( 'There are %d messages in the mail queue.', 'events-made-easy' ), $eme_queued_count );
+			printf( esc_html__( 'There are %d messages in the mail queue.', 'events-made-easy' ), intval( $eme_queued_count ) );
 	} elseif ( $eme_queued_count ) {
-			echo sprintf( __( 'There is 1 message in the mail queue.', 'events-made-easy' ), $eme_queued_count );
+			printf( esc_html__( 'There is 1 message in the mail queue.', 'events-made-easy' ), intval( $eme_queued_count ) );
 	} else {
 		esc_html_e( 'There are no messages in the mail queue.', 'events-made-easy' );
 	}

--- a/eme-countries.php
+++ b/eme-countries.php
@@ -358,7 +358,7 @@ function eme_manage_countries_layout( $message = '' ) {
 		<?php esc_html_e( 'If you want, use this to import countries into the database', 'events-made-easy' ); ?>
 	</form>
 	</div>
-	<?php echo sprintf( __( 'See <a href="%s">here</a> for more info on country codes', 'events-made-easy' ), 'https://en.wikipedia.org/wiki/ISO_3166-1' ); ?>
+	<?php printf( wp_kses_post( __( 'See <a href="%s">here</a> for more info on country codes', 'events-made-easy' ) ), esc_url( 'https://en.wikipedia.org/wiki/ISO_3166-1' ) ); ?>
 	<br>
 	<?php esc_html_e( 'The language should correspond to one of the WordPress languages you want to support, or leave it empty as a default or fallback. Some examples are: nl, fr, en, de', 'events-made-easy' ); ?>
 	<br>
@@ -424,7 +424,7 @@ function eme_manage_states_layout( $message = '' ) {
 		<?php esc_html_e( 'If you want, use this to import states into the database', 'events-made-easy' ); ?>
 	</form>
 	</div>
-	<?php echo sprintf( __( 'See <a href="%s">here</a> for more info on state codes', 'events-made-easy' ), 'https://wikipedia.org/wiki/ISO_3166-2' ); ?>
+	<?php printf( wp_kses_post( __( 'See <a href="%s">here</a> for more info on state codes', 'events-made-easy' ) ), esc_url( 'https://wikipedia.org/wiki/ISO_3166-2' ) ); ?>
 	<br>
 	<?php esc_html_e( 'The code should consist of 2 letters. An example would be the code "WA" for "Washington, US"', 'events-made-easy' ); ?>
 	<?php } ?>

--- a/eme-cron.php
+++ b/eme-cron.php
@@ -374,7 +374,7 @@ function eme_cron_form( $message = '' ) {
 <?php
     $eme_queued_count = eme_get_queued_count();
     if ( $eme_queued_count > 1 ) {
-        echo sprintf( __( 'There are %d messages in the mail queue.', 'events-made-easy' ), $eme_queued_count );
+        printf( esc_html__( 'There are %d messages in the mail queue.', 'events-made-easy' ), intval( $eme_queued_count ) );
     } elseif ( $eme_queued_count ) {
         esc_html_e( 'There is 1 message in the mail queue.', 'events-made-easy' );
     } else {
@@ -475,15 +475,15 @@ function eme_cron_form( $message = '' ) {
             if (!empty($eme_cron_queued_schedule)) {
                 $mail_schedule = $schedules[ $eme_cron_queued_schedule ];
                 if ( $eme_cron_queue_count> 0 ) {
-                    echo sprintf( __( '%s there will be a check if new events should be mailed to EME registered people (those will then be queued and send out in batches of %d %s)', 'events-made-easy' ), $new_events_schedule['display'], $eme_cron_queue_count, $mail_schedule['display'] );
+                    printf( esc_html__( '%s there will be a check if new events should be mailed to EME registered people (those will then be queued and send out in batches of %d %s)', 'events-made-easy' ), esc_html( $new_events_schedule['display'] ), intval( $eme_cron_queue_count ), esc_html( $mail_schedule['display'] ) );
                 } else {
-                    echo sprintf( __( '%s there will be a check if new events should be mailed to EME registered people (those will then be queued and send out all at once %s)', 'events-made-easy' ), $new_events_schedule['display'], $mail_schedule['display'] );
+                    printf( esc_html__( '%s there will be a check if new events should be mailed to EME registered people (those will then be queued and send out all at once %s)', 'events-made-easy' ), esc_html( $new_events_schedule['display'] ), esc_html( $mail_schedule['display'] ) );
                 }
             } else {
                 if ( $eme_cron_queue_count> 0 ) {
-                    echo sprintf( __( '%s there will be a check if new events should be mailed to EME registered people (those will then be queued and send out in batches of %d every time the queue is processed via the REST API call)', 'events-made-easy' ), $new_events_schedule['display'], $eme_cron_queue_count );
+                    printf( esc_html__( '%s there will be a check if new events should be mailed to EME registered people (those will then be queued and send out in batches of %d every time the queue is processed via the REST API call)', 'events-made-easy' ), esc_html( $new_events_schedule['display'] ), intval( $eme_cron_queue_count ) );
                 } else {
-                    echo sprintf( __( '%s there will be a check if new events should be mailed to EME registered people (those will then be queued and send out all at once every time the queue is processed via the REST API call)', 'events-made-easy' ), $new_events_schedule['display'], $mail_schedule['display'] );
+                    printf( esc_html__( '%s there will be a check if new events should be mailed to EME registered people (those will then be queued and send out all at once every time the queue is processed via the REST API call)', 'events-made-easy' ), esc_html( $new_events_schedule['display'] ), esc_html( $mail_schedule['display'] ) );
                 }
             }
         }

--- a/eme-discounts.php
+++ b/eme-discounts.php
@@ -852,12 +852,12 @@ function eme_discounts_edit_layout( $discount_id = 0, $message = '' ) {
 		<table class='form-table'>
 		<tr class='form-field'>
 			<th scope='row' style='vertical-align:top'><label for='name'><?php esc_html_e( 'Discount name', 'events-made-easy' ); ?></label></th>
-			<td><input name='name' id='name' required='required' type='text' value='<?php echo eme_esc_html( $discount['name'] ); ?>' size='40'><br>
+			<td><input name='name' id='name' required='required' type='text' value='<?php echo esc_html( $discount['name'] ); ?>' size='40'><br>
 			<?php esc_html_e( 'The name of the discount', 'events-made-easy' ); ?></td>
 		</tr>
 		<tr class='form-field'>
 			<th scope='row' style='vertical-align:top'><label for='description'><?php esc_html_e( 'Description', 'events-made-easy' ); ?></label></th>
-			<td><textarea name='description' id='description' rows='5' ><?php echo eme_esc_html( $discount['description'] ); ?></textarea></td>
+			<td><textarea name='description' id='description' rows='5' ><?php echo esc_html( $discount['description'] ); ?></textarea></td>
 		</tr>
 		<tr class='form-field'>
 			<th scope='row' style='vertical-align:top'><label for='type'><?php esc_html_e( 'Type', 'events-made-easy' ); ?></label></th>
@@ -866,14 +866,14 @@ function eme_discounts_edit_layout( $discount_id = 0, $message = '' ) {
 		</tr>
 		<tr class='form-field'>
 			<th scope='row' style='vertical-align:top'><label for='value'><?php esc_html_e( 'Discount value', 'events-made-easy' ); ?></label></th>
-			<td><input name='value' id='value' type='text' value='<?php echo eme_esc_html( $discount['value'] ); ?>' size='40'>
+			<td><input name='value' id='value' type='text' value='<?php echo esc_html( $discount['value'] ); ?>' size='40'>
 			<br><?php esc_html_e( 'The applied discount value if the correct coupon code is entered (this does not apply to discounts of type "Code")', 'events-made-easy' ); ?>
 			<br><?php esc_html_e( 'For type "Percentage" the value should be >=0 and <=100', 'events-made-easy' ); ?>
 				</td>
 		</tr>
 		<tr class='form-field'>
 			<th scope='row' style='vertical-align:top'><label for='coupon'><?php esc_html_e( 'Coupon code', 'events-made-easy' ); ?></label></th>
-			<td><input name='coupon' id='coupon' type='text' value='<?php echo eme_esc_html( $discount['coupon'] ); ?>' size='40'>
+			<td><input name='coupon' id='coupon' type='text' value='<?php echo esc_html( $discount['coupon'] ); ?>' size='40'>
 			<br><?php esc_html_e( 'The coupon code to enter for the discount to apply (this does not apply to discounts of type "Code")', 'events-made-easy' ); ?>
 			<br><?php esc_html_e( 'If you leave the coupon code empty but set a discount expiration date, you can use this as an "early bird" discount', 'events-made-easy' ); ?>
 			</td>
@@ -948,32 +948,32 @@ function eme_discounts_edit_layout( $discount_id = 0, $message = '' ) {
 		</tr>
 		<tr class='form-field'>
 			<th scope='row' style='vertical-align:top'><label for='maxcount'><?php esc_html_e( 'Maximum usage count', 'events-made-easy' ); ?></label></th>
-			<td><input name='maxcount' id='maxcount' type='text' value='<?php echo eme_esc_html( $discount['maxcount'] ); ?>' size='40'>
+			<td><input name='maxcount' id='maxcount' type='text' value='<?php echo esc_html( $discount['maxcount'] ); ?>' size='40'>
 			<br><?php esc_html_e( 'The maximum number of times this discount can be applied', 'events-made-easy' ); ?>
 			</td>
 		</tr>
 		<tr class='form-field'>
 			<th scope='row' style='vertical-align:top'><label for='maxcount'><?php esc_html_e( 'Maximum usage count per user', 'events-made-easy' ); ?></label></th>
-			<td><input name='properties[maxcount_pp]' id='properties[maxcount_pp]' type='text' value='<?php echo eme_esc_html( $discount['properties']['maxcount_pp'] ); ?>' size='40'>
+			<td><input name='properties[maxcount_pp]' id='properties[maxcount_pp]' type='text' value='<?php echo esc_html( $discount['properties']['maxcount_pp'] ); ?>' size='40'>
 			<br><?php esc_html_e( 'The maximum number of times this discount can be applied per user (this implies the person needs to be logged in). This checks all bookings and members, so it can be heavy on the database (and removed bookings of course impact the count).', 'events-made-easy' ); ?>
 			</td>
 		</tr>
 		<tr class='form-field'>
 			<th scope='row' style='vertical-align:top'><label for='properties[min_seats]'><?php esc_html_e( 'Min #seats booked', 'events-made-easy' ); ?></label></th>
-			<td><input name='properties[min_seats]' id='properties[min_seats]' type='text' value='<?php echo eme_esc_html( $discount['properties']['min_seats'] ); ?>' size='40'>
+			<td><input name='properties[min_seats]' id='properties[min_seats]' type='text' value='<?php echo esc_html( $discount['properties']['min_seats'] ); ?>' size='40'>
 			<br><p class='eme_smaller'><?php esc_html_e( 'The minimum number of seats that need to be booked for the discount to apply. Leave empty (not 0) for no limit.', 'events-made-easy' ); ?></p>
 			</td>
 		</tr>
 		<tr class='form-field'>
 			<th scope='row' style='vertical-align:top'><label for='properties[max_seats]'><?php esc_html_e( 'Max #seats booked', 'events-made-easy' ); ?></label></th>
-			<td><input name='properties[max_seats]' id='properties[max_seats]' type='text' value='<?php echo eme_esc_html( $discount['properties']['max_seats'] ); ?>' size='40'>
+			<td><input name='properties[max_seats]' id='properties[max_seats]' type='text' value='<?php echo esc_html( $discount['properties']['max_seats'] ); ?>' size='40'>
 			<br><p class='eme_smaller'><?php esc_html_e( 'The maximum number of seats that need to be booked for the discount to apply. Leave empty (not 0) for no limit.', 'events-made-easy' ); ?></p>
 			</td>
 		</tr>
 	<?php if ( $discount_id ) { ?>
 		<tr class='form-field'>
 			<th scope='row' style='vertical-align:top'><label for='count'><?php esc_html_e( 'Current usage count', 'events-made-easy' ); ?></label></th>
-			<td><input name='count' id='count' type='text' value='<?php echo eme_esc_html( $discount['count'] ); ?>' size='40'>
+			<td><input name='count' id='count' type='text' value='<?php echo esc_html( $discount['count'] ); ?>' size='40'>
 			<br><?php esc_html_e( 'The current number of times this discount has been applied', 'events-made-easy' ); ?>
 			</td>
 		</tr>
@@ -1023,16 +1023,16 @@ function eme_dgroups_edit_layout( $dgroup_id = 0, $message = '' ) {
 		<table class='form-table'>
 			<tr class='form-field'>
 		<th scope='row' style='vertical-align:top'><label for='name'><?php esc_html_e( 'Discountgroup name', 'events-made-easy' ); ?></label></th>
-		<td><input name='name' id='name' required='required' type='text' value='<?php echo eme_esc_html( $dgroup['name'] ); ?>' size='40'><br>
+		<td><input name='name' id='name' required='required' type='text' value='<?php echo esc_html( $dgroup['name'] ); ?>' size='40'><br>
 		<?php esc_html_e( 'The name of the discount group', 'events-made-easy' ); ?></td>
 			</tr>
 			<tr class='form-field'>
 		<th scope='row' style='vertical-align:top'><label for='description'><?php esc_html_e( 'Description', 'events-made-easy' ); ?></label></th>
-			<td><textarea name='description' id='description' rows='5' ><?php echo eme_esc_html( $dgroup['description'] ); ?></textarea></td>
+			<td><textarea name='description' id='description' rows='5' ><?php echo esc_html( $dgroup['description'] ); ?></textarea></td>
 			</tr>
 			<tr class='form-field'>
 		<th scope='row' style='vertical-align:top'><label for='maxdiscounts'><?php esc_html_e( 'Max amount of discounts applied', 'events-made-easy' ); ?></label></th>
-			<td><input name='maxdiscounts' id='maxdiscounts' type='text' value='<?php echo eme_esc_html( $dgroup['maxdiscounts'] ); ?>' size='40'>
+			<td><input name='maxdiscounts' id='maxdiscounts' type='text' value='<?php echo esc_html( $dgroup['maxdiscounts'] ); ?>' size='40'>
 			<br><?php esc_html_e( 'A discount group exists of several discounts, and you can ask for several discount codes by using #_DISCOUNT repeatedly. This parameter then puts a limit of the number of valid discounts that can be applied. So even if you e.g. enter 5 valid coupon codes, you can limit the usage to only 3 or so.', 'events-made-easy' ); ?>
 				</td>
 			</tr>

--- a/eme-events.php
+++ b/eme-events.php
@@ -6841,7 +6841,7 @@ function eme_event_form( $event, $info, $edit_recurrence = 0 ) {
         // if it is not a new event and there's no contact person defined, then the event author becomes contact person
         // So let's display a warning what this means if there's no author (like when submitting via the frontend submission form)
         if ( ! $is_new_event && $event['event_contactperson_id'] < 1 && $event['event_author'] < 1 ) {
-            print '<br>' . __( 'Since the author is undefined for this event, any reference to the contact person (like when using #_CONTACTPERSON when sending emails), will use the admin user info.', 'events-made-easy' );
+            print '<br>' . esc_html__( 'Since the author is undefined for this event, any reference to the contact person (like when using #_CONTACTPERSON when sending emails), will use the admin user info.', 'events-made-easy' );
         }
 ?>
         </p>
@@ -6879,7 +6879,7 @@ function eme_event_form( $event, $info, $edit_recurrence = 0 ) {
 <?php
         $templates = get_page_templates();
         print eme_ui_select_inverted( $event['event_properties']['wp_page_template'], 'eme_prop_wp_page_template', $templates, __( 'Default Template' ) ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select()
-        print '<br>' . __( 'By default the event uses the same WP page template as the defined special events page. If your theme provides several different page templates, chose another one if wanted.', 'events-made-easy' );
+        print '<br>' . esc_html__( 'By default the event uses the same WP page template as the defined special events page. If your theme provides several different page templates, chose another one if wanted.', 'events-made-easy' );
 ?>
                     </div>
                     </div>
@@ -7043,7 +7043,7 @@ function eme_meta_box_div_event_name( $event, $edit_recurrence = 0 ) {
 ?>
 <div id="titlediv">
     <!-- we need title for qtranslate as ID -->
-    <input type="text" id="title" name="event_name" required="required" placeholder="<?php esc_attr_e( 'Event name', 'events-made-easy' ); ?>" value="<?php echo eme_esc_html( $event['event_name'] ); ?>">
+    <input type="text" id="title" name="event_name" required="required" placeholder="<?php esc_attr_e( 'Event name', 'events-made-easy' ); ?>" value="<?php echo esc_html( $event['event_name'] ); ?>">
     <br>
     <br>
 <?php
@@ -7329,7 +7329,7 @@ function eme_meta_box_div_event_page_title_format( $event, $templates_array ) {
     <img src="<?php echo esc_url(EME_PLUGIN_URL); ?>images/showhide.png" class="showhidebutton" alt="show/hide" data-showhide="event_page_title_format_div" style="cursor: pointer; vertical-align: middle; ">
     <br>
     <div id="event_page_title_format_div" <?php echo $showhide_style; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- hardcoded CSS class/style string ?>>
-    <input type="text" maxlength="250" style="width: 100%;" name="event_page_title_format" id="event_page_title_format" value="<?php echo eme_esc_html( $event['event_page_title_format']); ?>" data-default="<?php echo esc_attr(get_option('eme_event_page_title_format')); ?>">
+    <input type="text" maxlength="250" style="width: 100%;" name="event_page_title_format" id="event_page_title_format" value="<?php echo esc_html( $event['event_page_title_format']); ?>" data-default="<?php echo esc_attr(get_option('eme_event_page_title_format')); ?>">
     </div>
 </div>
 <?php
@@ -7398,7 +7398,7 @@ function eme_meta_box_div_event_contactperson_ipn_email( $event, $templates_arra
     <?php esc_html_e( 'Or enter your own (if anything is entered here, it takes precedence over the selected template): ', 'events-made-easy' ); ?>
     <img src="<?php echo esc_url(EME_PLUGIN_URL); ?>images/showhide.png" class="showhidebutton" alt="show/hide" data-showhide="eme_prop_contactperson_registration_ipn_email_subject" style="cursor: pointer; vertical-align: middle; ">
     <br>
-    <input type="text" maxlength="250" name="eme_prop_contactperson_registration_ipn_email_subject" id="eme_prop_contactperson_registration_ipn_email_subject" <?php echo $showhide_style; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- hardcoded CSS class/style string ?> value="<?php echo eme_esc_html( $event['event_properties']['contactperson_registration_ipn_email_subject']); ?>" data-default="<?php echo esc_attr(get_option('contactperson_ipn_email_subject')); ?>">
+    <input type="text" maxlength="250" name="eme_prop_contactperson_registration_ipn_email_subject" id="eme_prop_contactperson_registration_ipn_email_subject" <?php echo $showhide_style; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- hardcoded CSS class/style string ?> value="<?php echo esc_html( $event['event_properties']['contactperson_registration_ipn_email_subject']); ?>" data-default="<?php echo esc_attr(get_option('contactperson_ipn_email_subject')); ?>">
     <br>
 <?php
     if ( eme_is_empty_string( $event['event_properties']['contactperson_registration_ipn_email_body'] ) ) {
@@ -7479,15 +7479,15 @@ function eme_meta_box_div_event_registration_approved_email( $event, $templates_
         $showhide_style = 'style="width:100%;"';
     }
     if ( ! get_option( 'eme_rsvp_mail_notify_is_active' ) ) {
-        print "<div class='info eme-message-admin'><p>" . __( 'RSVP notifications are not activated, so these emails will not be sent. Go in the Email settings to activate this if wanted.', 'events-made-easy' ) . '</p></div>';
+        print "<div class='info eme-message-admin'><p>" . esc_html__( 'RSVP notifications are not activated, so these emails will not be sent. Go in the Email settings to activate this if wanted.', 'events-made-easy' ) . '</p></div>';
     } else {
         if ( ! get_option( 'eme_rsvp_mail_notify_approved' ) ) {
-            print "<div class='info eme-message-admin'><p>" . __( 'RSVP notifications are not activated for bookings made or approved, so these emails will not be sent. Go in the Email settings to activate this if wanted.', 'events-made-easy' ) . '</p></div>';
+            print "<div class='info eme-message-admin'><p>" . esc_html__( 'RSVP notifications are not activated for bookings made or approved, so these emails will not be sent. Go in the Email settings to activate this if wanted.', 'events-made-easy' ) . '</p></div>';
         } else {
             if ( get_option( 'eme_rsvp_mail_notify_paid' ) ) {
-                print "<div class='info eme-message-admin'><p>" . __( 'When an event is configured to auto-approve bookings after payment and the total amount to pay is 0, this email will be sent when a pending booking is marked as paid (and not the paid-email, since there was nothing to pay for).', 'events-made-easy' ) . '</p></div>';
+                print "<div class='info eme-message-admin'><p>" . esc_html__( 'When an event is configured to auto-approve bookings after payment and the total amount to pay is 0, this email will be sent when a pending booking is marked as paid (and not the paid-email, since there was nothing to pay for).', 'events-made-easy' ) . '</p></div>';
             } else {
-                print "<div class='info eme-message-admin'><p>" . __( 'Since RSVP notifications after payment are not active, this email will also be sent when a booking is marked as paid.', 'events-made-easy' ) . '</p></div>';
+                print "<div class='info eme-message-admin'><p>" . esc_html__( 'Since RSVP notifications after payment are not active, this email will also be sent when a booking is marked as paid.', 'events-made-easy' ) . '</p></div>';
             }
         }
     }
@@ -7506,7 +7506,7 @@ function eme_meta_box_div_event_registration_approved_email( $event, $templates_
     <?php esc_html_e( 'Or enter your own (if anything is entered here, it takes precedence over the selected template): ', 'events-made-easy' ); ?>
     <img src="<?php echo esc_url(EME_PLUGIN_URL); ?>images/showhide.png" class="showhidebutton" alt="show/hide" data-showhide="eme_prop_event_respondent_email_subject" style="cursor: pointer; vertical-align: middle; ">
     <br>
-    <input type="text" maxlength="250" name="eme_prop_event_respondent_email_subject" id="eme_prop_event_respondent_email_subject" <?php echo $showhide_style; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- hardcoded CSS class/style string ?> value="<?php echo eme_esc_html( $event['event_properties']['event_respondent_email_subject'] ); ?>" data-default="<?php echo esc_attr(get_option('eme_respondent_email_subject')); ?>">
+    <input type="text" maxlength="250" name="eme_prop_event_respondent_email_subject" id="eme_prop_event_respondent_email_subject" <?php echo $showhide_style; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- hardcoded CSS class/style string ?> value="<?php echo esc_html( $event['event_properties']['event_respondent_email_subject'] ); ?>" data-default="<?php echo esc_attr(get_option('eme_respondent_email_subject')); ?>">
     <br>
 <?php
     if ( eme_is_empty_string( $event['event_respondent_email_body'] ) ) {
@@ -7554,7 +7554,7 @@ function eme_meta_box_div_event_registration_approved_email( $event, $templates_
     <?php esc_html_e( 'Or enter your own (if anything is entered here, it takes precedence over the selected template): ', 'events-made-easy' ); ?>
     <img src="<?php echo esc_url(EME_PLUGIN_URL); ?>images/showhide.png" class="showhidebutton" alt="show/hide" data-showhide="eme_prop_event_contactperson_email_subject" style="cursor: pointer; vertical-align: middle; ">
     <br>
-    <input type="text" maxlength="250" name="eme_prop_event_contactperson_email_subject" id="eme_prop_event_contactperson_email_subject" <?php echo $showhide_style; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- hardcoded CSS class/style string ?> value="<?php echo eme_esc_html( $event['event_properties']['event_contactperson_email_subject'] ); ?>" data-default="<?php echo esc_attr(get_option('eme_contactperson_email_subject')); ?>">
+    <input type="text" maxlength="250" name="eme_prop_event_contactperson_email_subject" id="eme_prop_event_contactperson_email_subject" <?php echo $showhide_style; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- hardcoded CSS class/style string ?> value="<?php echo esc_html( $event['event_properties']['event_contactperson_email_subject'] ); ?>" data-default="<?php echo esc_attr(get_option('eme_contactperson_email_subject')); ?>">
     <br>
 <?php
     if ( eme_is_empty_string( $event['event_contactperson_email_body'] ) ) {
@@ -7629,9 +7629,9 @@ function eme_meta_box_div_event_registration_userpending_email( $event, $templat
         $showhide_style = 'style="width:100%;"';
     }
     if ( ! get_option( 'eme_rsvp_mail_notify_is_active' ) ) {
-        print "<div class='info eme-message-admin'><p>" . __( 'RSVP notifications are not activated, so these emails will not be sent. Go in the Email settings to activate this if wanted.', 'events-made-easy' ) . '</p></div>';
+        print "<div class='info eme-message-admin'><p>" . esc_html__( 'RSVP notifications are not activated, so these emails will not be sent. Go in the Email settings to activate this if wanted.', 'events-made-easy' ) . '</p></div>';
     } elseif ( ! get_option( 'eme_rsvp_mail_notify_pending' ) ) {
-        print "<div class='info eme-message-admin'><p>" . __( 'RSVP notifications are not activated for pending bookings, so these emails will not be sent. Go in the Email settings to activate this if wanted.', 'events-made-easy' ) . '</p></div>';
+        print "<div class='info eme-message-admin'><p>" . esc_html__( 'RSVP notifications are not activated for pending bookings, so these emails will not be sent. Go in the Email settings to activate this if wanted.', 'events-made-easy' ) . '</p></div>';
     }
 ?>
 
@@ -7649,7 +7649,7 @@ function eme_meta_box_div_event_registration_userpending_email( $event, $templat
     <?php esc_html_e( 'Or enter your own (if anything is entered here, it takes precedence over the selected template): ', 'events-made-easy' ); ?>
     <img src="<?php echo esc_url(EME_PLUGIN_URL); ?>images/showhide.png" class="showhidebutton" alt="show/hide" data-showhide="eme_prop_event_registration_userpending_email_subject" style="cursor: pointer; vertical-align: middle; ">
     <br>
-    <input type="text" maxlength="250" name="eme_prop_event_registration_userpending_email_subject" id="eme_prop_event_registration_userpending_email_subject" <?php echo $showhide_style; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- hardcoded CSS class/style string ?> value="<?php echo eme_esc_html( $event['event_properties']['event_registration_userpending_email_subject'] ); ?>">
+    <input type="text" maxlength="250" name="eme_prop_event_registration_userpending_email_subject" id="eme_prop_event_registration_userpending_email_subject" <?php echo $showhide_style; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- hardcoded CSS class/style string ?> value="<?php echo esc_html( $event['event_properties']['event_registration_userpending_email_subject'] ); ?>">
     <br>
 <?php
     if ( eme_is_empty_string( $event['event_properties']['event_registration_userpending_email_body'] ) ) {
@@ -7686,11 +7686,11 @@ function eme_meta_box_div_event_registration_pending_email( $event, $templates_a
         $showhide_style = 'style="width:100%;"';
     }
     if ( ! get_option( 'eme_rsvp_mail_notify_is_active' ) ) {
-        print "<div class='info eme-message-admin'><p>" . __( 'RSVP notifications are not activated, so these emails will not be sent. Go in the Email settings to activate this if wanted.', 'events-made-easy' ) . '</p></div>';
+        print "<div class='info eme-message-admin'><p>" . esc_html__( 'RSVP notifications are not activated, so these emails will not be sent. Go in the Email settings to activate this if wanted.', 'events-made-easy' ) . '</p></div>';
     } elseif ( ! get_option( 'eme_rsvp_mail_notify_pending' ) ) {
-        print "<div class='info eme-message-admin'><p>" . __( 'RSVP notifications are not activated for pending bookings, so these emails will not be sent. Go in the Email settings to activate this if wanted.', 'events-made-easy' ) . '</p></div>';
+        print "<div class='info eme-message-admin'><p>" . esc_html__( 'RSVP notifications are not activated for pending bookings, so these emails will not be sent. Go in the Email settings to activate this if wanted.', 'events-made-easy' ) . '</p></div>';
     }
-    print "<div class='info eme-message-admin'><p>" . __( 'When this mail is not yet sent (in the queue) and the booking is approved or paid during that time and a mail is planned for that action, this mail gets removed from the queue so people do not get 2 emails at the same time.', 'events-made-easy' ) . '</p></div>';
+    print "<div class='info eme-message-admin'><p>" . esc_html__( 'When this mail is not yet sent (in the queue) and the booking is approved or paid during that time and a mail is planned for that action, this mail gets removed from the queue so people do not get 2 emails at the same time.', 'events-made-easy' ) . '</p></div>';
 ?>
 
 <div>
@@ -7707,7 +7707,7 @@ function eme_meta_box_div_event_registration_pending_email( $event, $templates_a
     <?php esc_html_e( 'Or enter your own (if anything is entered here, it takes precedence over the selected template): ', 'events-made-easy' ); ?>
     <img src="<?php echo esc_url(EME_PLUGIN_URL); ?>images/showhide.png" class="showhidebutton" alt="show/hide" data-showhide="eme_prop_event_registration_pending_email_subject" style="cursor: pointer; vertical-align: middle; ">
     <br>
-    <input type="text" maxlength="250" name="eme_prop_event_registration_pending_email_subject" id="eme_prop_event_registration_pending_email_subject" <?php echo $showhide_style; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- hardcoded CSS class/style string ?> value="<?php echo eme_esc_html( $event['event_properties']['event_registration_pending_email_subject'] ); ?>" data-default="<?php echo esc_attr(get_option('eme_registration_pending_email_subject')); ?>">
+    <input type="text" maxlength="250" name="eme_prop_event_registration_pending_email_subject" id="eme_prop_event_registration_pending_email_subject" <?php echo $showhide_style; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- hardcoded CSS class/style string ?> value="<?php echo esc_html( $event['event_properties']['event_registration_pending_email_subject'] ); ?>" data-default="<?php echo esc_attr(get_option('eme_registration_pending_email_subject')); ?>">
     <br>
 <?php
     if ( eme_is_empty_string( $event['event_registration_pending_email_body'] ) ) {
@@ -7755,7 +7755,7 @@ function eme_meta_box_div_event_registration_pending_email( $event, $templates_a
     <?php esc_html_e( 'Or enter your own (if anything is entered here, it takes precedence over the selected template): ', 'events-made-easy' ); ?>
     <img src="<?php echo esc_url(EME_PLUGIN_URL); ?>images/showhide.png" class="showhidebutton" alt="show/hide" data-showhide="eme_prop_contactperson_registration_pending_email_subject" style="cursor: pointer; vertical-align: middle; ">
     <br>
-    <input type="text" maxlength="250" name="eme_prop_contactperson_registration_pending_email_subject" id="eme_prop_contactperson_registration_pending_email_subject" <?php echo $showhide_style; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- hardcoded CSS class/style string ?> value="<?php echo eme_esc_html( $event['event_properties']['contactperson_registration_pending_email_subject'] ); ?>" data-default="<?php echo esc_attr(get_option('eme_contactperson_pending_email_subject')); ?>">
+    <input type="text" maxlength="250" name="eme_prop_contactperson_registration_pending_email_subject" id="eme_prop_contactperson_registration_pending_email_subject" <?php echo $showhide_style; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- hardcoded CSS class/style string ?> value="<?php echo esc_html( $event['event_properties']['contactperson_registration_pending_email_subject'] ); ?>" data-default="<?php echo esc_attr(get_option('eme_contactperson_pending_email_subject')); ?>">
     <br>
 <?php
     if ( eme_is_empty_string( $event['event_properties']['contactperson_registration_pending_email_body'] ) ) {
@@ -7844,7 +7844,7 @@ function eme_meta_box_div_event_registration_updated_email( $event, $templates_a
     <?php esc_html_e( 'Or enter your own (if anything is entered here, it takes precedence over the selected template): ', 'events-made-easy' ); ?>
     <img src="<?php echo esc_url(EME_PLUGIN_URL); ?>images/showhide.png" class="showhidebutton" alt="show/hide" data-showhide="eme_prop_event_registration_updated_email_subject" style="cursor: pointer; vertical-align: middle; ">
     <br>
-    <input type="text" maxlength="250" name="eme_prop_event_registration_updated_email_subject" id="eme_prop_event_registration_updated_email_subject" <?php echo $showhide_style; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- hardcoded CSS class/style string ?> value="<?php echo eme_esc_html( $event['event_properties']['event_registration_updated_email_subject'] ); ?>" data-default="<?php echo esc_attr(get_option('eme_registration_updated_email_subject')); ?>">
+    <input type="text" maxlength="250" name="eme_prop_event_registration_updated_email_subject" id="eme_prop_event_registration_updated_email_subject" <?php echo $showhide_style; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- hardcoded CSS class/style string ?> value="<?php echo esc_html( $event['event_properties']['event_registration_updated_email_subject'] ); ?>" data-default="<?php echo esc_attr(get_option('eme_registration_updated_email_subject')); ?>">
     <br>
 <?php
     if ( eme_is_empty_string( $event['event_registration_updated_email_body'] ) ) {
@@ -7895,7 +7895,7 @@ function eme_meta_box_div_event_registration_reminder_email( $event, $templates_
     <?php esc_html_e( 'Or enter your own (if anything is entered here, it takes precedence over the selected template): ', 'events-made-easy' ); ?>
     <img src="<?php echo esc_url(EME_PLUGIN_URL); ?>images/showhide.png" class="showhidebutton" alt="show/hide" data-showhide="eme_prop_event_registration_pending_reminder_email_subject" style="cursor: pointer; vertical-align: middle; ">
     <br>
-    <input type="text" maxlength="250" name="eme_prop_event_registration_pending_reminder_email_subject" id="eme_prop_event_registration_pending_reminder_email_subject" <?php echo $showhide_style; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- hardcoded CSS class/style string ?> value="<?php echo eme_esc_html( $event['event_properties']['event_registration_pending_reminder_email_subject'] ); ?>" data-default="<?php echo esc_attr(get_option('eme_registration_pending_reminder_email_subject')); ?>">
+    <input type="text" maxlength="250" name="eme_prop_event_registration_pending_reminder_email_subject" id="eme_prop_event_registration_pending_reminder_email_subject" <?php echo $showhide_style; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- hardcoded CSS class/style string ?> value="<?php echo esc_html( $event['event_properties']['event_registration_pending_reminder_email_subject'] ); ?>" data-default="<?php echo esc_attr(get_option('eme_registration_pending_reminder_email_subject')); ?>">
     <br>
 <?php
     if ( eme_is_empty_string( $event['event_properties']['event_registration_pending_reminder_email_body'] ) ) {
@@ -7936,7 +7936,7 @@ function eme_meta_box_div_event_registration_reminder_email( $event, $templates_
     <?php esc_html_e( 'Or enter your own (if anything is entered here, it takes precedence over the selected template): ', 'events-made-easy' ); ?>
     <img src="<?php echo esc_url(EME_PLUGIN_URL); ?>images/showhide.png" class="showhidebutton" alt="show/hide" data-showhide="eme_prop_event_registration_reminder_email_subject" style="cursor: pointer; vertical-align: middle; ">
     <br>
-    <input type="text" maxlength="250" name="eme_prop_event_registration_reminder_email_subject" id="eme_prop_event_registration_reminder_email_subject" <?php echo $showhide_style; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- hardcoded CSS class/style string ?> value="<?php echo eme_esc_html( $event['event_properties']['event_registration_reminder_email_subject'] ); ?>" data-default="<?php echo esc_attr(get_option('eme_registration_reminder_email_subject')); ?>">
+    <input type="text" maxlength="250" name="eme_prop_event_registration_reminder_email_subject" id="eme_prop_event_registration_reminder_email_subject" <?php echo $showhide_style; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- hardcoded CSS class/style string ?> value="<?php echo esc_html( $event['event_properties']['event_registration_reminder_email_subject'] ); ?>" data-default="<?php echo esc_attr(get_option('eme_registration_reminder_email_subject')); ?>">
     <br>
 <?php
     if ( eme_is_empty_string( $event['event_properties']['event_registration_reminder_email_body'] ) ) {
@@ -7987,7 +7987,7 @@ function eme_meta_box_div_event_registration_cancelled_email( $event, $templates
     <?php esc_html_e( 'Or enter your own (if anything is entered here, it takes precedence over the selected template): ', 'events-made-easy' ); ?>
     <img src="<?php echo esc_url(EME_PLUGIN_URL); ?>images/showhide.png" class="showhidebutton" alt="show/hide" data-showhide="eme_prop_event_registration_cancelled_email_subject" style="cursor: pointer; vertical-align: middle; ">
     <br>
-    <input type="text" maxlength="250" name="eme_prop_event_registration_cancelled_email_subject" id="eme_prop_event_registration_cancelled_email_subject" <?php echo $showhide_style; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- hardcoded CSS class/style string ?> value="<?php echo eme_esc_html( $event['event_properties']['event_registration_cancelled_email_subject'] ); ?>" data-default="<?php echo esc_attr(get_option('eme_registration_cancelled_email_subject')); ?>">
+    <input type="text" maxlength="250" name="eme_prop_event_registration_cancelled_email_subject" id="eme_prop_event_registration_cancelled_email_subject" <?php echo $showhide_style; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- hardcoded CSS class/style string ?> value="<?php echo esc_html( $event['event_properties']['event_registration_cancelled_email_subject'] ); ?>" data-default="<?php echo esc_attr(get_option('eme_registration_cancelled_email_subject')); ?>">
     <br>
 <?php
     if ( eme_is_empty_string( $event['event_registration_cancelled_email_body'] ) ) {
@@ -8035,7 +8035,7 @@ function eme_meta_box_div_event_registration_cancelled_email( $event, $templates
     <?php esc_html_e( 'Or enter your own (if anything is entered here, it takes precedence over the selected template): ', 'events-made-easy' ); ?>
     <img src="<?php echo esc_url(EME_PLUGIN_URL); ?>images/showhide.png" class="showhidebutton" alt="show/hide" data-showhide="eme_prop_contactperson_registration_cancelled_email_subject" style="cursor: pointer; vertical-align: middle; ">
     <br>
-    <input type="text" maxlength="250" name="eme_prop_contactperson_registration_cancelled_email_subject" id="eme_prop_contactperson_registration_cancelled_email_subject" <?php echo $showhide_style; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- hardcoded CSS class/style string ?> value="<?php echo eme_esc_html( $event['event_properties']['contactperson_registration_cancelled_email_subject'] ); ?>" data-default="<?php echo esc_attr(get_option('eme_contactperson_cancelled_email_subject')); ?>">
+    <input type="text" maxlength="250" name="eme_prop_contactperson_registration_cancelled_email_subject" id="eme_prop_contactperson_registration_cancelled_email_subject" <?php echo $showhide_style; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- hardcoded CSS class/style string ?> value="<?php echo esc_html( $event['event_properties']['contactperson_registration_cancelled_email_subject'] ); ?>" data-default="<?php echo esc_attr(get_option('eme_contactperson_cancelled_email_subject')); ?>">
     <br>
 <?php
     if ( eme_is_empty_string( $event['event_properties']['contactperson_registration_cancelled_email_body'] ) ) {
@@ -8072,9 +8072,9 @@ function eme_meta_box_div_event_registration_paid_email( $event, $templates_arra
         $showhide_style = 'style="width:100%;"';
     }
     if ( ! get_option( 'eme_rsvp_mail_notify_is_active' ) ) {
-        print "<div class='info eme-message-admin'><p>" . __( 'RSVP notifications are not activated, so these emails will not be sent. Go in the Email settings to activate this if wanted.', 'events-made-easy' ) . '</p></div>';
+        print "<div class='info eme-message-admin'><p>" . esc_html__( 'RSVP notifications are not activated, so these emails will not be sent. Go in the Email settings to activate this if wanted.', 'events-made-easy' ) . '</p></div>';
     } elseif ( ! get_option( 'eme_rsvp_mail_notify_paid' ) ) {
-        print "<div class='info eme-message-admin'><p>" . __( 'RSVP notifications are not activated for paid bookings, so these emails will not be sent. Go in the Email settings to activate this if wanted.', 'events-made-easy' ) . '</p></div>';
+        print "<div class='info eme-message-admin'><p>" . esc_html__( 'RSVP notifications are not activated for paid bookings, so these emails will not be sent. Go in the Email settings to activate this if wanted.', 'events-made-easy' ) . '</p></div>';
     }
 ?>
 <div>
@@ -8091,7 +8091,7 @@ function eme_meta_box_div_event_registration_paid_email( $event, $templates_arra
     <?php esc_html_e( 'Or enter your own (if anything is entered here, it takes precedence over the selected template): ', 'events-made-easy' ); ?>
     <img src="<?php echo esc_url(EME_PLUGIN_URL); ?>images/showhide.png" class="showhidebutton" alt="show/hide" data-showhide="eme_prop_event_registration_paid_email_subject" style="cursor: pointer; vertical-align: middle; ">
     <br>
-    <input type="text" maxlength="250" name="eme_prop_event_registration_paid_email_subject" id="eme_prop_event_registration_paid_email_subject" <?php echo $showhide_style; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- hardcoded CSS class/style string ?> value="<?php echo eme_esc_html( $event['event_properties']['event_registration_paid_email_subject'] ); ?>" data-default="<?php echo esc_attr(get_option('eme_registration_paid_email_subject')); ?>">
+    <input type="text" maxlength="250" name="eme_prop_event_registration_paid_email_subject" id="eme_prop_event_registration_paid_email_subject" <?php echo $showhide_style; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- hardcoded CSS class/style string ?> value="<?php echo esc_html( $event['event_properties']['event_registration_paid_email_subject'] ); ?>" data-default="<?php echo esc_attr(get_option('eme_registration_paid_email_subject')); ?>">
     <br>
 <?php
     if ( eme_is_empty_string( $event['event_registration_paid_email_body'] ) ) {
@@ -8139,7 +8139,7 @@ function eme_meta_box_div_event_registration_paid_email( $event, $templates_arra
     <?php esc_html_e( 'Or enter your own (if anything is entered here, it takes precedence over the selected template): ', 'events-made-easy' ); ?>
     <img src="<?php echo esc_url(EME_PLUGIN_URL); ?>images/showhide.png" class="showhidebutton" alt="show/hide" data-showhide="eme_prop_contactperson_registration_paid_email_subject" style="cursor: pointer; vertical-align: middle; ">
     <br>
-    <input type="text" maxlength="250" name="eme_prop_contactperson_registration_paid_email_subject" id="eme_prop_contactperson_registration_paid_email_subject" <?php echo $showhide_style; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- hardcoded CSS class/style string ?> value="<?php echo eme_esc_html( $event['event_properties']['contactperson_registration_paid_email_subject'] ); ?>">
+    <input type="text" maxlength="250" name="eme_prop_contactperson_registration_paid_email_subject" id="eme_prop_contactperson_registration_paid_email_subject" <?php echo $showhide_style; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- hardcoded CSS class/style string ?> value="<?php echo esc_html( $event['event_properties']['contactperson_registration_paid_email_subject'] ); ?>">
     <br>
 <?php
     if ( eme_is_empty_string( $event['event_properties']['contactperson_registration_paid_email_body'] ) ) {
@@ -8228,7 +8228,7 @@ function eme_meta_box_div_event_registration_trashed_email( $event, $templates_a
     <?php esc_html_e( 'Or enter your own (if anything is entered here, it takes precedence over the selected template): ', 'events-made-easy' ); ?>
     <img src="<?php echo esc_url(EME_PLUGIN_URL); ?>images/showhide.png" class="showhidebutton" alt="show/hide" data-showhide="eme_prop_event_registration_trashed_email_subject" style="cursor: pointer; vertical-align: middle; ">
     <br>
-    <input type="text" maxlength="250" name="eme_prop_event_registration_trashed_email_subject" id="eme_prop_event_registration_trashed_email_subject" <?php echo $showhide_style; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- hardcoded CSS class/style string ?> value="<?php echo eme_esc_html( $event['event_properties']['event_registration_trashed_email_subject'] ); ?>" data-default="<?php echo esc_attr(get_option('eme_registration_trashed_email_subject')); ?>">
+    <input type="text" maxlength="250" name="eme_prop_event_registration_trashed_email_subject" id="eme_prop_event_registration_trashed_email_subject" <?php echo $showhide_style; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- hardcoded CSS class/style string ?> value="<?php echo esc_html( $event['event_properties']['event_registration_trashed_email_subject'] ); ?>" data-default="<?php echo esc_attr(get_option('eme_registration_trashed_email_subject')); ?>">
     <br>
 <?php
     if ( eme_is_empty_string( $event['event_registration_trashed_email_body'] ) ) {
@@ -8568,7 +8568,7 @@ function eme_meta_box_div_event_url( $event ) {
     <h3>
         <?php esc_html_e( 'External URL', 'events-made-easy' ); ?>
     </h3>
-    <input type="url" id="event_url" name="event_url" autocomplete="off" value="<?php echo eme_esc_html( $event['event_url'] ); ?>">
+    <input type="url" id="event_url" name="event_url" autocomplete="off" value="<?php echo esc_html( $event['event_url'] ); ?>">
     <br>
     <p class="eme_smaller"><?php esc_html_e( 'If this is filled in, the single event URL will point to this url instead of the standard event page.', 'events-made-easy' ); ?></p>
 </div>
@@ -8720,7 +8720,7 @@ function eme_meta_box_div_event_rsvp( $event, $pdf_templates_array ) {
         <br>
 <?php
     if ( ! get_option( 'eme_rsvp_mail_notify_pending' ) ) {
-        print "<span id='span_approval_required_mail_warning'><img style='vertical-align: middle;' src='" . esc_url(EME_PLUGIN_URL) . "images/warning.png' alt='warning'>" . __( 'RSVP notifications are not activated for pending bookings, so these emails will not be sent. Go in the Email settings to activate this if wanted.', 'events-made-easy' ) . '</span>';
+        print "<span id='span_approval_required_mail_warning'><img style='vertical-align: middle;' src='" . esc_url(EME_PLUGIN_URL) . "images/warning.png' alt='warning'>" . esc_html__( 'RSVP notifications are not activated for pending bookings, so these emails will not be sent. Go in the Email settings to activate this if wanted.', 'events-made-easy' ) . '</span>';
     }
 ?>
     </p>
@@ -8731,11 +8731,11 @@ function eme_meta_box_div_event_rsvp( $event, $pdf_templates_array ) {
         <br>
         <?php echo eme_ui_checkbox_binary( $event['event_properties']['ignore_pending'], 'eme_prop_ignore_pending', __( 'Consider pending bookings as available seats for new bookings', 'events-made-easy' ) . '<br>' . __( 'In case online payments are possible, pending bookings younger than 5 minutes will count as occupied too, to be able to allow people to finish online payments.', 'events-made-easy' ) ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_checkbox_binary() ?>
         <br>
-        <input id="eme_prop_rsvp_pending_reminder_days" name='eme_prop_rsvp_pending_reminder_days' type='text' value="<?php echo eme_esc_html( $eme_prop_rsvp_pending_reminder_days ); ?>">
+        <input id="eme_prop_rsvp_pending_reminder_days" name='eme_prop_rsvp_pending_reminder_days' type='text' value="<?php echo esc_html( $eme_prop_rsvp_pending_reminder_days ); ?>">
         <label for="eme_prop_rsvp_pending_reminder_days"><?php esc_html_e( 'Set the number of days before reminder emails will be sent for pending bookings (counting from the start date of the event). If you want to send out multiple reminders, seperate the days here by commas. Leave empty for no reminder emails.', 'events-made-easy' ); ?></label>
     </p>
     <p id='p_rsvp_approved_reminder_days'>
-        <input id="eme_prop_rsvp_approved_reminder_days" name='eme_prop_rsvp_approved_reminder_days' type='text' value="<?php echo eme_esc_html( $eme_prop_rsvp_approved_reminder_days ); ?>">
+        <input id="eme_prop_rsvp_approved_reminder_days" name='eme_prop_rsvp_approved_reminder_days' type='text' value="<?php echo esc_html( $eme_prop_rsvp_approved_reminder_days ); ?>">
         <label for="eme_prop_rsvp_approved_reminder_days"><?php esc_html_e( 'Set the number of days before reminder emails will be sent for approved bookings (counting from the start date of the event). If you want to send out multiple reminders, seperate the days here by commas. Leave empty for no reminder emails.', 'events-made-easy' ); ?></label>
     </p>
     <p id='p_create_wp_user'>
@@ -8751,14 +8751,14 @@ function eme_meta_box_div_event_rsvp( $event, $pdf_templates_array ) {
     <table class="eme_event_admin_table">
     <tr id='row_seats'>
         <td><label for='seats-input'><?php esc_html_e( 'Seats', 'events-made-easy' ); ?> :</label></td>
-        <td><input id="seats-input" type="text" name="event_seats" size='8' title="<?php echo esc_attr__( 'Enter 0 for no limit', 'events-made-easy' ) . "\n" . esc_attr( __( 'For multiseat events, separate the values by \'||\'', 'events-made-easy' ) ); ?>" value="<?php echo eme_esc_html( $event_number_seats ); ?>">
+        <td><input id="seats-input" type="text" name="event_seats" size='8' title="<?php echo esc_attr__( 'Enter 0 for no limit', 'events-made-easy' ) . "\n" . esc_attr( __( 'For multiseat events, separate the values by \'||\'', 'events-made-easy' ) ); ?>" value="<?php echo esc_html( $event_number_seats ); ?>">
             <span class="eme_smaller"><br><?php esc_html_e( 'The max available seats for this event. Enter 0 for no limit. For multiseat events, separate the values by \'||\'', 'events-made-easy' ); ?></span>
             <span class="eme-hidden" id="loc_max_cap_warning"><br><img style='vertical-align: middle;' src='<?php echo esc_url(EME_PLUGIN_URL);?>images/warning.png' alt='warning'><b><?php esc_html_e( 'A location maximum capacity is set. If your event maximum surpasses this capacity, the location capacity will take precendence.', 'events-made-easy' ); ?></b></span>
         </td>
     </tr>
     <tr id='row_price'>
         <td><label for='price'><?php esc_html_e( 'Price: ', 'events-made-easy' ); ?></label></td>
-        <td><input id="price" type="text" size="8" name="price" style="field-sizing: content; min-width: 100px; max-width: 500px;" title="<?php esc_attr_e( 'For multiprice events, separate the values by \'||\'', 'events-made-easy' ); ?>" value="<?php echo eme_esc_html( $event['price'] ); ?>">
+        <td><input id="price" type="text" size="8" name="price" style="field-sizing: content; min-width: 100px; max-width: 500px;" title="<?php esc_attr_e( 'For multiprice events, separate the values by \'||\'', 'events-made-easy' ); ?>" value="<?php echo esc_html( $event['price'] ); ?>">
             <select id="currency" name="currency">
 <?php
     foreach ( $currency_array as $key => $value ) {
@@ -8779,15 +8779,15 @@ function eme_meta_box_div_event_rsvp( $event, $pdf_templates_array ) {
     </tr>
     <tr id='row_price_desc'>
         <td><label for='eme_prop_price_desc'><?php esc_html_e( 'Price description', 'events-made-easy' ); ?> :</label></td>
-        <td><input type="text" name="eme_prop_price_desc" id="eme_prop_price_desc" value="<?php echo eme_esc_html( $event['event_properties']['price_desc'] ); ?>" style="field-sizing: content; min-width: 200px;"><p class="eme_smaller"><?php esc_html_e( 'Add an optional description for the price (which can be used in templates).', 'events-made-easy' ); ?></p></td>
+        <td><input type="text" name="eme_prop_price_desc" id="eme_prop_price_desc" value="<?php echo esc_html( $event['event_properties']['price_desc'] ); ?>" style="field-sizing: content; min-width: 200px;"><p class="eme_smaller"><?php esc_html_e( 'Add an optional description for the price (which can be used in templates).', 'events-made-easy' ); ?></p></td>
     </tr>
     <tr id='row_multiprice_desc'>
         <td><label for='eme_prop_multiprice_desc'><?php esc_html_e( 'Price Categories descriptions', 'events-made-easy' ); ?> :</label></td>
-        <td><textarea name="eme_prop_multiprice_desc" id="eme_prop_multiprice_desc" rows="6" col="40" style="field-sizing: content; min-width: 200px; max-width: 500px; min-height: 50px; max-height: 200px; resize: both;" ><?php echo str_replace( '||', "\n", eme_esc_html( $event['event_properties']['multiprice_desc'] ) ); ?></textarea><p class="eme_smaller"><?php esc_html_e( 'Add an optional description for each price category (one price description per line).', 'events-made-easy' ); ?></p></td>
+        <td><textarea name="eme_prop_multiprice_desc" id="eme_prop_multiprice_desc" rows="6" col="40" style="field-sizing: content; min-width: 200px; max-width: 500px; min-height: 50px; max-height: 200px; resize: both;" ><?php echo str_replace( '||', "\n", esc_html( $event['event_properties']['multiprice_desc'] ) ); ?></textarea><p class="eme_smaller"><?php esc_html_e( 'Add an optional description for each price category (one price description per line).', 'events-made-easy' ); ?></p></td>
     </tr>
     <tr id='row_vat'>
         <td><label for='eme_prop_vat_pct'><?php esc_html_e( 'VAT percentage: ', 'events-made-easy' ); ?></label></td>
-        <td><input id="eme_prop_vat_pct" type="text" name="eme_prop_vat_pct" size='8' title="<?php esc_attr_e( 'VAT percentage', 'events-made-easy' ); ?>" value="<?php echo eme_esc_html( $event['event_properties']['vat_pct'] ); ?>">%
+        <td><input id="eme_prop_vat_pct" type="text" name="eme_prop_vat_pct" size='8' title="<?php esc_attr_e( 'VAT percentage', 'events-made-easy' ); ?>" value="<?php echo esc_html( $event['event_properties']['vat_pct'] ); ?>">%
         <br><p class='eme_smaller'><?php esc_html_e( 'The price you indicate for events is VAT included, special placeholders are foreseen to indicate the price without VAT.', 'events-made-easy' ); ?></p>
         </td>
     </tr>
@@ -8801,7 +8801,7 @@ function eme_meta_box_div_event_rsvp( $event, $pdf_templates_array ) {
     </tr>
     <tr id='row_waitinglist_seats'>
         <td><label for='eme_prop_waitinglist_seats'><?php esc_html_e( 'Waitinglist seats', 'events-made-easy' ); ?></label></td>
-        <td><input id="eme_prop_waitinglist_seats" type="text" name="eme_prop_waitinglist_seats" size='8' title="<?php esc_attr_e( 'The number of seats considered to be a waiting list.', 'events-made-easy' ); ?>" value="<?php echo eme_esc_html( $event['event_properties']['waitinglist_seats'] ); ?>"><br><span class="eme_smaller"><?php esc_html_e( 'The number of seats considered to be a waiting list.', 'events-made-easy' ); ?></span></td>
+        <td><input id="eme_prop_waitinglist_seats" type="text" name="eme_prop_waitinglist_seats" size='8' title="<?php esc_attr_e( 'The number of seats considered to be a waiting list.', 'events-made-easy' ); ?>" value="<?php echo esc_html( $event['event_properties']['waitinglist_seats'] ); ?>"><br><span class="eme_smaller"><?php esc_html_e( 'The number of seats considered to be a waiting list.', 'events-made-easy' ); ?></span></td>
     </tr>
     <tr id='row_check_free_waiting'>
         <td><label for='eme_prop_check_free_waiting'><?php esc_html_e( 'Check waitinglist when seats become available', 'events-made-easy' ); ?></label></td>
@@ -8810,11 +8810,11 @@ function eme_meta_box_div_event_rsvp( $event, $pdf_templates_array ) {
     </tr>
     <tr id='row_max_allowed'>
         <td><label for='eme_prop_max_allowed'><?php esc_html_e( 'Max number of seats to book', 'events-made-easy' ); ?></label></td>
-        <td><input id="eme_prop_max_allowed" type="text" name="eme_prop_max_allowed" size='8' title="<?php echo esc_attr__( 'The maximum number of seats a person can book in one go.', 'events-made-easy' ) . ' ' . esc_attr__( '(is multi-compatible)', 'events-made-easy' ); ?>" value="<?php echo eme_esc_html( $event['event_properties']['max_allowed'] ); ?>"><br><span class="eme_smaller"><?php echo esc_html__( 'The maximum number of seats a person can book in one go.', 'events-made-easy' ) . ' ' . esc_html__( '(is multi-compatible)', 'events-made-easy' ) . '<br>' . esc_html__( 'If the min and max number of seats to book are identical, then the field to choose the number of seats to book will be hidden.', 'events-made-easy' ); ?></span></td>
+        <td><input id="eme_prop_max_allowed" type="text" name="eme_prop_max_allowed" size='8' title="<?php echo esc_attr__( 'The maximum number of seats a person can book in one go.', 'events-made-easy' ) . ' ' . esc_attr__( '(is multi-compatible)', 'events-made-easy' ); ?>" value="<?php echo esc_html( $event['event_properties']['max_allowed'] ); ?>"><br><span class="eme_smaller"><?php echo esc_html__( 'The maximum number of seats a person can book in one go.', 'events-made-easy' ) . ' ' . esc_html__( '(is multi-compatible)', 'events-made-easy' ) . '<br>' . esc_html__( 'If the min and max number of seats to book are identical, then the field to choose the number of seats to book will be hidden.', 'events-made-easy' ); ?></span></td>
     </tr>
     <tr id='row_min_allowed'>
         <td><label for='eme_prop_min_allowed'><?php esc_html_e( 'Min number of seats to book', 'events-made-easy' ); ?></label></td>
-        <td><input id="eme_prop_min_allowed" type="text" name="eme_prop_min_allowed" size='8' title="<?php echo esc_attr__( 'The minimum number of seats a person can book in one go (it can be 0, for e.g. just an attendee list).', 'events-made-easy' ) . ' ' . esc_attr__( '(is multi-compatible)', 'events-made-easy' ); ?>" value="<?php echo eme_esc_html( $event['event_properties']['min_allowed'] ); ?>"><br><span class="eme_smaller"><?php echo esc_html__( 'The minimum number of seats a person can book in one go (it can be 0, for e.g. just an attendee list).', 'events-made-easy' ) . ' ' . esc_html__( '(is multi-compatible)', 'events-made-easy' ) . '<br>' . esc_html__( 'If the min and max number of seats to book are identical, then the field to choose the number of seats to book will be hidden.', 'events-made-easy' ); ?></span></td>
+        <td><input id="eme_prop_min_allowed" type="text" name="eme_prop_min_allowed" size='8' title="<?php echo esc_attr__( 'The minimum number of seats a person can book in one go (it can be 0, for e.g. just an attendee list).', 'events-made-easy' ) . ' ' . esc_attr__( '(is multi-compatible)', 'events-made-easy' ); ?>" value="<?php echo esc_html( $event['event_properties']['min_allowed'] ); ?>"><br><span class="eme_smaller"><?php echo esc_html__( 'The minimum number of seats a person can book in one go (it can be 0, for e.g. just an attendee list).', 'events-made-easy' ) . ' ' . esc_html__( '(is multi-compatible)', 'events-made-easy' ) . '<br>' . esc_html__( 'If the min and max number of seats to book are identical, then the field to choose the number of seats to book will be hidden.', 'events-made-easy' ); ?></span></td>
     </tr>
     <tr id='row_take_attendance'>
         <td><label for='eme_prop_take_attendance'><?php esc_html_e( 'Attendance-only event?', 'events-made-easy' ); ?></label></td>
@@ -8845,7 +8845,7 @@ function eme_meta_box_div_event_rsvp( $event, $pdf_templates_array ) {
     </tr>
     <tr id='row_rsvppassword'>
         <td><label for='eme_prop_rsvp_password'><?php esc_html_e( 'RSVP Password', 'events-made-easy' ); ?></label></td>
-        <td><input id="eme_prop_rsvp_password" type="text" class="eme_passwordfield" autocomplete='off' name="eme_prop_rsvp_password" size='20' value="<?php echo eme_esc_html( $event['event_properties']['rsvp_password'] ); ?>"><p class="eme_smaller"><?php esc_html_e( 'A password required for RSVP submit to succeed. If used, #_PASSWORD is required in the RSVP form too.', 'events-made-easy' ); ?></p></td>
+        <td><input id="eme_prop_rsvp_password" type="text" class="eme_passwordfield" autocomplete='off' name="eme_prop_rsvp_password" size='20' value="<?php echo esc_html( $event['event_properties']['rsvp_password'] ); ?>"><p class="eme_smaller"><?php esc_html_e( 'A password required for RSVP submit to succeed. If used, #_PASSWORD is required in the RSVP form too.', 'events-made-easy' ); ?></p></td>
     </tr>
     <tr id='row_inviteonly'>
         <td><label for='eme_prop_invite_only'><?php esc_html_e( 'Invite-only event?', 'events-made-easy' ); ?></label></td>
@@ -8896,12 +8896,12 @@ function eme_meta_box_div_event_rsvp( $event, $pdf_templates_array ) {
     </p>
     <p id='span_rsvp_cutoff'>
         <?php esc_html_e( 'RSVP cancel cutoff before event starts', 'events-made-easy' ); ?>
-        <input id="eme_prop_cancel_rsvp_days" type="text" name="eme_prop_cancel_rsvp_days" size='4' value="<?php echo eme_esc_html( $event['event_properties']['cancel_rsvp_days'] ); ?>">
+        <input id="eme_prop_cancel_rsvp_days" type="text" name="eme_prop_cancel_rsvp_days" size='4' value="<?php echo esc_html( $event['event_properties']['cancel_rsvp_days'] ); ?>">
         <span class="eme_smaller"><?php esc_html_e( 'Allow RSVP cancellation until this many days before the event starts.', 'events-made-easy' ); ?></span>
         <span id="rsvp-cancel-end-display" style="background-color: lightgrey;"></span>
         <br>
         <?php esc_html_e( 'RSVP cancel cutoff booking age', 'events-made-easy' ); ?>
-        <input id="eme_prop_cancel_rsvp_age" type="text" name="eme_prop_cancel_rsvp_age" size='4' value="<?php echo eme_esc_html( $event['event_properties']['cancel_rsvp_age'] ); ?>">
+        <input id="eme_prop_cancel_rsvp_age" type="text" name="eme_prop_cancel_rsvp_age" size='4' value="<?php echo esc_html( $event['event_properties']['cancel_rsvp_age'] ); ?>">
         <span class="eme_smaller"><?php esc_html_e( 'Allow RSVP cancellation until this many days after the booking has been made.', 'events-made-easy' ); ?></span>
     </p>
 </div>
@@ -10803,7 +10803,7 @@ function eme_ajax_events_snapselect() {
     header( 'Content-type: application/json; charset=utf-8' );
     check_ajax_referer( 'eme_admin', 'eme_admin_nonce' );
     if ( ! current_user_can( get_option( 'eme_cap_list_events' ) ) ) {
-        print wp_json_encode( [ 'Result' => 'Error', 'Message' => __( 'Access denied!', 'events-made-easy' ) ] );
+        print wp_json_encode( [ 'Result' => 'Error', 'Message' => esc_html__( 'Access denied!', 'events-made-easy' ) ] );
         wp_die();
     }
     $current_userid = get_current_user_id();

--- a/eme-functions.php
+++ b/eme-functions.php
@@ -4113,7 +4113,7 @@ function eme_wysiwyg_textarea( $name, $value, $show_wp_editor = 0, $show_full = 
         switch ( $html_editor ) {
             case 'jodit':
                 ?>
-                <textarea class="eme-editor" name="<?php echo esc_attr( $name ); ?>" id="<?php echo esc_attr( $editor_id ); ?>" rows="6" <?php echo $data_default; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- pre-escaped with esc_attr() on line 4094 ?>><?php echo eme_esc_html( $value ); ?></textarea>
+                <textarea class="eme-editor" name="<?php echo esc_attr( $name ); ?>" id="<?php echo esc_attr( $editor_id ); ?>" rows="6" <?php echo $data_default; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- pre-escaped with esc_attr() on line 4094 ?>><?php echo esc_html( $value ); ?></textarea>
                 <?php
                 break;
             default: // the original tinymce goes here
@@ -4126,7 +4126,7 @@ function eme_wysiwyg_textarea( $name, $value, $show_wp_editor = 0, $show_full = 
         }
     } else { 
         ?>
-        <textarea name="<?php echo esc_attr( $name ); ?>" id="<?php echo esc_attr( $editor_id ); ?>" rows="6" style="width: 95%"><?php echo eme_esc_html( $value ); ?></textarea>
+        <textarea name="<?php echo esc_attr( $name ); ?>" id="<?php echo esc_attr( $editor_id ); ?>" rows="6" style="width: 95%"><?php echo esc_html( $value ); ?></textarea>
         <?php
     }
 }

--- a/eme-locations.php
+++ b/eme-locations.php
@@ -379,7 +379,7 @@ function eme_locations_edit_layout( $location, $message = '' ) {
     if ( $action == 'add' ) {
         esc_html_e( 'Insert New Location', 'events-made-easy' );
     } else {
-        echo sprintf( __( "Edit Location '%s'", 'events-made-easy' ), esc_html( eme_translate( $location['location_name'] ) ) );
+        printf( esc_html__( "Edit Location '%s'", 'events-made-easy' ), esc_html( eme_translate( $location['location_name'] ) ) );
     }
 ?>
         </h1>
@@ -553,27 +553,27 @@ function eme_meta_box_div_location_details( $location ) {
             <div class="inside" style="float:left; width:50%">
             <table><tr>
             <td><label for="location_address1"><?php echo eme_translate( get_option( 'eme_address1_string' ) ); ?></label></td>
-            <td><input id="location_address1" name="location_address1" type="text" value="<?php echo eme_esc_html( $location['location_address1'] ); ?>" size="40"></td>
+            <td><input id="location_address1" name="location_address1" type="text" value="<?php echo esc_html( $location['location_address1'] ); ?>" size="40"></td>
             </tr>
             <tr>
             <td><label for="location_address2"><?php echo eme_translate( get_option( 'eme_address2_string' ) ); ?></label></td>
-            <td><input id="location_address2" name="location_address2" type="text" value="<?php echo eme_esc_html( $location['location_address2'] ); ?>" size="40"></td>
+            <td><input id="location_address2" name="location_address2" type="text" value="<?php echo esc_html( $location['location_address2'] ); ?>" size="40"></td>
             </tr>
             <tr>
             <td><label for="location_city"><?php esc_html_e( 'City', 'events-made-easy' ); ?></label></td>
-            <td><input name="location_city" id="location_city" type="text" value="<?php echo eme_esc_html( $location['location_city'] ); ?>" size="40"></td>
+            <td><input name="location_city" id="location_city" type="text" value="<?php echo esc_html( $location['location_city'] ); ?>" size="40"></td>
             </tr>
             <tr>
             <td><label for="location_state"><?php esc_html_e( 'State', 'events-made-easy' ); ?></label></td>
-            <td><input name="location_state" id="location_state" type="text" value="<?php echo eme_esc_html( $location['location_state'] ); ?>" size="40"></td>
+            <td><input name="location_state" id="location_state" type="text" value="<?php echo esc_html( $location['location_state'] ); ?>" size="40"></td>
             </tr>
             <tr>
             <td><label for="location_zip"><?php esc_html_e( 'Postal code', 'events-made-easy' ); ?></label></td>
-            <td><input name="location_zip" id="location_zip" type="text" value="<?php echo eme_esc_html( $location['location_zip'] ); ?>" size="40"></td>
+            <td><input name="location_zip" id="location_zip" type="text" value="<?php echo esc_html( $location['location_zip'] ); ?>" size="40"></td>
             </tr>
             <tr>
             <td><label for="location_country"><?php esc_html_e( 'Country', 'events-made-easy' ); ?></label></td>
-            <td><input name="location_country" id="location_country" type="text" value="<?php echo eme_esc_html( $location['location_country'] ); ?>" size="40"></td>
+            <td><input name="location_country" id="location_country" type="text" value="<?php echo esc_html( $location['location_country'] ); ?>" size="40"></td>
             </tr>
             <tr>
             <td colspan='2'>
@@ -586,11 +586,11 @@ function eme_meta_box_div_location_details( $location ) {
             </tr>
             <tr>
             <td><label for="location_latitude"><?php esc_html_e( 'Latitude', 'events-made-easy' ); ?></label></td>
-            <td><input id="location_latitude" name="location_latitude" type="text" value="<?php echo eme_esc_html( $location['location_latitude'] ); ?>" size="40"></td>
+            <td><input id="location_latitude" name="location_latitude" type="text" value="<?php echo esc_html( $location['location_latitude'] ); ?>" size="40"></td>
             </tr>
             <tr>
             <td><label for="location_longitude"><?php esc_html_e( 'Longitude', 'events-made-easy' ); ?></label></td>
-            <td><input id="location_longitude" name="location_longitude" type="text" value="<?php echo eme_esc_html( $location['location_longitude'] ); ?>" size="40"></td>
+            <td><input id="location_longitude" name="location_longitude" type="text" value="<?php echo esc_html( $location['location_longitude'] ); ?>" size="40"></td>
             </tr></table>
             </div>
             <div class="inside" style="float:left;">
@@ -625,7 +625,7 @@ function eme_meta_box_div_location_details( $location ) {
             <div class="inside">
             <table><tr>
             <td><label for="eme_loc_prop_map_icon"><?php esc_html_e( 'Map icon url', 'events-made-easy' ); ?></label></td>
-        <td><input id="eme_loc_prop_map_icon" name="eme_loc_prop_map_icon" type="text" value="<?php echo eme_esc_html( $location['location_properties']['map_icon'] ); ?>" size="40">
+        <td><input id="eme_loc_prop_map_icon" name="eme_loc_prop_map_icon" type="text" value="<?php echo esc_html( $location['location_properties']['map_icon'] ); ?>" size="40">
         <br><?php esc_html_e( "By default a regular pin is shown on the map where the location is. If you don't like the default, you can set another map icon here.", 'events-made-easy' ); ?>
         <br><?php esc_html_e( 'Size should be 32x32, bottom center will be pointing to the location on the map.', 'events-made-easy' ); ?>
             </td>
@@ -724,7 +724,7 @@ function eme_meta_box_div_location_url( $location ) {
     <table>
     <tr>
     <td><label for="location_url"><?php esc_html_e( 'External URL', 'events-made-easy' ); ?></label></td>
-    <td><input id="location_url" name="location_url" type="text" value="<?php echo eme_esc_html( $location['location_url'] ); ?>" size="40">
+    <td><input id="location_url" name="location_url" type="text" value="<?php echo esc_html( $location['location_url'] ); ?>" size="40">
     </td>
     </tr>
     <tr>

--- a/eme-mailer.php
+++ b/eme-mailer.php
@@ -2887,7 +2887,7 @@ function eme_emails_page() {
             echo '</div>';
         }
     } else {
-        echo "<textarea name='event_mail_message' id='event_mail_message' rows='10' required='required'>" . eme_esc_html( $event_mail_message ) . '</textarea>';
+        echo "<textarea name='event_mail_message' id='event_mail_message' rows='10' required='required'>" . esc_html( $event_mail_message ) . '</textarea>';
     }
 ?>
         </div>
@@ -2896,10 +2896,10 @@ function eme_emails_page() {
     esc_html_e( 'You can use any placeholders mentioned here:', 'events-made-easy' );
     print "<br><a href='//www.e-dynamics.be/wordpress/?cat=25'>" . esc_html__( 'Event placeholders', 'events-made-easy' ) . '</a>';
     print "<br><a href='//www.e-dynamics.be/wordpress/category/documentation/7-placeholders/7-12-people/'>" . esc_html__( 'People placeholders', 'events-made-easy' ) . '</a>';
-    print "<br><a href='//www.e-dynamics.be/wordpress/?cat=48'>" . esc_html__( 'Attendees placeholders', 'events-made-easy' ) . '</a> (' . __( 'for ', 'events-made-easy' ) . __( 'Attendee emails', 'events-made-easy' ) . ')';
-    print "<br><a href='//www.e-dynamics.be/wordpress/?cat=45'>" . esc_html__( 'Booking placeholders', 'events-made-easy' ) . '</a> (' . __( 'for ', 'events-made-easy' ) . __( 'Booking emails', 'events-made-easy' ) . ')';
-    print "<br><a href='//www.e-dynamics.be/wordpress/category/documentation/7-placeholders/7-14-members/'>" . esc_html__( 'Member placeholders', 'events-made-easy' ) . '</a> (' . __( 'if you selected members, memberships or member groups', 'events-made-easy' ) . ')';
-    print '<br>' . __( 'You can also use any shortcode you want.', 'events-made-easy' );
+    print "<br><a href='//www.e-dynamics.be/wordpress/?cat=48'>" . esc_html__( 'Attendees placeholders', 'events-made-easy' ) . '</a> (' . esc_html__( 'for ', 'events-made-easy' ) . esc_html__( 'Attendee emails', 'events-made-easy' ) . ')';
+    print "<br><a href='//www.e-dynamics.be/wordpress/?cat=45'>" . esc_html__( 'Booking placeholders', 'events-made-easy' ) . '</a> (' . esc_html__( 'for ', 'events-made-easy' ) . esc_html__( 'Booking emails', 'events-made-easy' ) . ')';
+    print "<br><a href='//www.e-dynamics.be/wordpress/category/documentation/7-placeholders/7-14-members/'>" . esc_html__( 'Member placeholders', 'events-made-easy' ) . '</a> (' . esc_html__( 'if you selected members, memberships or member groups', 'events-made-easy' ) . ')';
+    print '<br>' . esc_html__( 'You can also use any shortcode you want.', 'events-made-easy' );
 ?>
         </p></div>
             <hr>
@@ -2956,7 +2956,7 @@ function eme_emails_page() {
 ?>
             <div class='eme-message-admin'><p>
 <?php
-            printf( __( 'Email queueing has been activated but not scheduled. Go in the <a href="%s">Email settings</a> and select a schedule or make sure to run the registered REST API call from system cron with the appropriate options to process the queue.', 'events-made-easy' ), esc_url( admin_url( 'admin.php?page=eme-options&tab=mail' ) ) );
+            printf( wp_kses_post( __( 'Email queueing has been activated but not scheduled. Go in the <a href="%s">Email settings</a> and select a schedule or make sure to run the registered REST API call from system cron with the appropriate options to process the queue.', 'events-made-easy' ) ), esc_url( admin_url( 'admin.php?page=eme-options&tab=mail' ) ) );
 ?>
                 </p></div>
 <?php
@@ -3071,16 +3071,16 @@ function eme_emails_page() {
                 echo '</div>';
             }
         } else {
-            echo "<textarea name='generic_mail_message' id='generic_mail_message' rows='10' required='required'>" . eme_esc_html( $generic_mail_message ) . '</textarea>';
+            echo "<textarea name='generic_mail_message' id='generic_mail_message' rows='10' required='required'>" . esc_html( $generic_mail_message ) . '</textarea>';
         }
 ?>
         </div>
         <div>
 <?php
         esc_html_e( 'You can use any placeholders mentioned here:', 'events-made-easy' );
-        print "<br><a href='//www.e-dynamics.be/wordpress/category/documentation/7-placeholders/7-12-people/'>" . esc_html__( 'People placeholders', 'events-made-easy' ) . '</a> (' . __( 'for ', 'events-made-easy' ) . __( 'People or groups', 'events-made-easy' ) . ')';
-        print "<br><a href='//www.e-dynamics.be/wordpress/category/documentation/7-placeholders/7-14-members/'>" . esc_html__( 'Member placeholders', 'events-made-easy' ) . '</a> (' . __( 'for ', 'events-made-easy' ) . __( 'members', 'events-made-easy' ) . ')';
-        print '<br>' . __( 'You can also use any shortcode you want.', 'events-made-easy' );
+        print "<br><a href='//www.e-dynamics.be/wordpress/category/documentation/7-placeholders/7-12-people/'>" . esc_html__( 'People placeholders', 'events-made-easy' ) . '</a> (' . esc_html__( 'for ', 'events-made-easy' ) . esc_html__( 'People or groups', 'events-made-easy' ) . ')';
+        print "<br><a href='//www.e-dynamics.be/wordpress/category/documentation/7-placeholders/7-14-members/'>" . esc_html__( 'Member placeholders', 'events-made-easy' ) . '</a> (' . esc_html__( 'for ', 'events-made-easy' ) . esc_html__( 'members', 'events-made-easy' ) . ')';
+        print '<br>' . esc_html__( 'You can also use any shortcode you want.', 'events-made-easy' );
 ?>
         </div>
             <hr>
@@ -3138,7 +3138,7 @@ function eme_emails_page() {
 ?>
             <div class='eme-message-admin'><p>
 <?php
-                printf( __( 'Email queueing has been activated but not scheduled. Go in the <a href="%s">Email settings</a> and select a schedule or make sure to run the registered REST API call from system cron with the appropriate options to process the queue.', 'events-made-easy' ), esc_url( admin_url( 'admin.php?page=eme-options&tab=mail' ) ) );
+                printf( wp_kses_post( __( 'Email queueing has been activated but not scheduled. Go in the <a href="%s">Email settings</a> and select a schedule or make sure to run the registered REST API call from system cron with the appropriate options to process the queue.', 'events-made-easy' ) ), esc_url( admin_url( 'admin.php?page=eme-options&tab=mail' ) ) );
 ?>
                 </p></div>
 <?php

--- a/eme-members.php
+++ b/eme-members.php
@@ -1584,7 +1584,7 @@ function eme_admin_edit_memberform( $member, $membership_id, $limited = 0 ) {
         <tr><td><?php esc_html_e( 'Membership', 'events-made-easy' ); ?></td>
         <td>
 <?php
-                    echo eme_esc_html( $membership['name'] );
+                    echo esc_html( $membership['name'] );
 ?>
     </td></tr>
     <?php if ( ! empty( $membership['properties']['family_membership'] ) ) { ?>
@@ -1605,7 +1605,7 @@ function eme_admin_edit_memberform( $member, $membership_id, $limited = 0 ) {
                      if ( $related_member ) {
                          $related_person = eme_get_person( $related_member['person_id'] );
                          if ( $related_person ) {
-                             print "<br><a href='" . esc_url( admin_url( "admin.php?page=eme-members&eme_admin_action=edit_member&member_id=$related_member_id" ) ) . "' title='" . esc_attr__( 'Edit member', 'events-made-easy' ) . "'>" . eme_esc_html( eme_format_full_name( $related_person['firstname'], $related_person['lastname'], $related_person['email'] ) ) . '</a>';
+                             print "<br><a href='" . esc_url( admin_url( "admin.php?page=eme-members&eme_admin_action=edit_member&member_id=$related_member_id" ) ) . "' title='" . esc_attr__( 'Edit member', 'events-made-easy' ) . "'>" . esc_html( eme_format_full_name( $related_person['firstname'], $related_person['lastname'], $related_person['email'] ) ) . '</a>';
                          }
                      }
                  }
@@ -1818,7 +1818,7 @@ function eme_membership_edit_layout( $membership, $message = '' ) {
     if ( $is_new_membership == 1 ) {
         esc_html_e( 'Add a membership definition', 'events-made-easy' );
     } else {
-        echo sprintf( __( "Edit membership '%s'", 'events-made-easy' ), eme_esc_html( $membership['name'] ) );
+        printf( esc_html__( "Edit membership '%s'", 'events-made-easy' ), esc_html( $membership['name'] ) );
     }
 ?>
             </h1>
@@ -1890,11 +1890,11 @@ function eme_meta_box_div_membershipdetails( $membership, $is_new_membership ) {
     <table class="eme_membership_admin_table">
     <tr>
     <td><label for="name"><?php esc_html_e( 'Name', 'events-made-easy' ); ?></label></td>
-    <td><input required='required' id="name" name="name" type="text" value="<?php echo eme_esc_html( $membership['name'] ); ?>" size="40"></td>
+    <td><input required='required' id="name" name="name" type="text" value="<?php echo esc_html( $membership['name'] ); ?>" size="40"></td>
     </tr>
     <tr>
     <td><label for="description"><?php esc_html_e( 'Description', 'events-made-easy' ); ?></label></td>
-    <td><input id="description" name="description" type="text" value="<?php echo eme_esc_html( $membership['description'] ); ?>" size="40"></td>
+    <td><input id="description" name="description" type="text" value="<?php echo esc_html( $membership['description'] ); ?>" size="40"></td>
     </tr>
     <tr>
     <td><label for="type"><?php esc_html_e( 'Type', 'events-made-easy' ); ?></label></td>
@@ -1982,13 +1982,13 @@ function eme_meta_box_div_membershipdetails( $membership, $is_new_membership ) {
     </tr>
     <tr>
     <td><label for="price"><?php esc_html_e( 'Price', 'events-made-easy' ); ?></label></td>
-    <td><input id="price" name="properties[price]" type="text" value="<?php echo eme_esc_html( $membership['properties']['price'] ); ?>" size="4">
+    <td><input id="price" name="properties[price]" type="text" value="<?php echo esc_html( $membership['properties']['price'] ); ?>" size="4">
     <span class="eme_smaller"><br><?php esc_html_e( 'Use the point as decimal separator', 'events-made-easy' ); ?></span>
     </td>
     </tr>
     <tr>
     <td><label for="extra_charge"><?php esc_html_e( 'Extra charge for new members', 'events-made-easy' ); ?></label></td>
-    <td><input id="extra_charge" name="properties[extra_charge]" type="text" value="<?php echo eme_esc_html( $membership['properties']['extra_charge'] ); ?>" size="4">
+    <td><input id="extra_charge" name="properties[extra_charge]" type="text" value="<?php echo esc_html( $membership['properties']['extra_charge'] ); ?>" size="4">
     <span class="eme_smaller"><br><?php esc_html_e( 'Use the point as decimal separator', 'events-made-easy' ); ?></span>
     </td>
     </tr>
@@ -1998,7 +1998,7 @@ function eme_meta_box_div_membershipdetails( $membership, $is_new_membership ) {
     </tr>
     <tr>
     <td><label for="vat_pct"><?php esc_html_e( 'VAT percentage', 'events-made-easy' ); ?></label></td>
-    <td><input id="vat_pct" name="properties[vat_pct]" type="text" value="<?php echo eme_esc_html( $membership['properties']['vat_pct'] ); ?>" size="4">%
+    <td><input id="vat_pct" name="properties[vat_pct]" type="text" value="<?php echo esc_html( $membership['properties']['vat_pct'] ); ?>" size="4">%
         <br><p class='eme_smaller'><?php esc_html_e( 'The price you indicate for memberships is VAT included, special placeholders are foreseen to indicate the price without VAT.', 'events-made-easy' ); ?></p>
     </td>
     </tr>
@@ -2246,7 +2246,7 @@ function eme_meta_box_div_membershipmailformats( $membership ) {
     <table class="eme_membership_admin_table">
     <tr>
     <td><label for="properties[new_subject_format]"><?php esc_html_e( 'New member email subject', 'events-made-easy' ); ?></label></td>
-    <td><input id="properties[new_subject_format]" name="properties[new_subject_format]" type="text" value="<?php echo eme_esc_html( $membership['properties']['new_subject_format'] ); ?>" size="40">
+    <td><input id="properties[new_subject_format]" name="properties[new_subject_format]" type="text" value="<?php echo esc_html( $membership['properties']['new_subject_format'] ); ?>" size="40">
         <br><p class='eme_smaller'><?php esc_html_e( 'The subject of the mail sent to the person signing up as a member.', 'events-made-easy' ); ?></p>
         <br>
     </td>
@@ -2316,7 +2316,7 @@ function eme_meta_box_div_membershipmailformats( $membership ) {
     </tr>
     <tr>
     <td><label for="properties[contact_new_subject_format]"><?php esc_html_e( 'Contactperson new member email subject', 'events-made-easy' ); ?></label></td>
-    <td><input id="properties[contact_new_subject_format]" name="properties[contact_new_subject_format]" type="text" value="<?php echo eme_esc_html( $membership['properties']['contact_new_subject_format'] ); ?>" size="40">
+    <td><input id="properties[contact_new_subject_format]" name="properties[contact_new_subject_format]" type="text" value="<?php echo esc_html( $membership['properties']['contact_new_subject_format'] ); ?>" size="40">
         <br><p class='eme_smaller'><?php esc_html_e( 'The subject of the mail sent to the contactperson when someone signes up as a member.', 'events-made-easy' ); ?></p>
         <br>
     </td>
@@ -2352,7 +2352,7 @@ function eme_meta_box_div_membershipmailformats( $membership ) {
     <table class="eme_membership_admin_table">
     <tr>
     <td><label for="name"><?php esc_html_e( 'Updated member email subject', 'events-made-easy' ); ?></label></td>
-    <td><input id="properties[updated_subject_format]" name="properties[updated_subject_format]" type="text" value="<?php echo eme_esc_html( $membership['properties']['updated_subject_format'] ); ?>" size="40">
+    <td><input id="properties[updated_subject_format]" name="properties[updated_subject_format]" type="text" value="<?php echo esc_html( $membership['properties']['updated_subject_format'] ); ?>" size="40">
         <br><p class='eme_smaller'><?php esc_html_e( 'The subject of the mail sent to the member upon changes.', 'events-made-easy' ); ?></p>
         <br><p class='eme_smaller'><?php esc_html_e( 'Currently only used when a member is manually marked as unpaid.', 'events-made-easy' ); ?></p>
     </td>
@@ -2390,7 +2390,7 @@ function eme_meta_box_div_membershipmailformats( $membership ) {
     <table class="eme_membership_admin_table">
     <tr>
     <td><label for="name"><?php esc_html_e( 'Membership extended email subject', 'events-made-easy' ); ?></label></td>
-    <td><input id="properties[extended_subject_format]" name="properties[extended_subject_format]" type="text" value="<?php echo eme_esc_html( $membership['properties']['extended_subject_format'] ); ?>" size="40">
+    <td><input id="properties[extended_subject_format]" name="properties[extended_subject_format]" type="text" value="<?php echo esc_html( $membership['properties']['extended_subject_format'] ); ?>" size="40">
         <br><p class='eme_smaller'><?php esc_html_e( 'The subject of the mail sent to the member when the membership is extended.', 'events-made-easy' ); ?></p>
         <br>
     </td>
@@ -2469,7 +2469,7 @@ function eme_meta_box_div_membershipmailformats( $membership ) {
     <table class="eme_membership_admin_table">
     <tr>
     <td><label for="name"><?php esc_html_e( 'Membership paid email subject', 'events-made-easy' ); ?></label></td>
-    <td><input id="properties[paid_subject_format]" name="properties[paid_subject_format]" type="text" value="<?php echo eme_esc_html( $membership['properties']['paid_subject_format'] ); ?>" size="40">
+    <td><input id="properties[paid_subject_format]" name="properties[paid_subject_format]" type="text" value="<?php echo esc_html( $membership['properties']['paid_subject_format'] ); ?>" size="40">
         <br><p class='eme_smaller'><?php esc_html_e( 'The subject of the mail sent to the member when marked as paid.', 'events-made-easy' ); ?></p>
         <br>
     </td>
@@ -2539,7 +2539,7 @@ function eme_meta_box_div_membershipmailformats( $membership ) {
     </tr>
     <tr>
     <td><label for="name"><?php esc_html_e( 'Contactperson membership paid email subject', 'events-made-easy' ); ?></label></td>
-    <td><input id="properties[contact_paid_subject_format]" name="properties[contact_paid_subject_format]" type="text" value="<?php echo eme_esc_html( $membership['properties']['contact_paid_subject_format'] ); ?>" size="40">
+    <td><input id="properties[contact_paid_subject_format]" name="properties[contact_paid_subject_format]" type="text" value="<?php echo esc_html( $membership['properties']['contact_paid_subject_format'] ); ?>" size="40">
         <br><p class='eme_smaller'><?php esc_html_e( 'The subject of the mail sent to the contactperson after a member is marked as paid.', 'events-made-easy' ); ?></p>
         <br>
     </td>
@@ -2576,7 +2576,7 @@ function eme_meta_box_div_membershipmailformats( $membership ) {
     <table class="eme_membership_admin_table">
     <tr>
     <td><label for="name"><?php esc_html_e( 'Membership reminder email subject', 'events-made-easy' ); ?></label></td>
-    <td><input id="properties[reminder_subject_format]" name="properties[reminder_subject_format]" type="text" value="<?php echo eme_esc_html( $membership['properties']['reminder_subject_format'] ); ?>" size="40">
+    <td><input id="properties[reminder_subject_format]" name="properties[reminder_subject_format]" type="text" value="<?php echo esc_html( $membership['properties']['reminder_subject_format'] ); ?>" size="40">
         <br><p class='eme_smaller'><?php esc_html_e( 'The subject of the mail sent to the member when membership is about to expire. These reminders will be sent once a day, based on the reminder settings of the defined membership.', 'events-made-easy' ); ?>
         <br><?php esc_html_e( 'This reminder email does NOT take into account an optional grace period.', 'events-made-easy' ); ?>
         </p>
@@ -2616,7 +2616,7 @@ function eme_meta_box_div_membershipmailformats( $membership ) {
     <table class="eme_membership_admin_table">
     <tr>
     <td><label for="name"><?php esc_html_e( 'Membership stopped email subject', 'events-made-easy' ); ?></label></td>
-    <td><input id="properties[stop_subject_format]" name="properties[stop_subject_format]" type="text" value="<?php echo eme_esc_html( $membership['properties']['stop_subject_format'] ); ?>" size="40">
+    <td><input id="properties[stop_subject_format]" name="properties[stop_subject_format]" type="text" value="<?php echo esc_html( $membership['properties']['stop_subject_format'] ); ?>" size="40">
         <br><p class='eme_smaller'><?php esc_html_e( 'The subject of the mail sent to the member when a membership has expired or is marked as stopped.', 'events-made-easy' ); ?>
         <br><?php esc_html_e( 'If a grace period is defined for the membership, the expiry email is only sent at the end of the grace period.', 'events-made-easy' ); ?>
         </p>
@@ -2647,7 +2647,7 @@ function eme_meta_box_div_membershipmailformats( $membership ) {
     </tr>
     <tr>
     <td><label for="name"><?php esc_html_e( 'Contactperson membership stopped email subject', 'events-made-easy' ); ?></label></td>
-    <td><input id="properties[contact_stop_subject_format]" name="properties[contact_stop_subject_format]" type="text" value="<?php echo eme_esc_html( $membership['properties']['contact_stop_subject_format'] ); ?>" size="40">
+    <td><input id="properties[contact_stop_subject_format]" name="properties[contact_stop_subject_format]" type="text" value="<?php echo esc_html( $membership['properties']['contact_stop_subject_format'] ); ?>" size="40">
         <br><p class='eme_smaller'><?php esc_html_e( 'The subject of the mail sent to the contactperson when a membership has expired or is stopped.', 'events-made-easy' ); ?>
                     <br><?php esc_html_e( 'If a grace period is defined for the membership, the expiry email is only sent at the end of the grace period.', 'events-made-easy' ); ?>
             </p>
@@ -2686,7 +2686,7 @@ function eme_meta_box_div_membershipmailformats( $membership ) {
     <table class="eme_membership_admin_table">
     <tr>
     <td><label for="name"><?php esc_html_e( 'Contactperson member deleted email subject', 'events-made-easy' ); ?></label></td>
-    <td><input id="properties[contact_deleted_subject_format]" name="properties[contact_deleted_subject_format]" type="text" value="<?php echo eme_esc_html( $membership['properties']['contact_deleted_subject_format'] ); ?>" size="40">
+    <td><input id="properties[contact_deleted_subject_format]" name="properties[contact_deleted_subject_format]" type="text" value="<?php echo esc_html( $membership['properties']['contact_deleted_subject_format'] ); ?>" size="40">
         <br><p class='eme_smaller'><?php esc_html_e( 'The subject of the mail sent to the contactperson just before a member is deleted.', 'events-made-easy' ); ?>
             </p>
         <br>
@@ -2723,7 +2723,7 @@ function eme_meta_box_div_membershipmailformats( $membership ) {
     <table class="eme_membership_admin_table">
     <tr>
     <td><label for="name"><?php esc_html_e( 'Contactperson payment notification email subject', 'events-made-easy' ); ?></label></td>
-    <td><input id="properties[contact_ipn_subject_format]" name="properties[contact_ipn_subject_format]" type="text" value="<?php echo eme_esc_html( $membership['properties']['contact_ipn_subject_format'] ); ?>" size="40">
+    <td><input id="properties[contact_ipn_subject_format]" name="properties[contact_ipn_subject_format]" type="text" value="<?php echo esc_html( $membership['properties']['contact_ipn_subject_format'] ); ?>" size="40">
         <br><p class='eme_smaller'><?php esc_html_e( 'The subject of the email that will be sent to the contact person when a payment notification is received via a payment gateway.', 'events-made-easy' ); ?></p>
         <br>
     </td>

--- a/eme-options.php
+++ b/eme-options.php
@@ -1448,7 +1448,7 @@ function eme_explain_slug_conflict( $conflict_found ) {
         } else {
             esc_html_e( 'The EME SEO permalink settings are conflicting with an existing page (the permalink setting for either events, locations or categories is identical with the permalink of another WordPress page). This might cause problems rendering either events or that page. Please resolve the conflict by either changing your EME SEO permalink settings or the permalink of the conflicting page.', 'events-made-easy' );
             echo '<br>';
-            echo sprintf( __( 'The conflicting page can be edited <a href="%s" target="_blank">here</a>.', 'events-made-easy' ), esc_url( admin_url( "post.php?post=$conflict_found&action=edit" ) ) );
+            printf( wp_kses_post( __( 'The conflicting page can be edited <a href="%s" target="_blank">here</a>.', 'events-made-easy' ) ), esc_url( admin_url( "post.php?post=$conflict_found&action=edit" ) ) );
         }
         ?>
         </p></div>
@@ -1466,7 +1466,7 @@ function eme_options_page() {
     ?>
 <div class="wrap">
 <form id="eme_options_form" method="post" action="options.php" autocomplete="off">
-<input type='hidden' name='tab' value='<?php echo eme_esc_html( $tab ); ?>'>
+<input type='hidden' name='tab' value='<?php echo esc_html( $tab ); ?>'>
     <?php
     settings_fields( 'eme-options' );
     switch ( $tab ) {
@@ -1475,7 +1475,7 @@ function eme_options_page() {
 
 <h2><?php esc_html_e( 'General options', 'events-made-easy' ); ?></h2>
 <p> 
-    <?php printf( __( "Please also check <a href='%s'>your profile</a> for some per-user EME settings.", 'events-made-easy' ), esc_url( admin_url( 'profile.php' ) ) ); ?>
+    <?php printf( wp_kses_post( __( "Please also check <a href='%s'>your profile</a> for some per-user EME settings.", 'events-made-easy' ) ), esc_url( admin_url( 'profile.php' ) ) ); ?>
 </p>
 <table class="form-table">
             <?php
@@ -1739,11 +1739,11 @@ function eme_options_page() {
 <h2><?php esc_html_e( 'Events format', 'events-made-easy' ); ?></h2>
 <table class="form-table">
 <?php
-            eme_options_textarea( __( 'Default event list format header', 'events-made-easy' ), 'eme_event_list_item_format_header', sprintf( __( 'This content will appear just above your code for the default event list format. If you leave this empty, the value <code>%s</code> will be used.', 'events-made-easy' ), eme_esc_html( DEFAULT_EVENT_LIST_HEADER_FORMAT ) ) );
-            eme_options_textarea( __( 'Default categories event list format header', 'events-made-easy' ), 'eme_cat_event_list_item_format_header', sprintf( __( 'This content will appear just above your code for the event list format when showing events for a specific category. If you leave this empty, the value <code>%s</code> will be used.', 'events-made-easy' ), eme_esc_html( DEFAULT_CAT_EVENT_LIST_HEADER_FORMAT ) ) );
+            eme_options_textarea( __( 'Default event list format header', 'events-made-easy' ), 'eme_event_list_item_format_header', sprintf( __( 'This content will appear just above your code for the default event list format. If you leave this empty, the value <code>%s</code> will be used.', 'events-made-easy' ), esc_html( DEFAULT_EVENT_LIST_HEADER_FORMAT ) ) );
+            eme_options_textarea( __( 'Default categories event list format header', 'events-made-easy' ), 'eme_cat_event_list_item_format_header', sprintf( __( 'This content will appear just above your code for the event list format when showing events for a specific category. If you leave this empty, the value <code>%s</code> will be used.', 'events-made-easy' ), esc_html( DEFAULT_CAT_EVENT_LIST_HEADER_FORMAT ) ) );
             eme_options_textarea( __( 'Default event list format', 'events-made-easy' ), 'eme_event_list_item_format', __( 'The format of any events in a list.', 'events-made-easy' ) . '<br>' . esc_html__( 'For all possible placeholders, see ', 'events-made-easy' ) . "<a target='_blank' href='//www.e-dynamics.be/wordpress/?cat=25'>" . esc_html__( 'the documentation', 'events-made-easy' ) . '</a>' );
-            eme_options_textarea( __( 'Default event list format footer', 'events-made-easy' ), 'eme_event_list_item_format_footer', sprintf( __( 'This content will appear just below your code for the default event list format. If you leave this empty, the value <code>%s</code> will be used.', 'events-made-easy' ), eme_esc_html( DEFAULT_EVENT_LIST_FOOTER_FORMAT ) ) );
-            eme_options_textarea( __( 'Default categories event list format footer', 'events-made-easy' ), 'eme_cat_event_list_item_format_footer', sprintf( __( 'This content will appear just below your code for the default event list format when showing events for a specific category. If you leave this empty, the value <code>%s</code> will be used.', 'events-made-easy' ), eme_esc_html( DEFAULT_CAT_EVENT_LIST_FOOTER_FORMAT ) ) );
+            eme_options_textarea( __( 'Default event list format footer', 'events-made-easy' ), 'eme_event_list_item_format_footer', sprintf( __( 'This content will appear just below your code for the default event list format. If you leave this empty, the value <code>%s</code> will be used.', 'events-made-easy' ), esc_html( DEFAULT_EVENT_LIST_FOOTER_FORMAT ) ) );
+            eme_options_textarea( __( 'Default categories event list format footer', 'events-made-easy' ), 'eme_cat_event_list_item_format_footer', sprintf( __( 'This content will appear just below your code for the default event list format when showing events for a specific category. If you leave this empty, the value <code>%s</code> will be used.', 'events-made-easy' ), esc_html( DEFAULT_CAT_EVENT_LIST_FOOTER_FORMAT ) ) );
             eme_options_input_text( __( 'Single event page title format', 'events-made-easy' ), 'eme_event_page_title_format', __( 'The format of the page title when viewing a single event. Follow the previous formatting instructions.', 'events-made-easy' ) );
             eme_options_input_text( __( 'Single event html title format', 'events-made-easy' ), 'eme_event_html_title_format', __( 'The format of the page html title when viewing a single event. Follow the previous formatting instructions.', 'events-made-easy' ) . __( 'If empty (the default), the value of "Single event page title format" will be used.', 'events-made-easy' ) );
             eme_options_textarea( __( 'Default single event format', 'events-made-easy' ), 'eme_single_event_format', __( 'The format of a single event page.<br>Follow the previous formatting instructions. <br>Use <code>#_MAP</code> to insert a map.<br>Use <code>#_CONTACTNAME</code>, <code>#_CONTACTEMAIL</code>, <code>#_CONTACTPHONE</code> to insert respectively the name, email address and phone number of the designated contact person. <br>Use <code>#_ADDBOOKINGFORM</code> to insert a form to allow the user to respond to your events booking one or more seats (RSVP).<br> Use <code>#_REMOVEBOOKINGFORM</code> to insert a form where users, inserting their name and email address, can remove their bookings.', 'events-made-easy' ) . __( '<br>Use <code>#_ADDBOOKINGFORM_IF_NOT_REGISTERED</code> to insert the booking form only if the user has not registered yet. Similar use <code>#_REMOVEBOOKINGFORM_IF_REGISTERED</code> to insert the booking removal form only if the user has already registered before. These two codes only work for WP users.', 'events-made-easy' ) . __( '<br> Use <code>#_DIRECTIONS</code> to insert a form so people can ask directions to the event.', 'events-made-easy' ) . __( '<br> Use <code>#_CATEGORIES</code> to insert a comma-separated list of categories an event is in.', 'events-made-easy' ) . __( '<br> Use <code>#_ATTENDEES</code> to get a list of the names attending the event.', 'events-made-easy' ) . '<br>' . esc_html__( 'For all possible placeholders, see ', 'events-made-easy' ) . "<a target='_blank' href='//www.e-dynamics.be/wordpress/?cat=25'>" . esc_html__( 'the documentation', 'events-made-easy' ) . '</a>', 1 );
@@ -1789,9 +1789,9 @@ function eme_options_page() {
 <h2><?php esc_html_e( 'Locations format', 'events-made-easy' ); ?></h2>
 <table class="form-table">
 <?php
-            eme_options_textarea( __( 'Default location list format header', 'events-made-easy' ), 'eme_location_list_format_header', sprintf( __( 'This content will appear just above your code for the default location list format. If you leave this empty, the value <code>%s</code> will be used.<br>Used by the shortcode <code>[eme_locations]</code>', 'events-made-easy' ), eme_esc_html( DEFAULT_LOCATION_LIST_HEADER_FORMAT ) ) );
-            eme_options_textarea( __( 'Default location list item format', 'events-made-easy' ), 'eme_location_list_format_item', sprintf( __( 'The format of a location in a location list. If you leave this empty, the value <code>%s</code> will be used.<br>See the documentation for a list of available placeholders for locations.<br>Used by the shortcode <code>[eme_locations]</code>', 'events-made-easy' ), eme_esc_html( DEFAULT_LOCATION_EVENT_LIST_ITEM_FORMAT ) ) . '<br>' . esc_html__( 'For all possible placeholders, see ', 'events-made-easy' ) . "<a target='_blank' href='//www.e-dynamics.be/wordpress/?cat=26'>" . esc_html__( 'the documentation', 'events-made-easy' ) . '</a>' );
-            eme_options_textarea( __( 'Default location list format footer', 'events-made-easy' ), 'eme_location_list_format_footer', sprintf( __( 'This content will appear just below your code for the default location list format. If you leave this empty, the value <code>%s</code> will be used.<br>Used by the shortcode <code>[eme_locations]</code>', 'events-made-easy' ), eme_esc_html( DEFAULT_LOCATION_LIST_FOOTER_FORMAT ) ) );
+            eme_options_textarea( __( 'Default location list format header', 'events-made-easy' ), 'eme_location_list_format_header', sprintf( __( 'This content will appear just above your code for the default location list format. If you leave this empty, the value <code>%s</code> will be used.<br>Used by the shortcode <code>[eme_locations]</code>', 'events-made-easy' ), esc_html( DEFAULT_LOCATION_LIST_HEADER_FORMAT ) ) );
+            eme_options_textarea( __( 'Default location list item format', 'events-made-easy' ), 'eme_location_list_format_item', sprintf( __( 'The format of a location in a location list. If you leave this empty, the value <code>%s</code> will be used.<br>See the documentation for a list of available placeholders for locations.<br>Used by the shortcode <code>[eme_locations]</code>', 'events-made-easy' ), esc_html( DEFAULT_LOCATION_EVENT_LIST_ITEM_FORMAT ) ) . '<br>' . esc_html__( 'For all possible placeholders, see ', 'events-made-easy' ) . "<a target='_blank' href='//www.e-dynamics.be/wordpress/?cat=26'>" . esc_html__( 'the documentation', 'events-made-easy' ) . '</a>' );
+            eme_options_textarea( __( 'Default location list format footer', 'events-made-easy' ), 'eme_location_list_format_footer', sprintf( __( 'This content will appear just below your code for the default location list format. If you leave this empty, the value <code>%s</code> will be used.<br>Used by the shortcode <code>[eme_locations]</code>', 'events-made-easy' ), esc_html( DEFAULT_LOCATION_LIST_FOOTER_FORMAT ) ) );
             eme_options_input_text( __( 'Single location page title format', 'events-made-easy' ), 'eme_location_page_title_format', __( 'The format of the page title when viewing a single location. Follow the previous formatting instructions.', 'events-made-easy' ) );
             eme_options_input_text( __( 'Single location html title format', 'events-made-easy' ), 'eme_location_html_title_format', __( 'The format of the page html title when viewing a single location. Follow the previous formatting instructions.', 'events-made-easy' ) . __( 'If empty (the default), the value of "Single location page title format" will be used.', 'events-made-easy' ) );
             eme_options_textarea( __( 'Default single location page format', 'events-made-easy' ), 'eme_single_location_format', __( 'The format of a single location page.', 'events-made-easy' ) . '<br>' . esc_html__( 'For all possible placeholders, see ', 'events-made-easy' ) . "<a target='_blank' href='//www.e-dynamics.be/wordpress/?cat=26'>" . esc_html__( 'the documentation', 'events-made-easy' ) . '</a>', 1 );
@@ -1870,8 +1870,8 @@ function eme_options_page() {
     <tr style='vertical-align:top' id='eme_rsvp_start_number_row'>
         <th scope="row"><?php esc_html_e( 'By default allow RSVP from', 'events-made-easy' ); ?></th>
         <td>
-        <input name="eme_rsvp_start_number_days" type="text" id="eme_rsvp_start_number_days" value="<?php echo eme_esc_html( $eme_rsvp_start_number_days ); ?>" size="4"> <?php esc_html_e( 'days', 'events-made-easy' ); ?>
-        <input name="eme_rsvp_start_number_hours" type="text" id="eme_rsvp_start_number_hours" value="<?php echo eme_esc_html( $eme_rsvp_start_number_hours ); ?>" size="4"> <?php esc_html_e( 'hours', 'events-made-easy' ); ?>
+        <input name="eme_rsvp_start_number_days" type="text" id="eme_rsvp_start_number_days" value="<?php echo esc_html( $eme_rsvp_start_number_days ); ?>" size="4"> <?php esc_html_e( 'days', 'events-made-easy' ); ?>
+        <input name="eme_rsvp_start_number_hours" type="text" id="eme_rsvp_start_number_hours" value="<?php echo esc_html( $eme_rsvp_start_number_hours ); ?>" size="4"> <?php esc_html_e( 'hours', 'events-made-easy' ); ?>
 <?php
             $eme_rsvp_start_target_list = [
                 'start' => __( 'starts', 'events-made-easy' ),
@@ -1886,8 +1886,8 @@ function eme_options_page() {
     <tr style='vertical-align:top' id='eme_rsvp_end_number_row'>
         <th scope="row"><?php esc_html_e( 'By default allow RSVP until this many', 'events-made-easy' ); ?></th>
         <td>
-        <input name="eme_rsvp_end_number_days" type="text" id="eme_rsvp_end_number_days" value="<?php echo eme_esc_html( $eme_rsvp_end_number_days ); ?>" size="4"> <?php esc_html_e( 'days', 'events-made-easy' ); ?>
-        <input name="eme_rsvp_end_number_hours" type="text" id="eme_rsvp_end_number_hours" value="<?php echo eme_esc_html( $eme_rsvp_end_number_hours ); ?>" size="4"> <?php esc_html_e( 'hours', 'events-made-easy' ); ?>
+        <input name="eme_rsvp_end_number_days" type="text" id="eme_rsvp_end_number_days" value="<?php echo esc_html( $eme_rsvp_end_number_days ); ?>" size="4"> <?php esc_html_e( 'days', 'events-made-easy' ); ?>
+        <input name="eme_rsvp_end_number_hours" type="text" id="eme_rsvp_end_number_hours" value="<?php echo esc_html( $eme_rsvp_end_number_hours ); ?>" size="4"> <?php esc_html_e( 'hours', 'events-made-easy' ); ?>
 <?php
             $eme_rsvp_end_target_list = [
                 'start' => __( 'starts', 'events-made-easy' ),
@@ -1918,9 +1918,9 @@ function eme_options_page() {
             eme_options_input_text( __( 'Person already registered text', 'events-made-easy' ), 'eme_rsvp_person_already_registered_string', __( 'The text shown if the person (combo of last name/first name/email) used to register is already used by another booking and the person is allowed to register once.', 'events-made-easy' ) . '<br>' . sprintf( __( "For all placeholders you can use here, see <a target='_blank' href='%s'>the documentation</a>", 'events-made-easy' ), '//www.e-dynamics.be/wordpress/category/documentation/7-placeholders/7-2-events/' ) );
             eme_options_input_text( __( 'Attendees list format', 'events-made-easy' ), 'eme_attendees_list_format', __( 'The format for the attendees list when using the <code>#_ATTENDEES</code> placeholder.', 'events-made-easy' ) . '<br>' . esc_html__( 'For all placeholders you can use here, see ', 'events-made-easy' ) . "<a target='_blank' href='//www.e-dynamics.be/wordpress/?cat=48'>" . esc_html__( 'the documentation', 'events-made-easy' ) . '</a>' );
             eme_options_toggle( __( 'Attendees/bookings list ignore pending', 'events-made-easy' ), 'eme_attendees_list_ignore_pending', __( 'Whether or not to ignore pending bookings when using the <code>#_ATTENDEES</code> or <code>#_BOOKINGS</code> placeholders.', 'events-made-easy' ) );
-            eme_options_input_text( __( 'Bookings list header format', 'events-made-easy' ), 'eme_bookings_list_header_format', __( 'The header format for the bookings list when using the <code>#_BOOKINGS</code> placeholder.', 'events-made-easy' ) . sprintf( __( " The default is '%s'", 'events-made-easy' ), eme_esc_html( DEFAULT_BOOKINGS_LIST_HEADER_FORMAT ) ) );
+            eme_options_input_text( __( 'Bookings list header format', 'events-made-easy' ), 'eme_bookings_list_header_format', __( 'The header format for the bookings list when using the <code>#_BOOKINGS</code> placeholder.', 'events-made-easy' ) . sprintf( __( " The default is '%s'", 'events-made-easy' ), esc_html( DEFAULT_BOOKINGS_LIST_HEADER_FORMAT ) ) );
             eme_options_input_text( __( 'Bookings list format', 'events-made-easy' ), 'eme_bookings_list_format', __( 'The format for the bookings list when using the <code>#_BOOKINGS</code> placeholder.', 'events-made-easy' ) . '<br>' . esc_html__( 'For all placeholders you can use here, see ', 'events-made-easy' ) . "<a target='_blank' href='//www.e-dynamics.be/wordpress/?cat=45'>" . esc_html__( 'the documentation', 'events-made-easy' ) . '</a>' . '<br>' . esc_html__( 'For more information about form fields, see ', 'events-made-easy' ) . "<a target='_blank' href='//www.e-dynamics.be/wordpress/?cat=44'>" . esc_html__( 'the documentation', 'events-made-easy' ) . '</a>' );
-            eme_options_input_text( __( 'Bookings list footer format', 'events-made-easy' ), 'eme_bookings_list_footer_format', __( 'The footer format for the bookings list when using the <code>#_BOOKINGS</code> placeholder.', 'events-made-easy' ) . sprintf( __( " The default is '%s'", 'events-made-easy' ), eme_esc_html( DEFAULT_BOOKINGS_LIST_FOOTER_FORMAT ) ) );
+            eme_options_input_text( __( 'Bookings list footer format', 'events-made-easy' ), 'eme_bookings_list_footer_format', __( 'The footer format for the bookings list when using the <code>#_BOOKINGS</code> placeholder.', 'events-made-easy' ) . sprintf( __( " The default is '%s'", 'events-made-easy' ), esc_html( DEFAULT_BOOKINGS_LIST_FOOTER_FORMAT ) ) );
             eme_options_toggle( __( 'Ignore pending bookings in the bookings list', 'events-made-easy' ), 'eme_bookings_list_ignore_pending', __( 'Whether or not to ignore pending bookings when using the <code>#_BOOKINGS</code> placeholder.', 'events-made-easy' ) );
             eme_options_toggle( __( 'Check waitinglist when seats become available', 'events-made-easy' ), 'eme_check_free_waiting', __( 'Automatically take a booking from the waiting list when seats become available again', 'events-made-easy' ) );
 
@@ -2021,9 +2021,9 @@ function eme_options_page() {
 <?php
                 eme_options_input_int( __( 'Pause between emails', 'events-made-easy' ), 'eme_mail_sleep', __( 'Indicate how much time (in microseconds, one microsecond being one millionth of a second) to wait between queued emails being sent. By default this is 0, meaning EME sends emails in bursts based on your mail queue settings. This option can be used to send emails more slowly, but be aware to not cause PHP timeouts.', 'events-made-easy' ) );
             } else {
-                echo esc_html(sprintf( __( 'Multisite data sharing is activated for EME, the option "%s" will use the settings from the main site', 'events-made-easy' ), __( 'Email queuing', 'events-made-easy' ) ));
+                printf( esc_html__( 'Multisite data sharing is activated for EME, the option "%s" will use the settings from the main site', 'events-made-easy' ), esc_html__( 'Email queuing', 'events-made-easy' ) );
                 echo '<br>';
-                echo esc_html(sprintf( __( 'Multisite data sharing is activated for EME, the option "%s" will use the settings from the main site', 'events-made-easy' ), __( 'Pause between emails', 'events-made-easy' ) ));
+                printf( esc_html__( 'Multisite data sharing is activated for EME, the option "%s" will use the settings from the main site', 'events-made-easy' ), esc_html__( 'Pause between emails', 'events-made-easy' ) );
             }
             eme_options_toggle( __( 'Read tracking', 'events-made-easy' ), 'eme_mail_tracking', __( 'Add an image (1x1 transparant pixel) to html emails so you can track if people opened the mail or not (be aware that people can easily bypass this by disabling images in their mail client). As this might be a privacy issue, it is deactivated by default.', 'events-made-easy' ) );
             eme_options_toggle( __( 'MassMail', 'events-made-easy' ), 'eme_people_massmail', __( "Should new persons in the database be considered for massmailing or not? This setting is used if you don't ask for opt-in/out info in e.g. the RSVP form. Warning: setting this to 'yes' is not GDPR compliant if you don't ask for a person's mail preferences.", 'events-made-easy' ) );
@@ -2068,7 +2068,7 @@ function eme_options_page() {
             eme_options_toggle( __( 'Debug SMTP?', 'events-made-easy' ), 'eme_smtp_debug', __( 'Check this option if you have issues sending mail via SMTP. Only do this for debugging purposes and deactivate it afterwards!', 'events-made-easy' ) );
             $test_url = admin_url( 'admin.php?page=eme-emails#tab-testmail' );
             eme_options_textarea( __( 'Email blacklist', 'events-made-easy' ), 'eme_mail_blacklist', __( 'A list of emails (one per line) that will not be accepted in EME. Examples can be ".com" (to not accept anything from ".com"), "anything.com" (to not accept addresses ending in "anything.com"), or even specific email addresses.', 'events-made-easy' ) );
-            echo "<tr><th colspan='2'>" . sprintf( __( "Hint: after you changed your mail settings, go to the <a href='%s'>Emails management</a> submenu to send a test mail.", 'events-made-easy' ), esc_url($test_url) ) . '</td></tr>';
+            echo "<tr><th colspan='2'>" . wp_kses_post( sprintf( __( "Hint: after you changed your mail settings, go to the <a href='%s'>Emails management</a> submenu to send a test mail.", 'events-made-easy' ), esc_url($test_url) ) ) . '</td></tr>';
 ?>
 </table>
 <?php
@@ -2099,15 +2099,15 @@ function eme_options_page() {
 <div>
 <?php
             if ( ! get_option( 'eme_rsvp_mail_notify_is_active' ) ) {
-                print "<div class='info eme-message-admin'><p>" . __( 'RSVP notifications are not activated, so these emails will not be sent. Go in the Email settings to activate this if wanted.', 'events-made-easy' ) . '</p></div>';
+                print "<div class='info eme-message-admin'><p>" . esc_html__( 'RSVP notifications are not activated, so these emails will not be sent. Go in the Email settings to activate this if wanted.', 'events-made-easy' ) . '</p></div>';
             } else {
                 if ( ! get_option( 'eme_rsvp_mail_notify_approved' ) ) {
-                    print "<div class='info eme-message-admin'><p>" . __( 'RSVP notifications are not activated for bookings made or approved, so these emails will not be sent. Go in the Email settings to activate this if wanted.', 'events-made-easy' ) . '</p></div>';
+                    print "<div class='info eme-message-admin'><p>" . esc_html__( 'RSVP notifications are not activated for bookings made or approved, so these emails will not be sent. Go in the Email settings to activate this if wanted.', 'events-made-easy' ) . '</p></div>';
                 } else {
                     if ( get_option( 'eme_rsvp_mail_notify_paid' ) ) {
-                        print "<div class='info eme-message-admin'><p>" . __( 'When an event is configured to auto-approve bookings after payment and the total amount to pay is 0, this email will be sent when a pending booking is marked as paid (and not the paid-email, since there was nothing to pay for).', 'events-made-easy' ) . '</p></div>';
+                        print "<div class='info eme-message-admin'><p>" . esc_html__( 'When an event is configured to auto-approve bookings after payment and the total amount to pay is 0, this email will be sent when a pending booking is marked as paid (and not the paid-email, since there was nothing to pay for).', 'events-made-easy' ) . '</p></div>';
                     } else {
-                        print "<div class='info eme-message-admin'><p>" . __( 'Since RSVP notifications after payment are not active, this email will also be sent when a booking is marked as paid.', 'events-made-easy' ) . '</p></div>';
+                        print "<div class='info eme-message-admin'><p>" . esc_html__( 'Since RSVP notifications after payment are not active, this email will also be sent when a booking is marked as paid.', 'events-made-easy' ) . '</p></div>';
                     }
                 }
             }
@@ -2164,11 +2164,11 @@ function eme_options_page() {
 <div>
 <?php
             if ( ! get_option( 'eme_rsvp_mail_notify_is_active' ) ) {
-                print "<div class='info eme-message-admin'><p>" . __( 'RSVP notifications are not activated, so these emails will not be sent. Go in the Email settings to activate this if wanted.', 'events-made-easy' ) . '</p></div>';
+                print "<div class='info eme-message-admin'><p>" . esc_html__( 'RSVP notifications are not activated, so these emails will not be sent. Go in the Email settings to activate this if wanted.', 'events-made-easy' ) . '</p></div>';
             } elseif ( ! get_option( 'eme_rsvp_mail_notify_pending' ) ) {
-                print "<div class='info eme-message-admin'><p>" . __( 'RSVP notifications are not activated for pending bookings, so these emails will not be sent. Go in the Email settings to activate this if wanted.', 'events-made-easy' ) . '</p></div>';
+                print "<div class='info eme-message-admin'><p>" . esc_html__( 'RSVP notifications are not activated for pending bookings, so these emails will not be sent. Go in the Email settings to activate this if wanted.', 'events-made-easy' ) . '</p></div>';
             }
-            print "<div class='info eme-message-admin'><p>" . __( 'When this mail is not yet sent (in the queue) and the booking is approved or paid during that time and a mail is planned for that action, this mail gets removed from the queue so people do not get 2 emails at the same time.', 'events-made-easy' ) . '</p></div>';
+            print "<div class='info eme-message-admin'><p>" . esc_html__( 'When this mail is not yet sent (in the queue) and the booking is approved or paid during that time and a mail is planned for that action, this mail gets removed from the queue so people do not get 2 emails at the same time.', 'events-made-easy' ) . '</p></div>';
 ?>
 <table class='form-table'>
 <?php
@@ -2225,7 +2225,7 @@ function eme_options_page() {
 <table class='form-table'>
 <?php
             if ( ! get_option( 'eme_rsvp_mail_notify_is_active' ) ) {
-                print "<div class='info eme-message-admin'><p>" . __( 'RSVP notifications are not activated, so these emails will not be sent. Go in the Email settings to activate this if wanted.', 'events-made-easy' ) . '</p></div>';
+                print "<div class='info eme-message-admin'><p>" . esc_html__( 'RSVP notifications are not activated, so these emails will not be sent. Go in the Email settings to activate this if wanted.', 'events-made-easy' ) . '</p></div>';
             }
             eme_options_input_text( __( 'Booking Updated Email Subject', 'events-made-easy' ), 'eme_registration_updated_email_subject', __( 'The subject of the email that will be sent to the respondent if the booking has been updated by an admin.', 'events-made-easy' ) . '<br>' . esc_html__( 'For all possible placeholders, see ', 'events-made-easy' ) . "<a target='_blank' href='//www.e-dynamics.be/wordpress/?cat=27'>" . esc_html__( 'the documentation', 'events-made-easy' ) . '</a><br>' . __( 'If you leave this empty, this mail will not be sent.', 'events-made-easy' ) );
             eme_options_textarea( __( 'Booking Updated Email Body', 'events-made-easy' ), 'eme_registration_updated_email_body', __( 'The body of the email that will be sent to the respondent if the booking has been updated by an admin.', 'events-made-easy' ) . '<br>' . esc_html__( 'For all possible placeholders, see ', 'events-made-easy' ) . "<a target='_blank' href='//www.e-dynamics.be/wordpress/?cat=27'>" . esc_html__( 'the documentation', 'events-made-easy' ) . '</a><br>' . __( 'If you leave this empty, this mail will not be sent.', 'events-made-easy' ), $use_html_editor, $use_full );
@@ -2240,7 +2240,7 @@ function eme_options_page() {
 <table class='form-table'>
 <?php
             if ( ! get_option( 'eme_rsvp_mail_notify_is_active' ) ) {
-                print "<div class='info eme-message-admin'><p>" . __( 'RSVP notifications are not activated, so these emails will not be sent. Go in the Email settings to activate this if wanted.', 'events-made-easy' ) . '</p></div>';
+                print "<div class='info eme-message-admin'><p>" . esc_html__( 'RSVP notifications are not activated, so these emails will not be sent. Go in the Email settings to activate this if wanted.', 'events-made-easy' ) . '</p></div>';
             }
             eme_options_input_text( __( 'Pending Booking Reminder Email Subject', 'events-made-easy' ), 'eme_registration_pending_reminder_email_subject', __( 'The subject of the email that will be sent to the respondent as a reminder of a pending booking.', 'events-made-easy' ) . '<br>' . esc_html__( 'For all possible placeholders, see ', 'events-made-easy' ) . "<a target='_blank' href='//www.e-dynamics.be/wordpress/?cat=27'>" . esc_html__( 'the documentation', 'events-made-easy' ) . '</a><br>' . __( 'If you leave this empty, this mail will not be sent.', 'events-made-easy' ) );
             eme_options_textarea( __( 'Pending Booking Reminder Email Body', 'events-made-easy' ), 'eme_registration_pending_reminder_email_body', __( 'The body of the email that will be sent to the respondent as a reminder of a pending booking.', 'events-made-easy' ) . '<br>' . esc_html__( 'For all possible placeholders, see ', 'events-made-easy' ) . "<a target='_blank' href='//www.e-dynamics.be/wordpress/?cat=27'>" . esc_html__( 'the documentation', 'events-made-easy' ) . '</a><br>' . __( 'If you leave this empty, this mail will not be sent.', 'events-made-easy' ), $use_html_editor, $use_full );
@@ -2257,7 +2257,7 @@ function eme_options_page() {
 <table class='form-table'>
 <?php
             if ( ! get_option( 'eme_rsvp_mail_notify_is_active' ) ) {
-                print "<div class='info eme-message-admin'><p>" . __( 'RSVP notifications are not activated, so these emails will not be sent. Go in the Email settings to activate this if wanted.', 'events-made-easy' ) . '</p></div>';
+                print "<div class='info eme-message-admin'><p>" . esc_html__( 'RSVP notifications are not activated, so these emails will not be sent. Go in the Email settings to activate this if wanted.', 'events-made-easy' ) . '</p></div>';
             }
             eme_options_input_text( __( 'Booking Cancelled Email Subject', 'events-made-easy' ), 'eme_registration_cancelled_email_subject', __( 'The subject of the email that will be sent to the respondent when he cancels all his bookings for an event.', 'events-made-easy' ) . '<br>' . esc_html__( 'For all possible placeholders, see ', 'events-made-easy' ) . "<a target='_blank' href='//www.e-dynamics.be/wordpress/?cat=27'>" . esc_html__( 'the documentation', 'events-made-easy' ) . '</a><br>' . __( 'If you leave this empty, this mail will not be sent.', 'events-made-easy' ) );
             eme_options_textarea( __( 'Booking Cancelled Email Body', 'events-made-easy' ), 'eme_registration_cancelled_email_body', __( 'The body of the email that will be sent to the respondent when he cancels all his bookings for an event.', 'events-made-easy' ) . '<br>' . esc_html__( 'For all possible placeholders, see ', 'events-made-easy' ) . "<a target='_blank' href='//www.e-dynamics.be/wordpress/?cat=27'>" . esc_html__( 'the documentation', 'events-made-easy' ) . '</a><br>' . __( 'If you leave this empty, this mail will not be sent.', 'events-made-easy' ), $use_html_editor, $use_full );
@@ -2274,7 +2274,7 @@ function eme_options_page() {
 <table class='form-table'>
 <?php
             if ( ! get_option( 'eme_rsvp_mail_notify_is_active' ) ) {
-                print "<div class='info eme-message-admin'><p>" . __( 'RSVP notifications are not activated, so these emails will not be sent. Go in the Email settings to activate this if wanted.', 'events-made-easy' ) . '</p></div>';
+                print "<div class='info eme-message-admin'><p>" . esc_html__( 'RSVP notifications are not activated, so these emails will not be sent. Go in the Email settings to activate this if wanted.', 'events-made-easy' ) . '</p></div>';
             }
             eme_options_input_text( __( 'Booking Deleted Email Subject', 'events-made-easy' ), 'eme_registration_trashed_email_subject', __( 'The subject of the email that will be sent to the respondent if the booking is deleted by an admin.', 'events-made-easy' ) . '<br>' . esc_html__( 'For all possible placeholders, see ', 'events-made-easy' ) . "<a target='_blank' href='//www.e-dynamics.be/wordpress/?cat=27'>" . esc_html__( 'the documentation', 'events-made-easy' ) . '</a>' );
             eme_options_textarea( __( 'Booking Deleted Email Body', 'events-made-easy' ), 'eme_registration_trashed_email_body', __( 'The body of the email that will be sent to the respondent if the booking is deleted by an admin.', 'events-made-easy' ) . '<br>' . esc_html__( 'For all possible placeholders, see ', 'events-made-easy' ) . "<a target='_blank' href='//www.e-dynamics.be/wordpress/?cat=27'>" . esc_html__( 'the documentation', 'events-made-easy' ) . '</a>', $use_html_editor, $use_full );
@@ -2288,9 +2288,9 @@ function eme_options_page() {
 <div>
 <?php
             if ( ! get_option( 'eme_rsvp_mail_notify_is_active' ) ) {
-                print "<div class='info eme-message-admin'><p>" . __( 'RSVP notifications are not activated, so these emails will not be sent. Go in the Email settings to activate this if wanted.', 'events-made-easy' ) . '</p></div>';
+                print "<div class='info eme-message-admin'><p>" . esc_html__( 'RSVP notifications are not activated, so these emails will not be sent. Go in the Email settings to activate this if wanted.', 'events-made-easy' ) . '</p></div>';
             } elseif ( ! get_option( 'eme_rsvp_mail_notify_paid' ) ) {
-                print "<div class='info eme-message-admin'><p>" . __( 'RSVP notifications are not activated for paid bookings, so these emails will not be sent. Go in the Email settings to activate this if wanted.', 'events-made-easy' ) . '</p></div>';
+                print "<div class='info eme-message-admin'><p>" . esc_html__( 'RSVP notifications are not activated for paid bookings, so these emails will not be sent. Go in the Email settings to activate this if wanted.', 'events-made-easy' ) . '</p></div>';
             }
 ?>
 <table class='form-table'>
@@ -2345,7 +2345,7 @@ function eme_options_page() {
 <table class='form-table'>
 <?php
             if ( ! get_option( 'eme_rsvp_mail_notify_is_active' ) ) {
-                print "<div class='info eme-message-admin'><p>" . __( 'RSVP notifications are not activated, so these emails will not be sent. Go in the Email settings to activate this if wanted.', 'events-made-easy' ) . '</p></div>';
+                print "<div class='info eme-message-admin'><p>" . esc_html__( 'RSVP notifications are not activated, so these emails will not be sent. Go in the Email settings to activate this if wanted.', 'events-made-easy' ) . '</p></div>';
             }
             eme_options_input_text( __( 'Contact Person Payment Notification Email Subject', 'events-made-easy' ), 'eme_contactperson_ipn_email_subject', __( 'The subject of the email that will be sent to the contact person when a payment notification is received via a payment gateway.', 'events-made-easy' ) . '<br>' . esc_html__( 'For all possible placeholders, see ', 'events-made-easy' ) . "<a target='_blank' href='//www.e-dynamics.be/wordpress/?cat=27'>" . esc_html__( 'the documentation', 'events-made-easy' ) . '</a><br>' . __( 'If you leave this empty, this mail will not be sent.', 'events-made-easy' ) );
             eme_options_textarea( __( 'Contact Person Payment Notification Email Body', 'events-made-easy' ), 'eme_contactperson_ipn_email_body', __( 'The body of the email that will be sent to the contact person when a payment notification is received via a payment gateway.', 'events-made-easy' ) . '<br>' . esc_html__( 'For all possible placeholders, see ', 'events-made-easy' ) . "<a target='_blank' href='//www.e-dynamics.be/wordpress/?cat=27'>" . esc_html__( 'the documentation', 'events-made-easy' ) . '</a><br>' . __( 'If you leave this empty, this mail will not be sent.', 'events-made-easy' ), $use_html_editor, $use_full );
@@ -2532,7 +2532,7 @@ function eme_options_page() {
 case 'gdpr':
 ?>
 <h2><?php esc_html_e( 'GDPR: General Data Protection Regulation options', 'events-made-easy' ); ?></h2>
-            <?php print esc_html__( 'For more info concerning GDPR, see', 'events-made-easy' ) . " <a target='_blank' href='//www.e-dynamics.be/wordpress/category/documentation/6-shortcodes/eme_gdpr_approve/'>" . esc_html(sprintf( __( 'the documentation about the shortcode %s', 'events-made-easy' ), 'eme_gdpr_approve' )) . "</a>, <a target='_blank' href='//www.e-dynamics.be/wordpress/category/documentation/6-shortcodes/eme_request_personal_info/'>" . esc_html(sprintf( __( 'the documentation about the shortcode %s', 'events-made-easy' ), 'eme_request_personal_info' )) . '</a> ' . esc_html__( 'and', 'events-made-easy' ) . " <a target='_blank' href='//www.e-dynamics.be/wordpress/category/documentation/6-shortcodes/eme_change_personal_info/'>" .esc_html( sprintf( __( 'the documentation about the shortcode %s', 'events-made-easy' ), 'eme_change_personal_info' )) . '</a>'; ?>
+            <?php print esc_html__( 'For more info concerning GDPR, see', 'events-made-easy' ) . " <a target='_blank' href='//www.e-dynamics.be/wordpress/category/documentation/6-shortcodes/eme_gdpr_approve/'>" . sprintf( esc_html__( 'the documentation about the shortcode %s', 'events-made-easy' ), esc_html( 'eme_gdpr_approve' ) ) . "</a>, <a target='_blank' href='//www.e-dynamics.be/wordpress/category/documentation/6-shortcodes/eme_request_personal_info/'>" . sprintf( esc_html__( 'the documentation about the shortcode %s', 'events-made-easy' ), esc_html( 'eme_request_personal_info' ) ) . '</a> ' . esc_html__( 'and', 'events-made-easy' ) . " <a target='_blank' href='//www.e-dynamics.be/wordpress/category/documentation/6-shortcodes/eme_change_personal_info/'>" . sprintf( esc_html__( 'the documentation about the shortcode %s', 'events-made-easy' ), esc_html( 'eme_change_personal_info' ) ) . '</a>'; ?>
 <table class='form-table'>
 <?php
     if ( get_option( 'eme_mail_send_html' ) == '1' ) {
@@ -2551,17 +2551,17 @@ case 'gdpr':
         eme_options_input_text( __( 'Automatically archive old mailings and remove old emails', 'events-made-easy' ), 'eme_gdpr_archive_old_mailings_days', __( 'Set the number of days after which mailings are automatically archived and old emails are removed. Leave empty or 0 for no automatic archiving or removal.', 'events-made-easy' ) . '<br>' . __( 'Setting this to something greater than 0 helps you in achieving GDPR compliance. Recommended values are 180 (half a year) or 365 (one year).', 'events-made-easy' ) );
         eme_options_input_text( __( 'Automatically delete old attendance records', 'events-made-easy' ), 'eme_gdpr_remove_old_attendances_days', __( 'Set the number of days after which attendance records are automatically removed. Leave empty or 0 for no automatic removal.', 'events-made-easy' ) . '<br>' . __( 'Setting this to something greater than 0 helps you in achieving GDPR compliance. Recommended values are 180 (half a year) or 365 (one year).', 'events-made-easy' ) );
     } else {
-        echo esc_html(sprintf( __( 'Multisite data sharing is activated for EME, the option "%s" will use the settings from the main site', 'events-made-easy' ), __( 'Automatically remove expired members', 'events-made-easy' ) ));
+        printf( esc_html__( 'Multisite data sharing is activated for EME, the option "%s" will use the settings from the main site', 'events-made-easy' ), esc_html__( 'Automatically remove expired members', 'events-made-easy' ) );
         echo '<br>';
-        echo esc_html(sprintf( __( 'Multisite data sharing is activated for EME, the option "%s" will use the settings from the main site', 'events-made-easy' ), __( 'Automatically anonimyze old bookings', 'events-made-easy' )) );
+        printf( esc_html__( 'Multisite data sharing is activated for EME, the option "%s" will use the settings from the main site', 'events-made-easy' ), esc_html__( 'Automatically anonimyze old bookings', 'events-made-easy' ) );
         echo '<br>';
-        echo esc_html(sprintf( __( 'Multisite data sharing is activated for EME, the option "%s" will use the settings from the main site', 'events-made-easy' ), __( 'Automatically remove old events', 'events-made-easy' ) ));
+        printf( esc_html__( 'Multisite data sharing is activated for EME, the option "%s" will use the settings from the main site', 'events-made-easy' ), esc_html__( 'Automatically remove old events', 'events-made-easy' ) );
         echo '<br>';
-        echo esc_html(sprintf( __( 'Multisite data sharing is activated for EME, the option "%s" will use the settings from the main site', 'events-made-easy' ), __( 'Automatically remove task signups for old events', 'events-made-easy' )) );
+        printf( esc_html__( 'Multisite data sharing is activated for EME, the option "%s" will use the settings from the main site', 'events-made-easy' ), esc_html__( 'Automatically remove task signups for old events', 'events-made-easy' ) );
         echo '<br>';
-        echo esc_html(sprintf( __( 'Multisite data sharing is activated for EME, the option "%s" will use the settings from the main site', 'events-made-easy' ), __( 'Automatically archive old mailings and remove old emails', 'events-made-easy' ) ));
+        printf( esc_html__( 'Multisite data sharing is activated for EME, the option "%s" will use the settings from the main site', 'events-made-easy' ), esc_html__( 'Automatically archive old mailings and remove old emails', 'events-made-easy' ) );
         echo '<br>';
-        echo esc_html(sprintf( __( 'Multisite data sharing is activated for EME, the option "%s" will use the settings from the main site', 'events-made-easy' ), __( 'Automatically delete old attendance records', 'events-made-easy' ) ));
+        printf( esc_html__( 'Multisite data sharing is activated for EME, the option "%s" will use the settings from the main site', 'events-made-easy' ), esc_html__( 'Automatically delete old attendance records', 'events-made-easy' ) );
         echo '<br>';
     }
     eme_options_input_text( __( 'Personal info approval email subject', 'events-made-easy' ), 'eme_gdpr_approve_subject', __( 'The subject of the email that will be sent to the person asking for personal info storage approval.', 'events-made-easy' ) . '<br>' . __( 'No placeholders can be used.', 'events-made-easy' ) . '<br>' . __( 'This setting is used in the mail sent as a result of submitting the form created by the shortcode [eme_gdpr_approve].', 'events-made-easy' ) );
@@ -2628,7 +2628,7 @@ case 'payments':
     eme_options_input_text( __( 'Extra charge 2', 'events-made-easy' ), 'eme_' . $gateway . '_cost2', __( 'Second extra charge added to the price. Can either be an absolute number or a percentage. E.g. 2 or 5%', 'events-made-easy' ) );
 ?>
 <tr><th colspan='2'><?php _e('Extra payment method information','events-made-easy');?></th></tr>
-<tr><td colspan='2'><?php echo sprintf(__('Internal payment method name: %s','events-made-easy'), 'offline');?></td></tr>
+<tr><td colspan='2'><?php printf(esc_html__('Internal payment method name: %s','events-made-easy'), esc_html('offline'));?></td></tr>
 </table>
 </div>
 </details>
@@ -2662,9 +2662,9 @@ case 'payments':
     eme_options_input_text( __( 'Text below payment button', 'events-made-easy' ), 'eme_' . $gateway . '_button_below', __( 'The text shown just below the payment button', 'events-made-easy' ) . '<br>' . esc_html__( 'For all possible placeholders, see ', 'events-made-easy' ) . "<a target='_blank' href='//www.e-dynamics.be/wordpress/category/documentation/7-placeholders/payment-gateways/'>" . esc_html__( 'the documentation', 'events-made-easy' ) . '</a>' );
 ?>
 <tr><th colspan='2'><?php _e('Extra payment method information','events-made-easy'); ?></th></tr>
-<tr><td colspan='2'><?php echo sprintf(__('The url for payment notifications is: %s','events-made-easy'), $notification_link); ?></td></tr>
+<tr><td colspan='2'><?php printf(esc_html__('The url for payment notifications is: %s','events-made-easy'), esc_html($notification_link)); ?></td></tr>
 <tr><td colspan='2'><?php _e('Refunding is possible.','events-made-easy'); ?></td></tr>
-<tr><td colspan='2'><?php echo sprintf(__('Internal payment method name: %s','events-made-easy'), $gateway); ?></td></tr>
+<tr><td colspan='2'><?php printf(esc_html__('Internal payment method name: %s','events-made-easy'), esc_html($gateway)); ?></td></tr>
 <?php
 $webhook_id = get_option('eme_paypal_webhook_id');
 if (!empty($webhook_id)) {
@@ -2717,9 +2717,9 @@ if (!empty($webhook_id)) {
     eme_options_input_text( __( 'Text below payment button', 'events-made-easy' ), 'eme_' . $gateway . '_button_below', __( 'The text shown just below the payment button', 'events-made-easy' ) . '<br>' . esc_html__( 'For all possible placeholders, see ', 'events-made-easy' ) . "<a target='_blank' href='//www.e-dynamics.be/wordpress/category/documentation/7-placeholders/payment-gateways/'>" . esc_html__( 'the documentation', 'events-made-easy' ) . '</a>' );
 ?>
 <tr><th colspan='2'><?php _e('Extra payment method information','events-made-easy'); ?></th></tr>
-<tr><td colspan='2'><?php echo sprintf(__('The url for payment notifications is: %s','events-made-easy'), $notification_link); ?></td></tr>
+<tr><td colspan='2'><?php printf(esc_html__('The url for payment notifications is: %s','events-made-easy'), esc_html($notification_link)); ?></td></tr>
 <tr><td colspan='2'><?php _e('Refunding is possible.','events-made-easy'); ?></td></tr>
-<tr><td colspan='2'><?php echo sprintf(__('Internal payment method name: %s','events-made-easy'), $gateway); ?></td></tr>
+<tr><td colspan='2'><?php printf(esc_html__('Internal payment method name: %s','events-made-easy'), esc_html($gateway)); ?></td></tr>
 </table>
 </div>
 </details>
@@ -2753,9 +2753,9 @@ if (!empty($webhook_id)) {
     eme_options_input_text( __( 'Text below payment button', 'events-made-easy' ), 'eme_' . $gateway . '_button_below', __( 'The text shown just below the payment button', 'events-made-easy' ) . '<br>' . esc_html__( 'For all possible placeholders, see ', 'events-made-easy' ) . "<a target='_blank' href='//www.e-dynamics.be/wordpress/category/documentation/7-placeholders/payment-gateways/'>" . esc_html__( 'the documentation', 'events-made-easy' ) . '</a>' );
 ?>
 <tr><th colspan='2'><?php _e('Extra payment method information','events-made-easy'); ?></th></tr>
-<tr><td colspan='2'><?php echo sprintf(__('The url for payment notifications is: %s','events-made-easy'), $notification_link); ?></td></tr>
+<tr><td colspan='2'><?php printf(esc_html__('The url for payment notifications is: %s','events-made-easy'), esc_html($notification_link)); ?></td></tr>
 <tr><td colspan='2'><?php _e('Refunding not implemented.','events-made-easy'); ?></td></tr>
-<tr><td colspan='2'><?php echo sprintf(__('Internal payment method name: %s','events-made-easy'), $gateway); ?></td></tr>
+<tr><td colspan='2'><?php printf(esc_html__('Internal payment method name: %s','events-made-easy'), esc_html($gateway)); ?></td></tr>
 </table>
 </div>
 </details>
@@ -2789,9 +2789,9 @@ if (!empty($webhook_id)) {
     eme_options_input_text( __( 'Text below payment button', 'events-made-easy' ), 'eme_' . $gateway . '_button_below', __( 'The text shown just below the payment button', 'events-made-easy' ) . '<br>' . esc_html__( 'For all possible placeholders, see ', 'events-made-easy' ) . "<a target='_blank' href='//www.e-dynamics.be/wordpress/category/documentation/7-placeholders/payment-gateways/'>" . esc_html__( 'the documentation', 'events-made-easy' ) . '</a>' );
 ?>
 <tr><th colspan='2'><?php _e('Extra payment method information','events-made-easy'); ?></th></tr>
-<tr><td colspan='2'><?php echo sprintf(__('The url for payment notifications is: %s','events-made-easy'), $notification_link); ?></td></tr>
+<tr><td colspan='2'><?php printf(esc_html__('The url for payment notifications is: %s','events-made-easy'), esc_html($notification_link)); ?></td></tr>
 <tr><td colspan='2'><?php _e('Refunding not implemented.','events-made-easy'); ?></td></tr>
-<tr><td colspan='2'><?php echo sprintf(__('Internal payment method name: %s','events-made-easy'), $gateway); ?></td></tr>
+<tr><td colspan='2'><?php printf(esc_html__('Internal payment method name: %s','events-made-easy'), esc_html($gateway)); ?></td></tr>
 </table>
 </div>
 </details>
@@ -2812,9 +2812,9 @@ if (!empty($webhook_id)) {
     eme_options_input_text( __( 'Text below payment button', 'events-made-easy' ), 'eme_' . $gateway . '_button_below', __( 'The text shown just below the payment button', 'events-made-easy' ) . '<br>' . esc_html__( 'For all possible placeholders, see ', 'events-made-easy' ) . "<a target='_blank' href='//www.e-dynamics.be/wordpress/category/documentation/7-placeholders/payment-gateways/'>" . esc_html__( 'the documentation', 'events-made-easy' ) . '</a>' );
 ?>
 <tr><th colspan='2'><?php _e('Extra payment method information','events-made-easy'); ?></th></tr>
-<tr><td colspan='2'><?php echo sprintf(__('The url for payment notifications is: %s','events-made-easy'), $notification_link); ?></td></tr>
+<tr><td colspan='2'><?php printf(esc_html__('The url for payment notifications is: %s','events-made-easy'), esc_html($notification_link)); ?></td></tr>
 <tr><td colspan='2'><?php _e('Refunding is possible.','events-made-easy'); ?></td></tr>
-<tr><td colspan='2'><?php echo sprintf(__('Internal payment method name: %s','events-made-easy'), $gateway); ?></td></tr>
+<tr><td colspan='2'><?php printf(esc_html__('Internal payment method name: %s','events-made-easy'), esc_html($gateway)); ?></td></tr>
 </table>
 </div>
 </details>
@@ -2844,9 +2844,9 @@ if (!empty($webhook_id)) {
     eme_options_input_text( __( 'Text below payment button', 'events-made-easy' ), 'eme_' . $gateway . '_button_below', __( 'The text shown just below the payment button', 'events-made-easy' ) . '<br>' . esc_html__( 'For all possible placeholders, see ', 'events-made-easy' ) . "<a target='_blank' href='//www.e-dynamics.be/wordpress/category/documentation/7-placeholders/payment-gateways/'>" . esc_html__( 'the documentation', 'events-made-easy' ) . '</a>' );
 ?>
 <tr><th colspan='2'><?php _e('Extra payment method information','events-made-easy'); ?></th></tr>
-<tr><td colspan='2'><?php echo sprintf(__('The url for payment notifications is: %s','events-made-easy'), $notification_link); ?></td></tr>
+<tr><td colspan='2'><?php printf(esc_html__('The url for payment notifications is: %s','events-made-easy'), esc_html($notification_link)); ?></td></tr>
 <tr><td colspan='2'><?php _e('Refunding is possible if funds are available on the account.','events-made-easy'); ?></td></tr>
-<tr><td colspan='2'><?php echo sprintf(__('Internal payment method name: %s','events-made-easy'), $gateway); ?></td></tr>
+<tr><td colspan='2'><?php printf(esc_html__('Internal payment method name: %s','events-made-easy'), esc_html($gateway)); ?></td></tr>
 </table>
 </div>
 </details>
@@ -2883,9 +2883,9 @@ if (!empty($webhook_id)) {
     eme_options_input_text( __( 'Text below payment button', 'events-made-easy' ), 'eme_' . $gateway . '_button_below', __( 'The text shown just below the payment button', 'events-made-easy' ) . '<br>' . esc_html__( 'For all possible placeholders, see ', 'events-made-easy' ) . "<a target='_blank' href='//www.e-dynamics.be/wordpress/category/documentation/7-placeholders/payment-gateways/'>" . esc_html__( 'the documentation', 'events-made-easy' ) . '</a>' );
 ?>
 <tr><th colspan='2'><?php _e('Extra payment method information','events-made-easy'); ?></th></tr>
-<tr><td colspan='2'><?php echo sprintf(__('The url for payment notifications is: %s','events-made-easy'), $notification_link); ?></td></tr>
+<tr><td colspan='2'><?php printf(esc_html__('The url for payment notifications is: %s','events-made-easy'), esc_html($notification_link)); ?></td></tr>
 <tr><td colspan='2'><?php _e('Refunding not implemented.','events-made-easy'); ?></td></tr>
-<tr><td colspan='2'><?php echo sprintf(__('Internal payment method name: %s','events-made-easy'), $gateway); ?></td></tr>
+<tr><td colspan='2'><?php printf(esc_html__('Internal payment method name: %s','events-made-easy'), esc_html($gateway)); ?></td></tr>
 </table>
 </div>
 </details>
@@ -2921,7 +2921,7 @@ if (!empty($webhook_id)) {
 <tr><th colspan='2'><?php _e('Extra payment method information','events-made-easy'); ?></th></tr>
 <tr><td colspan='2'><?php _e( 'Info: for Opayo to work, your PHP installation must have the mcrypt module installed and activated. Search the internet for which extra PHP package to install and/or which line in php.ini to change.', 'events-made-easy' ); ?></td></tr>
 <tr><td colspan='2'><?php _e('Refunding not implemented.','events-made-easy'); ?></td></tr>
-<tr><td colspan='2'><?php echo sprintf(__('Internal payment method name: %s','events-made-easy'), $gateway); ?></td></tr>
+<tr><td colspan='2'><?php printf(esc_html__('Internal payment method name: %s','events-made-easy'), esc_html($gateway)); ?></td></tr>
 </table>
 </div>
 </details>
@@ -2944,9 +2944,9 @@ if (!empty($webhook_id)) {
     eme_options_input_text( __( 'Text below payment button', 'events-made-easy' ), 'eme_' . $gateway . '_button_below', __( 'The text shown just below the payment button', 'events-made-easy' ) . '<br>' . esc_html__( 'For all possible placeholders, see ', 'events-made-easy' ) . "<a target='_blank' href='//www.e-dynamics.be/wordpress/category/documentation/7-placeholders/payment-gateways/'>" . esc_html__( 'the documentation', 'events-made-easy' ) . '</a>' );
 ?>
 <tr><th colspan='2'><?php _e('Extra payment method information','events-made-easy'); ?></th></tr>
-<tr><td colspan='2'><?php echo sprintf(__('The url for payment notifications is: %s','events-made-easy'), $notification_link); ?></td></tr>
+<tr><td colspan='2'><?php printf(esc_html__('The url for payment notifications is: %s','events-made-easy'), esc_html($notification_link)); ?></td></tr>
 <tr><td colspan='2'><?php _e('Refunding not implemented.','events-made-easy'); ?></td></tr>
-<tr><td colspan='2'><?php echo sprintf(__('Internal payment method name: %s','events-made-easy'), $gateway); ?></td></tr>
+<tr><td colspan='2'><?php printf(esc_html__('Internal payment method name: %s','events-made-easy'), esc_html($gateway)); ?></td></tr>
 </table>
 </div>
 </details>
@@ -2988,9 +2988,9 @@ if (!empty($webhook_id)) {
     eme_options_multiselect( __( 'Stripe payment methods', 'events-made-easy' ), 'eme_stripe_payment_methods', $stripe_pms, __( "The different Stripe payment methods you want to handle/provide. Defaults to 'card'. See the <a href='https://stripe.com/docs/api/checkout/sessions/create#create_checkout_session-payment_method_types'>Stripe doc</a> for more info.", 'events-made-easy' ), false, 'eme_snapselect' );
 ?>
 <tr><th colspan='2'><?php _e('Extra payment method information','events-made-easy'); ?></th></tr>
-<tr><td colspan='2'><?php echo sprintf(__('The url for payment notifications is: %s','events-made-easy'), $notification_link); ?></td></tr>
+<tr><td colspan='2'><?php printf(esc_html__('The url for payment notifications is: %s','events-made-easy'), esc_html($notification_link)); ?></td></tr>
 <tr><td colspan='2'><?php _e('Refunding is possible.','events-made-easy'); ?></td></tr>
-<tr><td colspan='2'><?php echo sprintf(__('Internal payment method name: %s','events-made-easy'), $gateway); ?></td></tr>
+<tr><td colspan='2'><?php printf(esc_html__('Internal payment method name: %s','events-made-easy'), esc_html($gateway)); ?></td></tr>
 <?php
     $eme_stripe_private_key = get_option( 'eme_stripe_private_key' );
     if ( ! empty( $eme_stripe_private_key ) ) {
@@ -3041,7 +3041,7 @@ if (!empty($webhook_id)) {
 ?>
 <tr><th colspan='2'><?php _e('Extra payment method information','events-made-easy'); ?></th></tr>
 <tr><td colspan='2'><?php _e('Refunding is possible.','events-made-easy'); ?></td></tr>
-<tr><td colspan='2'><?php echo sprintf(__('Internal payment method name: %s','events-made-easy'), $gateway); ?></td></tr>
+<tr><td colspan='2'><?php printf(esc_html__('Internal payment method name: %s','events-made-easy'), esc_html($gateway)); ?></td></tr>
 </table>
 </div>
 </details>
@@ -3076,9 +3076,9 @@ if (!empty($webhook_id)) {
     eme_options_input_text( __( 'Text below payment button', 'events-made-easy' ), 'eme_' . $gateway . '_button_below', __( 'The text shown just below the payment button', 'events-made-easy' ) . '<br>' . esc_html__( 'For all possible placeholders, see ', 'events-made-easy' ) . "<a target='_blank' href='//www.e-dynamics.be/wordpress/category/documentation/7-placeholders/payment-gateways/'>" . esc_html__( 'the documentation', 'events-made-easy' ) . '</a>' );
 ?>
 <tr><th colspan='2'><?php _e('Extra payment method information','events-made-easy'); ?></th></tr>
-<tr><td colspan='2'><?php echo sprintf(__('The url for payment notifications is: %s','events-made-easy'), $notification_link); ?></td></tr>
+<tr><td colspan='2'><?php printf(esc_html__('The url for payment notifications is: %s','events-made-easy'), esc_html($notification_link)); ?></td></tr>
 <tr><td colspan='2'><?php _e('Refunding is possible.','events-made-easy'); ?></td></tr>
-<tr><td colspan='2'><?php echo sprintf(__('Internal payment method name: %s','events-made-easy'), $gateway); ?></td></tr>
+<tr><td colspan='2'><?php printf(esc_html__('Internal payment method name: %s','events-made-easy'), esc_html($gateway)); ?></td></tr>
 </table>
 </div>
 </details>
@@ -3112,7 +3112,7 @@ if (!empty($webhook_id)) {
 ?>
 <tr><th colspan='2'><?php _e('Extra payment method information','events-made-easy'); ?></th></tr>
 <tr><td colspan='2'><?php _e('Refunding is possible.','events-made-easy'); ?></td></tr>
-<tr><td colspan='2'><?php echo sprintf(__('Internal payment method name: %s','events-made-easy'), $gateway); ?></td></tr>
+<tr><td colspan='2'><?php printf(esc_html__('Internal payment method name: %s','events-made-easy'), esc_html($gateway)); ?></td></tr>
 </table>
 </div>
 </details>
@@ -3134,9 +3134,9 @@ if (!empty($webhook_id)) {
     eme_options_input_text( __( 'Text below payment button', 'events-made-easy' ), 'eme_' . $gateway . '_button_below', __( 'The text shown just below the payment button', 'events-made-easy' ) . '<br>' . esc_html__( 'For all possible placeholders, see ', 'events-made-easy' ) . "<a target='_blank' href='//www.e-dynamics.be/wordpress/category/documentation/7-placeholders/payment-gateways/'>" . esc_html__( 'the documentation', 'events-made-easy' ) . '</a>' );
 ?>
 <tr><th colspan='2'><?php _e('Extra payment method information','events-made-easy'); ?></th></tr>
-<tr><td colspan='2'><?php echo sprintf(__('The url for payment notifications is: %s','events-made-easy'), $notification_link); ?></td></tr>
+<tr><td colspan='2'><?php printf(esc_html__('The url for payment notifications is: %s','events-made-easy'), esc_html($notification_link)); ?></td></tr>
 <tr><td colspan='2'><?php _e('Refunding is possible.','events-made-easy'); ?></td></tr>
-<tr><td colspan='2'><?php echo sprintf(__('Internal payment method name: %s','events-made-easy'), $gateway); ?></td></tr>
+<tr><td colspan='2'><?php printf(esc_html__('Internal payment method name: %s','events-made-easy'), esc_html($gateway)); ?></td></tr>
 </table>
 </div>
 </details>
@@ -3160,7 +3160,7 @@ case 'maps':
 case 'emefs':
 ?>
 <h2><?php esc_html_e( 'Frontend Submit options', 'events-made-easy' ); ?></h2>
-<?php echo sprintf( __( "For all information concerning frontend submit, see <a target='_blank' href='%s'>the documentation</a>", 'events-made-easy' ), '//www.e-dynamics.be/wordpress/category/documentation/6-placeholders/eme_add_event_form/' );
+<?php printf( wp_kses_post( __( "For all information concerning frontend submit, see <a target='_blank' href='%s'>the documentation</a>", 'events-made-easy' ) ), esc_url( '//www.e-dynamics.be/wordpress/category/documentation/6-placeholders/eme_add_event_form/' ) );
 echo '<br><br>';
 _e("Also check out the 'Email templates' and the 'Payment' sections for some extra frontend submit settings.", 'events-made-easy' );
 ?>

--- a/eme-payments.php
+++ b/eme-payments.php
@@ -208,7 +208,7 @@ function eme_event_payment_form( $payment_id, $resultcode = 0, $standalone = 0 )
             $ret_string .= $result;
             $ret_string .= '</div>';
         } else {
-            $ret_string     .= "<div id='eme-payment-handling' class='eme-payment-handling'>" . __( 'Payment handling', 'events-made-easy' ) . '</div>';
+            $ret_string     .= "<div id='eme-payment-handling' class='eme-payment-handling'>" . esc_html__( 'Payment handling', 'events-made-easy' ) . '</div>';
             $localized_price = eme_localized_price( $total_price, $cur );
             $ret_string     .= "<div id='eme-payment-price-info' class='eme-payment-price-info'>" . sprintf( __( 'The amount to pay is %s', 'events-made-easy' ), $localized_price ) . '</div>';
         }
@@ -348,7 +348,7 @@ function eme_member_payment_form( $payment_id, $resultcode = 0, $standalone = 0 
                 $ret_string .= '</div>';
             }
         } else {
-            $ret_string     .= "<div id='eme-payment-handling' class='eme-payment-handling'>" . __( 'Payment handling', 'events-made-easy' ) . '</div>';
+            $ret_string     .= "<div id='eme-payment-handling' class='eme-payment-handling'>" . esc_html__( 'Payment handling', 'events-made-easy' ) . '</div>';
             $localized_price = eme_localized_price( $total_price, $cur );
             $ret_string     .= "<div id='eme-payment-price-info' class='eme-payment-price-info'>" . sprintf( __( 'The amount to pay is %s', 'events-made-easy' ), $localized_price ) . '</div>';
         }
@@ -475,7 +475,7 @@ function eme_fs_event_payment_form( $payment_id, $resultcode = 0, $standalone = 
                 $ret_string .= '</div>';
             }
         } else {
-            $ret_string     .= "<div id='eme-payment-handling' class='eme-payment-handling'>" . __( 'Payment handling', 'events-made-easy' ) . '</div>';
+            $ret_string     .= "<div id='eme-payment-handling' class='eme-payment-handling'>" . esc_html__( 'Payment handling', 'events-made-easy' ) . '</div>';
             $localized_price = eme_localized_price( $total_price, $cur );
             $ret_string     .= "<div id='eme-payment-price-info' class='eme-payment-price-info'>" . sprintf( __( 'The amount to pay is %s', 'events-made-easy' ), $localized_price ) . '</div>';
         }

--- a/eme-people.php
+++ b/eme-people.php
@@ -1699,7 +1699,7 @@ function eme_printable_booking_report( $event_id ) {
 ?>
             </td>
             <td class='eme_print_total_price'><?php echo eme_localized_price( eme_get_total_booking_price( $booking ), $event['currency'] ); ?></td>
-            <td class='eme_print_comment'><?php echo eme_esc_html( $booking['booking_comment'] ); ?></td> 
+            <td class='eme_print_comment'><?php echo esc_html( $booking['booking_comment'] ); ?></td>
 <?php
         $answers = eme_get_nodyndata_booking_answers( $booking['booking_id'] );
         foreach ( $booking_answer_fieldids as $field_id ) {
@@ -1734,7 +1734,7 @@ function eme_printable_booking_report( $event_id ) {
                 $class         = 'eme_print_formfield' . $answer['field_id'];
                 $tmp_formfield = eme_get_formfield( $answer['field_id'] );
                 if ( ! empty( $tmp_formfield ) ) {
-                    print "<span class='$class'>$grouping.$occurence " . eme_esc_html( $tmp_formfield['field_name'] ) . ': ' . eme_answer2readable( $answer['answer'], $tmp_formfield, 1, '<br>', 'html' ) . '</span><br>';
+                    print "<span class='$class'>$grouping.$occurence " . esc_html( $tmp_formfield['field_name'] ) . ': ' . eme_answer2readable( $answer['answer'], $tmp_formfield, 1, '<br>', 'html' ) . '</span><br>';
                 }
             }
         }
@@ -1856,11 +1856,11 @@ function eme_person_verify_layout() {
             foreach ($person_ids as $person_id) {
                 print "<tr style='border-collapse: collapse;border: 1px solid black;'>";
                 print '<td>' . $person_id . '</td>';
-                print "<td><a href='" . esc_url( admin_url( 'admin.php?page=eme-people&eme_admin_action=edit_person&person_id=' . $person_id ) ) . "' title='" . esc_attr__( 'Edit person', 'events-made-easy' ) . "'>" . eme_esc_html( $row['lastname'] ) . '</a></td>';
-                print "<td><a href='" . esc_url( admin_url( 'admin.php?page=eme-people&eme_admin_action=edit_person&person_id=' . $person_id ) ) . "' title='" . esc_attr__( 'Edit person', 'events-made-easy' ) . "'>" . eme_esc_html( $row['firstname'] ) . '</a></td>';
-                print "<td><a href='" . esc_url( admin_url( 'admin.php?page=eme-people&eme_admin_action=edit_person&person_id=' . $person_id ) ) . "' title='" . esc_attr__( 'Edit person', 'events-made-easy' ) . "'>" . eme_esc_html( $row['email'] ) . '</a></td>';
+                print "<td><a href='" . esc_url( admin_url( 'admin.php?page=eme-people&eme_admin_action=edit_person&person_id=' . $person_id ) ) . "' title='" . esc_attr__( 'Edit person', 'events-made-easy' ) . "'>" . esc_html( $row['lastname'] ) . '</a></td>';
+                print "<td><a href='" . esc_url( admin_url( 'admin.php?page=eme-people&eme_admin_action=edit_person&person_id=' . $person_id ) ) . "' title='" . esc_attr__( 'Edit person', 'events-made-easy' ) . "'>" . esc_html( $row['firstname'] ) . '</a></td>';
+                print "<td><a href='" . esc_url( admin_url( 'admin.php?page=eme-people&eme_admin_action=edit_person&person_id=' . $person_id ) ) . "' title='" . esc_attr__( 'Edit person', 'events-made-easy' ) . "'>" . esc_html( $row['email'] ) . '</a></td>';
                 if ( $row['wp_id'] && isset( $wp_users[ $row['wp_id'] ] ) ) {
-                    print '<td>' . eme_esc_html( $wp_users[ $row['wp_id'] ] ) . '</td>';
+                    print '<td>' . esc_html( $wp_users[ $row['wp_id'] ] ) . '</td>';
                 } else {
                     print '<td>' . esc_html__('Non-existing WP user linked!!','events-made-easy' ) . '</td>';
                 }
@@ -1904,9 +1904,9 @@ function eme_person_verify_layout() {
             foreach ($person_ids as $person_id) {
                 print "<tr style='border-collapse: collapse;border: 1px solid black;'>";
                 print '<td>' . $person_id . '</td>';
-                print "<td><a href='" . esc_url( admin_url( 'admin.php?page=eme-people&eme_admin_action=edit_person&person_id=' . $person_id ) ) . "' title='" . esc_attr__( 'Edit person', 'events-made-easy' ) . "'>" . eme_esc_html( $row['lastname'] ) . '</a></td>';
-                print "<td><a href='" . esc_url( admin_url( 'admin.php?page=eme-people&eme_admin_action=edit_person&person_id=' . $person_id ) ) . "' title='" . esc_attr__( 'Edit person', 'events-made-easy' ) . "'>" . eme_esc_html( $row['firstname'] ) . '</a></td>';
-                print "<td><a href='" . esc_url( admin_url( 'admin.php?page=eme-people&eme_admin_action=edit_person&person_id=' . $person_id ) ) . "' title='" . esc_attr__( 'Edit person', 'events-made-easy' ) . "'>" . eme_esc_html( $row['email'] ) . '</a></td>';
+                print "<td><a href='" . esc_url( admin_url( 'admin.php?page=eme-people&eme_admin_action=edit_person&person_id=' . $person_id ) ) . "' title='" . esc_attr__( 'Edit person', 'events-made-easy' ) . "'>" . esc_html( $row['lastname'] ) . '</a></td>';
+                print "<td><a href='" . esc_url( admin_url( 'admin.php?page=eme-people&eme_admin_action=edit_person&person_id=' . $person_id ) ) . "' title='" . esc_attr__( 'Edit person', 'events-made-easy' ) . "'>" . esc_html( $row['firstname'] ) . '</a></td>';
+                print "<td><a href='" . esc_url( admin_url( 'admin.php?page=eme-people&eme_admin_action=edit_person&person_id=' . $person_id ) ) . "' title='" . esc_attr__( 'Edit person', 'events-made-easy' ) . "'>" . esc_html( $row['email'] ) . '</a></td>';
                 $membership_names = eme_get_linked_activemembership_names_by_personid( $person_id );
                 print "<td>$membership_names</td>";
                 $future_bookings = eme_get_bookings_by_person_id( $person_id, "future" );
@@ -1947,9 +1947,9 @@ function eme_person_verify_layout() {
             foreach ($person_ids as $person_id) {
                 print "<tr style='border-collapse: collapse;border: 1px solid black;'>";
                 print '<td>' . $person_id . '</td>';
-                print "<td><a href='" . esc_url( admin_url( 'admin.php?page=eme-people&eme_admin_action=edit_person&person_id=' . $person_id ) ) . "' title='" . esc_attr__( 'Edit person', 'events-made-easy' ) . "'>" . eme_esc_html( $row['lastname'] ) . '</a></td>';
-                print "<td><a href='" . esc_url( admin_url( 'admin.php?page=eme-people&eme_admin_action=edit_person&person_id=' . $person_id ) ) . "' title='" . esc_attr__( 'Edit person', 'events-made-easy' ) . "'>" . eme_esc_html( $row['firstname'] ) . '</a></td>';
-                print "<td><a href='" . esc_url( admin_url( 'admin.php?page=eme-people&eme_admin_action=edit_person&person_id=' . $person_id ) ) . "' title='" . esc_attr__( 'Edit person', 'events-made-easy' ) . "'>" . eme_esc_html( $row['email'] ) . '</a></td>';
+                print "<td><a href='" . esc_url( admin_url( 'admin.php?page=eme-people&eme_admin_action=edit_person&person_id=' . $person_id ) ) . "' title='" . esc_attr__( 'Edit person', 'events-made-easy' ) . "'>" . esc_html( $row['lastname'] ) . '</a></td>';
+                print "<td><a href='" . esc_url( admin_url( 'admin.php?page=eme-people&eme_admin_action=edit_person&person_id=' . $person_id ) ) . "' title='" . esc_attr__( 'Edit person', 'events-made-easy' ) . "'>" . esc_html( $row['firstname'] ) . '</a></td>';
+                print "<td><a href='" . esc_url( admin_url( 'admin.php?page=eme-people&eme_admin_action=edit_person&person_id=' . $person_id ) ) . "' title='" . esc_attr__( 'Edit person', 'events-made-easy' ) . "'>" . esc_html( $row['email'] ) . '</a></td>';
                 $membership_names = eme_get_linked_activemembership_names_by_personid( $person_id );
                 print "<td>$membership_names</td>";
                 $future_bookings = eme_get_bookings_by_person_id( $person_id, "future" );
@@ -2356,7 +2356,7 @@ function eme_manage_people_layout( $message = '' ) {
 <?php endif; ?>
 
     <h1><?php esc_html_e( 'Manage people', 'events-made-easy' ); ?></h1>
-    <?php echo sprintf( __( "Click <a href='%s'>here</a> to verify the integrity of EME people", 'events-made-easy' ), esc_url( admin_url( "admin.php?page=$plugin_page&eme_admin_action=verify_people" ) ) ); ?><br>
+    <?php printf( wp_kses_post( __( "Click <a href='%s'>here</a> to verify the integrity of EME people", 'events-made-easy' ) ), esc_url( admin_url( "admin.php?page=$plugin_page&eme_admin_action=verify_people" ) ) ); ?><br>
 
     <?php if ( isset( $_GET['trash'] ) && $_GET['trash'] == 1 ) { ?> 
         <a href="<?php echo esc_url( admin_url( "admin.php?page=$plugin_page&trash=0" ) ); ?>"><?php esc_html_e( 'Show regular content', 'events-made-easy' ); ?></a><br>
@@ -2483,7 +2483,7 @@ function eme_person_edit_layout( $person_id = 0, $message = '' ) {
         <table>
         <tr>
         <td style="vertical-align:top"><label for="firstname"><?php esc_html_e( 'First name', 'events-made-easy' ); ?></label></td>
-        <td><input id="firstname" name="firstname" type="text" value="<?php echo eme_esc_html( $person['firstname'] ); ?>" size="40" <?php echo $wp_readonly; ?>><br>
+        <td><input id="firstname" name="firstname" type="text" value="<?php echo esc_html( $person['firstname'] ); ?>" size="40" <?php echo $wp_readonly; ?>><br>
 <?php
     if ( ! empty( $wp_readonly ) ) {
         esc_html_e( 'Since this person is linked to a WP user, this field is read-only', 'events-made-easy' );
@@ -2496,7 +2496,7 @@ function eme_person_edit_layout( $person_id = 0, $message = '' ) {
         </tr>
         <tr>
         <td style="vertical-align:top"><label for="lastname"><?php esc_html_e( 'Last name', 'events-made-easy' ); ?></label></td>
-        <td><input id="lastname" name="lastname" type="text" value="<?php echo eme_esc_html( $person['lastname'] ); ?>" size="40" <?php echo $wp_readonly; ?>><br>
+        <td><input id="lastname" name="lastname" type="text" value="<?php echo esc_html( $person['lastname'] ); ?>" size="40" <?php echo $wp_readonly; ?>><br>
 <?php
     if ( ! empty( $wp_readonly ) ) {
         esc_html_e( 'Since this person is linked to a WP user, this field is read-only', 'events-made-easy' );
@@ -2507,7 +2507,7 @@ function eme_person_edit_layout( $person_id = 0, $message = '' ) {
         </tr>
         <tr>
         <td style="vertical-align:top"><label for="email"><?php esc_html_e( 'Email', 'events-made-easy' ); ?></label></td>
-        <td><input id="email" name="email" type="email" value="<?php echo eme_esc_html( $person['email'] ); ?>" size="40" <?php echo $wp_readonly; ?> autocomplete="off"><br>
+        <td><input id="email" name="email" type="email" value="<?php echo esc_html( $person['email'] ); ?>" size="40" <?php echo $wp_readonly; ?> autocomplete="off"><br>
 <?php
     if ( ! empty( $wp_readonly ) ) {
         esc_html_e( 'Since this person is linked to a WP user, this field is read-only', 'events-made-easy' );
@@ -2549,7 +2549,7 @@ function eme_person_edit_layout( $person_id = 0, $message = '' ) {
         foreach ( $familymember_person_ids as $family_person_id ) {
             $family_person = eme_get_person( $family_person_id );
             if ( $family_person ) {
-                print "<a href='" . esc_url( admin_url( "admin.php?page=eme-people&eme_admin_action=edit_person&person_id=$family_person_id" ) ) . "' title='" . esc_attr__( 'Edit person', 'events-made-easy' ) . "'>" . eme_esc_html( eme_format_full_name( $family_person['firstname'], $family_person['lastname'], $family_person['email'] ) ) . '</a><br>';
+                print "<a href='" . esc_url( admin_url( "admin.php?page=eme-people&eme_admin_action=edit_person&person_id=$family_person_id" ) ) . "' title='" . esc_attr__( 'Edit person', 'events-made-easy' ) . "'>" . esc_html( eme_format_full_name( $family_person['firstname'], $family_person['lastname'], $family_person['email'] ) ) . '</a><br>';
             }
         }
     }
@@ -2559,27 +2559,27 @@ function eme_person_edit_layout( $person_id = 0, $message = '' ) {
         </tr>
         <tr>
         <td><label for="phone"><?php esc_html_e( 'Phone Number', 'events-made-easy' ); ?></label></td>
-        <td><input id="phone" name="phone" type="text" value="<?php echo eme_esc_html( $person['phone'] ); ?>" size="40" autocomplete="off"></td>
+        <td><input id="phone" name="phone" type="text" value="<?php echo esc_html( $person['phone'] ); ?>" size="40" autocomplete="off"></td>
         <td></td>
         </tr>
         <tr>
         <td><label for="address1"><?php echo get_option( 'eme_address1_string' ); ?></label></td>
-        <td><input id="address1" name="address1" type="text" value="<?php echo eme_esc_html( $person['address1'] ); ?>" size="40"></td>
+        <td><input id="address1" name="address1" type="text" value="<?php echo esc_html( $person['address1'] ); ?>" size="40"></td>
         <td></td>
         </tr>
         <tr>
         <td><label for="address2"><?php echo get_option( 'eme_address2_string' ); ?></label></td>
-        <td><input id="address2" name="address2" type="text" value="<?php echo eme_esc_html( $person['address2'] ); ?>" size="40"></td>
+        <td><input id="address2" name="address2" type="text" value="<?php echo esc_html( $person['address2'] ); ?>" size="40"></td>
         <td></td>
         </tr>
         <tr>
         <td><label for="zip"><?php esc_html_e( 'Postal code', 'events-made-easy' ); ?></label></td>
-        <td><input name="zip" id="zip" type="text" value="<?php echo eme_esc_html( $person['zip'] ); ?>" size="40"></td>
+        <td><input name="zip" id="zip" type="text" value="<?php echo esc_html( $person['zip'] ); ?>" size="40"></td>
         <td></td>
         </tr>
         <tr>
         <td><label for="city"><?php esc_html_e( 'City', 'events-made-easy' ); ?></label></td>
-        <td><input name="city" id="city" type="text" value="<?php echo eme_esc_html( $person['city'] ); ?>" size="40"></td>
+        <td><input name="city" id="city" type="text" value="<?php echo esc_html( $person['city'] ); ?>" size="40"></td>
         <td></td>
         </tr>
         <tr>
@@ -2594,8 +2594,8 @@ function eme_person_edit_layout( $person_id = 0, $message = '' ) {
         </tr>
         <tr>
         <td><label for="dp_birthdate"><?php esc_html_e( 'Date of birth', 'events-made-easy' ); ?></label></td>
-        <td><input type='hidden' name='birthdate' id='birthdate' value='<?php echo eme_esc_html( $person['birthdate'] ); ?>'>
-        <input readonly='readonly' type='text' name='dp_birthdate' id='dp_birthdate' data-date='<?php echo eme_esc_html( $person['birthdate'] ); ?>' data-format='<?php echo EME_WP_DATE_FORMAT; ?>' data-alt-field='birthdate' data-view='years' class='eme_formfield_fdate'></td>
+        <td><input type='hidden' name='birthdate' id='birthdate' value='<?php echo esc_html( $person['birthdate'] ); ?>'>
+        <input readonly='readonly' type='text' name='dp_birthdate' id='dp_birthdate' data-date='<?php echo esc_html( $person['birthdate'] ); ?>' data-format='<?php echo EME_WP_DATE_FORMAT; ?>' data-alt-field='birthdate' data-view='years' class='eme_formfield_fdate'></td>
         <td></td>
         </tr>
         <tr>
@@ -2609,11 +2609,11 @@ function eme_person_edit_layout( $person_id = 0, $message = '' ) {
         </tr>
         <tr>
         <td><label for="birthplace"><?php esc_html_e( 'Place of birth', 'events-made-easy' ); ?></label></td>
-        <td colspan=2><input id="birthplace" name="birthplace" type="text" value="<?php echo eme_esc_html( $person['birthplace'] ); ?>" size="40"></td>
+        <td colspan=2><input id="birthplace" name="birthplace" type="text" value="<?php echo esc_html( $person['birthplace'] ); ?>" size="40"></td>
         </tr>
         <tr>
         <td><label for="language"><?php esc_html_e( 'Language', 'events-made-easy' ); ?></label></td>
-        <td colspan=2><input id="language" name="language" type="text" value="<?php echo eme_esc_html( $person['lang'] ); ?>" size="40" maxlength="7"></td>
+        <td colspan=2><input id="language" name="language" type="text" value="<?php echo esc_html( $person['lang'] ); ?>" size="40" maxlength="7"></td>
         </tr>
         <tr>
         <tr>
@@ -2776,15 +2776,15 @@ function eme_group_edit_layout( $group_id = 0, $message = '', $group_type = 'sta
         <table>
         <tr>
         <td><label for="name"><?php esc_html_e( 'Name', 'events-made-easy' ); ?></label></td>
-        <td><input required='required' id="name" name="name" type="text" value="<?php echo eme_esc_html( $group['name'] ); ?>" size="40"></td>
+        <td><input required='required' id="name" name="name" type="text" value="<?php echo esc_html( $group['name'] ); ?>" size="40"></td>
         </tr>
         <tr>
         <td><label for="description"><?php esc_html_e( 'Description', 'events-made-easy' ); ?></label></td>
-        <td><input id="description" name="description" type="text" value="<?php echo eme_esc_html( $group['description'] ); ?>" size="40"></td>
+        <td><input id="description" name="description" type="text" value="<?php echo esc_html( $group['description'] ); ?>" size="40"></td>
         </tr>
         <tr>
         <td><label for="email"><?php esc_html_e( 'Group email', 'events-made-easy' ); ?></label></td>
-        <td><input id="email" name="email" type="email" value="<?php echo eme_esc_html( $group['email'] ); ?>" size="40"><br>
+        <td><input id="email" name="email" type="email" value="<?php echo esc_html( $group['email'] ); ?>" size="40"><br>
             <?php esc_html_e( 'If you want to be able to send mail to this group via your mail client (and not just via EME), you need to configure the cli_mail method (see doc) and enter a unique email address for this group. This can be left empty.', 'events-made-easy' ); ?>
             </td>
         </tr>

--- a/eme-rsvp.php
+++ b/eme-rsvp.php
@@ -4816,14 +4816,14 @@ function eme_registration_seats_page( $pending = 0 ) {
         check_admin_referer( "eme_admin", 'eme_admin_nonce' );
         $event = eme_get_event( $event_id );
         if ( empty( $event ) ) {
-            print "<div id='message' class='error'><p>" . __( 'Access denied!', 'events-made-easy' ) . '</p></div>';
+            print "<div id='message' class='error'><p>" . esc_html__( 'Access denied!', 'events-made-easy' ) . '</p></div>';
             return;
         }
         $current_userid = get_current_user_id();
         if ( ! ( current_user_can( get_option( 'eme_cap_registrations' ) ) ||
             ( current_user_can( get_option( 'eme_cap_author_registrations' ) ) && ( $event['event_author'] == $current_userid || $event['event_contactperson_id'] == $current_userid ) ) ) ) {
 
-            print "<div id='message' class='error'><p>" . __( 'Access denied!', 'events-made-easy' ) . '</p></div>';
+            print "<div id='message' class='error'><p>" . esc_html__( 'Access denied!', 'events-made-easy' ) . '</p></div>';
             return;
         }
         // we need to set the action url, otherwise the GET parameters stay and we will fall in this if-statement all over again
@@ -4854,14 +4854,14 @@ function eme_registration_seats_page( $pending = 0 ) {
         $event_id = $booking['event_id'];
         $event    = eme_get_event( $event_id );
         if ( empty( $event ) ) {
-            print "<div id='message' class='error'><p>" . __( 'Access denied!', 'events-made-easy' ) . '</p></div>';
+            print "<div id='message' class='error'><p>" . esc_html__( 'Access denied!', 'events-made-easy' ) . '</p></div>';
             return;
         }
         $current_userid = get_current_user_id();
         if ( ! ( current_user_can( get_option( 'eme_cap_registrations' ) ) ||
             ( current_user_can( get_option( 'eme_cap_author_registrations' ) ) && ( $event['event_author'] == $current_userid || $event['event_contactperson_id'] == $current_userid ) ) ) ) {
 
-            print "<div id='message' class='error'><p>" . __( 'Access denied!', 'events-made-easy' ) . '</p></div>';
+            print "<div id='message' class='error'><p>" . esc_html__( 'Access denied!', 'events-made-easy' ) . '</p></div>';
             return;
         }
 
@@ -4909,7 +4909,7 @@ function eme_registration_seats_page( $pending = 0 ) {
             check_admin_referer( "eme_admin", 'eme_admin_nonce' );
             $event = eme_get_event( $event_id );
             if ( empty( $event ) ) {
-                print "<div id='message' class='error'><p>" . __( 'Access denied!', 'events-made-easy' ) . '</p></div>';
+                print "<div id='message' class='error'><p>" . esc_html__( 'Access denied!', 'events-made-easy' ) . '</p></div>';
             } else {
                 $booking_res = eme_book_seats( $event, $send_mail );
                 $result      = $booking_res[0];
@@ -5080,7 +5080,7 @@ function eme_registration_seats_page( $pending = 0 ) {
                 if ( $send_mail ) {
                     $mail_res = eme_email_booking_action( $booking, $action );
                     if ( ! $mail_res ) {
-                        print "<div id='mailmessage' class='error notice is-dismissible'><p>" . __( 'There were some problems while sending mail.', 'events-made-easy' ) . '</p></div>';
+                        print "<div id='mailmessage' class='error notice is-dismissible'><p>" . esc_html__( 'There were some problems while sending mail.', 'events-made-easy' ) . '</p></div>';
                     }
                 }
             } else {
@@ -5258,9 +5258,9 @@ function eme_registration_seats_form_table( $pending = 0 ) {
         } else {
             $event_q_string = '&event_id=' . intval( $_GET['event_id'] );
             if ( $pending ) {
-                printf( __( 'Manage pending bookings for %s', 'events-made-easy' ), esc_html( eme_translate( $event['event_name'] ) ) );
+                printf( esc_html__( 'Manage pending bookings for %s', 'events-made-easy' ), esc_html( eme_translate( $event['event_name'] ) ) );
             } else {
-                printf( __( 'Manage approved bookings for %s', 'events-made-easy' ), esc_html( eme_translate( $event['event_name'] ) ) );
+                printf( esc_html__( 'Manage approved bookings for %s', 'events-made-easy' ), esc_html( eme_translate( $event['event_name'] ) ) );
             }
         }
     } else {

--- a/eme-tasks.php
+++ b/eme-tasks.php
@@ -571,7 +571,7 @@ function eme_task_signups_table_layout( $message = '' ) {
     echo "
       <div class='wrap nosubsub'>
       <div id='poststuff'>
-         <h1>" . __( 'Manage task signups', 'events-made-easy' ) . "</h1>\n ";
+         <h1>" . esc_html__( 'Manage task signups', 'events-made-easy' ) . "</h1>\n ";
 
     ?>
     <div id="tasksignups-message" class="notice is-dismissible eme-message-admin <?php echo esc_attr( $hidden_class ); ?>">
@@ -904,7 +904,7 @@ function eme_meta_box_div_event_tasks( $event, $edit_recurrence = 0 ) {
         <?php
         if ( ! empty( $tasks ) ) {
             esc_html_e( 'Change the date of the listed tasks by this many days', 'events-made-easy' );
-            print "<input type='number' id=task_offset name=task_offset><button type='button' name='change_task_days' id='change_task_days'>" . __( 'Change', 'events-made-easy' ) . '</button>';
+            print "<input type='number' id=task_offset name=task_offset><button type='button' name='change_task_days' id='change_task_days'>" . esc_html__( 'Change', 'events-made-easy' ) . '</button>';
         }
         ?>
         <table class="eme_tasks">
@@ -972,7 +972,7 @@ function eme_meta_box_div_event_tasks( $event, $edit_recurrence = 0 ) {
                 <input <?php echo $required; ?> id="eme_tasks[<?php echo esc_attr( $count ); ?>][spaces]" name="eme_tasks[<?php echo esc_attr( $count ); ?>][spaces]" size="12" aria-label="spaces" value="<?php echo esc_attr( $task['spaces'] ); ?>">
                 </td>
                 <td>
-                <textarea class="eme_fullresizable" id="eme_tasks[<?php echo esc_attr( $count ); ?>][description]" name="eme_tasks[<?php echo esc_attr( $count ); ?>][description]" ><?php echo eme_esc_html( $task['description'] ); ?></textarea>
+                <textarea class="eme_fullresizable" id="eme_tasks[<?php echo esc_attr( $count ); ?>][description]" name="eme_tasks[<?php echo esc_attr( $count ); ?>][description]" ><?php echo esc_html( $task['description'] ); ?></textarea>
                 </td>
                 <td>
                 <a href="#" class='eme_remove_task'><?php echo "<img class='eme_remove_task' src='" . esc_url(EME_PLUGIN_URL) . "images/cross.png' alt='" . esc_attr__( 'Remove', 'events-made-easy' ) . "' title='" . esc_attr__( 'Remove', 'events-made-easy' ) . "'>"; ?></a><a href="#" class="eme_add_task"><?php echo "<img class='eme_add_task' src='" . esc_url(EME_PLUGIN_URL) . "images/plus_16.png' alt='" . esc_attr__( 'Add new task', 'events-made-easy' ) . "' title='" . esc_attr__( 'Add new task', 'events-made-easy' ) . "'>"; ?></a>

--- a/eme-templates.php
+++ b/eme-templates.php
@@ -160,7 +160,7 @@ function eme_templates_table_layout( $message = '' ) {
     echo "
       <div class='wrap nosubsub'>
       <div id='poststuff'>
-         <h1>" . __( 'Manage templates', 'events-made-easy' ) . "</h1>\n ";
+         <h1>" . esc_html__( 'Manage templates', 'events-made-easy' ) . "</h1>\n ";
 
     ?>
     <div id="templates-message" class="notice is-dismissible eme-message-admin <?php echo esc_attr( $hidden_class ); ?>">
@@ -252,11 +252,11 @@ function eme_templates_edit_layout( $template_id = 0, $message = '', $template =
         <table>
             <tr>
             <td><?php esc_html_e( 'Name', 'events-made-easy' ); ?></label></td>
-            <td><input required='required' id='name' name='name' type='text' value='<?php echo eme_esc_html( $template['name'] ); ?>' size='40'></td>
+            <td><input required='required' id='name' name='name' type='text' value='<?php echo esc_html( $template['name'] ); ?>' size='40'></td>
             </tr>
             <tr>
             <td><?php esc_html_e( 'Description', 'events-made-easy' ); ?></label></td>
-            <td><input id='description' name='description' type='text' value='<?php echo eme_esc_html( $template['description'] ); ?>' size='40'></td>
+            <td><input id='description' name='description' type='text' value='<?php echo esc_html( $template['description'] ); ?>' size='40'></td>
             </tr>
             <tr>
             <td><?php esc_html_e( 'Format', 'events-made-easy' ); ?></label></td>
@@ -294,22 +294,22 @@ function eme_templates_edit_layout( $template_id = 0, $message = '', $template =
             </tr>
             <tr class='form-field'>
             <th scope='row' style='vertical-align:top'><?php esc_html_e( 'PDF margins', 'events-made-easy' ); ?></th>
-            <td><input type='text' name='properties[pdf_margins]' id='properties[pdf_margins]' value='<?php echo eme_esc_html( $template['properties']['pdf_margins'] ); ?>' size='40'><br>
+            <td><input type='text' name='properties[pdf_margins]' id='properties[pdf_margins]' value='<?php echo esc_html( $template['properties']['pdf_margins'] ); ?>' size='40'><br>
             <?php esc_html_e( "See <a href='https://www.w3schools.com/cssref/pr_margin.asp'>this page</a> for info on what you can enter here.", 'events-made-easy' ); ?></td>
             </tr>
             <tr class='form-field template-pdf-custom'>
             <th scope='row' style='vertical-align:top'><?php esc_html_e( 'PDF width', 'events-made-easy' ); ?></th>
-            <td><input type='text' name='properties[pdf_width]' id='properties[pdf_width]' value='<?php echo eme_esc_html( $template['properties']['pdf_width'] ); ?>' size='40'><br>
+            <td><input type='text' name='properties[pdf_width]' id='properties[pdf_width]' value='<?php echo esc_html( $template['properties']['pdf_width'] ); ?>' size='40'><br>
             <?php esc_html_e( 'The width of the PDF document (in pt)', 'events-made-easy' ); ?></td>
             </tr>
             <tr class='form-field template-pdf-custom'>
             <th scope='row' style='vertical-align:top'><?php esc_html_e( 'PDF height', 'events-made-easy' ); ?></th>
-            <td><input type='text' name='properties[pdf_height]' id='properties[pdf_height]' value='<?php echo eme_esc_html( $template['properties']['pdf_height'] ); ?>' size='40'><br>
+            <td><input type='text' name='properties[pdf_height]' id='properties[pdf_height]' value='<?php echo esc_html( $template['properties']['pdf_height'] ); ?>' size='40'><br>
             <?php esc_html_e( 'The heigth of the PDF document (in pt)', 'events-made-easy' ); ?></td>
             </tr>
             <tr class='form-field'>
             <th scope='row' style='vertical-align:top'><?php esc_html_e( 'PDF mail attach format', 'events-made-easy' ); ?></th>
-            <td><input type='text' name='properties[pdf_attach_format]' id='properties[pdf_attach_format]' value='<?php echo eme_esc_html( $template['properties']['pdf_attach_format'] ); ?>' size='40'><br>
+            <td><input type='text' name='properties[pdf_attach_format]' id='properties[pdf_attach_format]' value='<?php echo esc_html( $template['properties']['pdf_attach_format'] ); ?>' size='40'><br>
             <?php esc_html_e( "When the template is being used as an attacment in a mail, the attachment has a default name. If you don't like the name given to the attachment in the mail, you can change it here. Relevant placeholders are allowed in their context (event/membership/booking/member/...). The '.pdf' extension will get added automatically, so no need to mention it.", 'events-made-easy' ); ?></td>
             </tr>
         </table>

--- a/eme-todos.php
+++ b/eme-todos.php
@@ -216,7 +216,7 @@ function eme_meta_box_div_event_todos( $event ) {
 				<input name='eme_todos[<?php echo esc_attr( $count ); ?>][todo_offset]' id='eme_todos[<?php echo esc_attr( $count ); ?>][todo_offset]' size="5" aria-label="event offset in days" value="<?php echo esc_attr( $todo['todo_offset'] ); ?>">
 				</td>
 				<td style="width: 60%;">
-				<textarea class="eme_fullresizable" id="eme_todos[<?php echo esc_attr( $count ); ?>][description]" name="eme_todos[<?php echo esc_attr( $count ); ?>][description]" ><?php echo eme_esc_html( $todo['description'] ); ?></textarea>
+				<textarea class="eme_fullresizable" id="eme_todos[<?php echo esc_attr( $count ); ?>][description]" name="eme_todos[<?php echo esc_attr( $count ); ?>][description]" ><?php echo esc_html( $todo['description'] ); ?></textarea>
 				</td>
 				<td>
 				<a href="#" class='eme_remove_todo'><?php echo "<img class='eme_remove_todo' src='" . esc_url(EME_PLUGIN_URL) . "images/cross.png' alt='" . esc_attr__( 'Remove', 'events-made-easy' ) . "' title='" . esc_attr__( 'Remove', 'events-made-easy' ) . "'>"; ?></a><a href="#" class="eme_add_todo"><?php echo "<img class='eme_add_todo' src='" . esc_url(EME_PLUGIN_URL) . "images/plus_16.png' alt='" . esc_attr__( 'Add new todo', 'events-made-easy' ) . "' title='" . esc_attr__( 'Add new todo', 'events-made-easy' ) . "'>"; ?></a>

--- a/events-manager.php
+++ b/events-manager.php
@@ -398,7 +398,7 @@ function eme_create_events_submenu() {
 function eme_explain_events_page_missing() {
 	$advice = sprintf( __( "Error: the special events page is not set or no longer exist, please set the option '%s' to an existing page or EME will not work correctly!", 'events-made-easy' ), __( 'Events page', 'events-made-easy' ) );
 	?>
-	<div id="message" class="error"><p> <?php echo eme_esc_html( $advice ); ?> </p></div>
+	<div id="message" class="error"><p> <?php echo esc_html( $advice ); ?> </p></div>
 	<?php
 }
 


### PR DESCRIPTION
## Summary
- Replace `eme_esc_html()` with `esc_html()` in echo/print output context (~107 PCP errors). PHPCS does not recognize custom wrappers as escaping functions, same pattern as PR #936 (eme_trans_esc_html).
- Convert unescaped `__()` in output to `esc_html__()` for plain text and `wp_kses_post(__())` for HTML-containing translations (~99 PCP errors).
- Convert `echo sprintf()` to `printf()` per maintainer preference (PR #935).
- The `eme_esc_html()` function definition is preserved -- it is still used in non-output contexts (variable assignments, array mapping).

## Test plan
- [x] PHP syntax check: all 20 files pass `php -l`
- [x] Automated tests: 76/76 pass
- [x] code-checks.sh --wpstore: all metrics stable
- [ ] Verify settings pages render correctly (eme-options.php has most changes)
- [ ] Verify event/member/people edit forms display correctly