### PR TITLE
Fix remaining output escaping: _e(), htmlspecialchars, variables, non-HTML output

### DIFF
--- a/class-qrcode.php
+++ b/class-qrcode.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped -- Third-party QR code library (MIT, Kazuhiko Arase). Output is computed from integer math and hardcoded color values, not user input.
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }

--- a/cli_mail.php
+++ b/cli_mail.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped -- CLI-only script (terminal output), not web HTML; WordPress escaping functions are inappropriate here.
 if ( php_sapi_name() != 'cli' ) {
 	echo "This script needs to be run in in command-line mode only !!!! \n";
 

--- a/eme-actions.php
+++ b/eme-actions.php
@@ -539,7 +539,7 @@ function eme_admin_notices() {
     <h3><?php esc_html_e( 'Events Made Easy has been installed or upgraded', 'events-made-easy' ); ?></h3>
     <h3><?php esc_html_e( 'Please donate to the development of Events Made Easy', 'events-made-easy' ); ?></h3>
 <?php
-            _e( 'If you find <strong>Events Made Easy</strong> useful to you, please consider making a small donation to help contribute to my time invested and to further development. Thanks for your kind support!', 'events-made-easy' );
+            echo wp_kses_post( __( 'If you find <strong>Events Made Easy</strong> useful to you, please consider making a small donation to help contribute to my time invested and to further development. Thanks for your kind support!', 'events-made-easy' ) );
 ?>
     <br><br>
 PayPal: <a href="https://www.paypal.com/donate/?business=SMGDS4GLCYWNG&no_recurring=0&currency_code=EUR"><img src="https://www.paypal.com/en_US/i/btn/btn_donate_LG.gif" alt="PayPal - The safer, easier way to pay online!"></a>

--- a/eme-attendances.php
+++ b/eme-attendances.php
@@ -125,7 +125,9 @@ function eme_attendances_table_layout( $message = '' ) {
       <div class='wrap nosubsub'>
       <div id='poststuff'>
          <h1>" . esc_html__( 'Manually add an attendance record', 'events-made-easy' ) . "</h1>
-	 <form action='#' method='post'>$nonce_field
+	 <form action='#' method='post'>"
+         . $nonce_field //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- wp_nonce_field() returns safe HTML
+         . "
          <input type='hidden' name='eme_admin_action' value='add_attendance'>
          <input type='hidden' name='person_id' value=''>
          "
@@ -141,7 +143,7 @@ function eme_attendances_table_layout( $message = '' ) {
 	if ( $message != '' ) {
 			echo "
             <div id='message' class='updated notice is-dismissible eme-message-admin'>
-               <p>$message</p>
+               <p>" . wp_kses_post( $message ) . "</p>
             </div>";
 	}
 	$att_types = eme_attendance_types();
@@ -150,7 +152,7 @@ function eme_attendances_table_layout( $message = '' ) {
 	<select id="search_type" name="search_type">
 	<?php
 	foreach ( $att_types as $key => $value ) {
-		echo "<option value='" . esc_html( $key ) . "'>" . esc_html( $value ) . '</option>';
+		echo "<option value='" . esc_attr( $key ) . "'>" . esc_html( $value ) . '</option>';
 	}
 	?>
 	</select>

--- a/eme-calendar.php
+++ b/eme-calendar.php
@@ -672,7 +672,7 @@ function eme_calendar_ajax() {
 	( ! empty( $_POST['holiday_id'] ) ) ? $holiday_id         = intval( $_POST['holiday_id'] ) : $holiday_id = '';
 	( ! empty( $_POST['weekdays'] ) ) ? $weekdays             = eme_sanitize_request( $_POST['weekdays'] ) : $weekdays = ''; // this can be a string like 0,2,3,5
 
-	echo eme_get_calendar( full: $full, month: $month, year: $year, long_events: $long_events, category: $category, author: $author, contact_person: $contact_person, location_id: $location_id, notcategory: $notcategory, template_id: $template_id, weekdays: $weekdays, holiday_id: $holiday_id, htmltable: $htmltable, htmldiv: $htmldiv );
+	echo eme_get_calendar( full: $full, month: $month, year: $year, long_events: $long_events, category: $category, author: $author, contact_person: $contact_person, location_id: $location_id, notcategory: $notcategory, template_id: $template_id, weekdays: $weekdays, holiday_id: $holiday_id, htmltable: $htmltable, htmldiv: $htmldiv ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted calendar HTML built by eme_get_calendar()
 	wp_die();
 }
 

--- a/eme-categories.php
+++ b/eme-categories.php
@@ -156,7 +156,7 @@ function eme_categories_edit_layout() {
 			    <th scope='row' style='vertical-align:top'><label for='slug'><?php echo esc_html( $permalink_string ); ?></label></th>
 				<td>
 				<?php
-				echo trailingslashit( home_url() );
+				echo esc_html( trailingslashit( home_url() ) );
 				$categories_prefixes = get_option( 'eme_permalink_categories_prefix', '' );
 				if ( empty( $categories_prefixes ) ) {
 					$extra_prefix        = 'cat/';
@@ -173,14 +173,14 @@ function eme_categories_edit_layout() {
 					$prefix = $category['category_prefix'] ? $category['category_prefix'] : '';
 					echo eme_ui_select( $prefix, 'category_prefix', $categories_prefixes_arr ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select()
 				} else {
-					echo eme_permalink_convert( $categories_prefixes );
+					echo esc_html( eme_permalink_convert( $categories_prefixes ) );
 				}
 				echo esc_html( $extra_prefix );
 				if ( $action == 'edit' ) {
 					$slug = $category['category_slug'] ? $category['category_slug'] : $category['category_name'];
 					$slug = eme_permalink_convert_noslash( $slug );
 					?>
-					<input type="text" id="slug" name="category_slug" value="<?php echo esc_attr( $slug ); ?>"><?php echo user_trailingslashit( '' ); ?>
+					<input type="text" id="slug" name="category_slug" value="<?php echo esc_attr( $slug ); ?>"><?php echo esc_html( user_trailingslashit( '' ) ); ?>
 						<?php
 				}
 				?>

--- a/eme-cleanup.php
+++ b/eme-cleanup.php
@@ -315,7 +315,7 @@ function eme_cleanup_form( $message = '', $preview_people = null ) {
     ?>
 <tr>
     <?php foreach ( [ 'person_id', 'firstname', 'lastname', 'email' ] as $field ) { ?>
-    <td><a href="<?php echo $edit_url; ?>" title="<?php echo $edit_title; ?>"><?php echo esc_html( $person[ $field ] ); ?></a></td>
+    <td><a href="<?php echo $edit_url; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- already escaped with esc_url() at assignment ?>" title="<?php echo $edit_title; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- already escaped with esc_attr__() at assignment ?>"><?php echo esc_html( $person[ $field ] ); ?></a></td>
     <?php } ?>
     <td> <?php echo esc_html( $person['creation_date'] ); ?></td>
     <td> <?php echo esc_html( $person['modif_date'] ); ?></td>

--- a/eme-cron.php
+++ b/eme-cron.php
@@ -311,7 +311,7 @@ function eme_cron_form( $message = '' ) {
             echo '<br>';
             esc_html_e( 'Put something like this in the crontab of your server:', 'events-made-easy' );
             echo '<br>';
-            echo '<code>*/5 * * * * wget -q -O - ' . site_url( '/wp-cron.php' ) . ' >/dev/null 2>&1 </code><br>';
+            echo '<code>*/5 * * * * wget -q -O - ' . esc_html( site_url( '/wp-cron.php' ) ) . ' >/dev/null 2>&1 </code><br>';
             esc_html_e( 'And add the following to your wp-config.php:', 'events-made-easy' );
             echo '<br>';
             echo "<code>define('DISABLE_WP_CRON', true);</code>";
@@ -324,7 +324,7 @@ function eme_cron_form( $message = '' ) {
             echo '<br>';
             esc_html_e( 'Put something like this in the crontab of your server:', 'events-made-easy' );
             echo '<br>';
-            echo '<code>*/5 * * * * curl --user "username:password" ' . site_url( '/wp-json/events-made-easy/v1/processqueue/60' ) . ' >/dev/null 2>&1 </code><br>';
+            echo '<code>*/5 * * * * curl --user "username:password" ' . esc_html( site_url( '/wp-json/events-made-easy/v1/processqueue/60' ) ) . ' >/dev/null 2>&1 </code><br>';
             esc_html_e( 'Change the "username" by your user and the "password" by an application password generated in your WP user settings.', 'events-made-easy' );
             echo '<br>';
             esc_html_e( '"60" means the script can run at most for 55 seconds (=60-5, 5 being a safety measure). Never set this higher than your cron recurrence of course.', 'events-made-easy' );
@@ -395,9 +395,9 @@ function eme_cron_form( $message = '' ) {
             $schedule = $schedules[ $eme_cron_send_queued_schedule ];
             echo '<br>';
             if ($eme_cron_queue_count > 0 ) {
-                echo sprintf( esc_html__( 'Queued emails will be send out in batches of %d %s', 'events-made-easy' ), get_option( 'eme_cron_queue_count' ), $schedule['display'] );
+                printf( esc_html__( 'Queued emails will be send out in batches of %d %s', 'events-made-easy' ), intval( get_option( 'eme_cron_queue_count' ) ), esc_html( $schedule['display'] ) );
             } else {
-                echo sprintf( esc_html__( 'All queued emails will be send out without limit %s.', 'events-made-easy' ), $schedule['display'] );
+                printf( esc_html__( 'All queued emails will be send out without limit %s.', 'events-made-easy' ), esc_html( $schedule['display'] ) );
             }
         }
     }

--- a/eme-discounts.php
+++ b/eme-discounts.php
@@ -893,14 +893,14 @@ function eme_discounts_edit_layout( $discount_id = 0, $message = '' ) {
 		<tr class='form-field'>
 			<th scope='row' style='vertical-align:top'><label for='dp_valid_from'><?php esc_html_e( 'Valid from', 'events-made-easy' ); ?></label></th>
 			<td><input type='hidden' readonly='readonly' name='valid_from' id='valid_from'>
-			<input type='text' readonly='readonly' name='dp_valid_from' id='dp_valid_from' data-date='<?php if ( $discount['valid_from'] ) { echo eme_js_datetime( $discount['valid_from'] );} ?>' data-alt-field='valid_from' class='eme_formfield_fdatetime'>
+			<input type='text' readonly='readonly' name='dp_valid_from' id='dp_valid_from' data-date='<?php if ( $discount['valid_from'] ) { echo esc_attr( eme_js_datetime( $discount['valid_from'] ) );} ?>' data-alt-field='valid_from' class='eme_formfield_fdatetime'>
 			<br><?php esc_html_e( 'An optional coupon start date and time, if entered the coupon is not valid before this date and time.', 'events-made-easy' ); ?>
 			</td>
 		</tr>
 		<tr class='form-field'>
 			<th scope='row' style='vertical-align:top'><label for='dp_valid_to'><?php esc_html_e( 'Valid until', 'events-made-easy' ); ?></label></th>
 			<td><input type='hidden' readonly='readonly' name='valid_to' id='valid_to'>
-			<input type='text' readonly='readonly' name='dp_valid_to' id='dp_valid_to' data-date='<?php if ( $discount['valid_to'] ) { echo eme_js_datetime( $discount['valid_to'] );} ?>' data-alt-field='valid_to' class='eme_formfield_fdatetime'>
+			<input type='text' readonly='readonly' name='dp_valid_to' id='dp_valid_to' data-date='<?php if ( $discount['valid_to'] ) { echo esc_attr( eme_js_datetime( $discount['valid_to'] ) );} ?>' data-alt-field='valid_to' class='eme_formfield_fdatetime'>
 			<br><?php esc_html_e( 'An optional coupon expiration date and time, if entered the coupon is not valid after this date and time.', 'events-made-easy' ); ?>
 			</td>
 		</tr>

--- a/eme-events.php
+++ b/eme-events.php
@@ -7052,7 +7052,7 @@ function eme_meta_box_div_event_name( $event, $edit_recurrence = 0 ) {
     } else {
         echo '<b>' . esc_html__( 'Permalink prefix: ', 'events-made-easy' ) . '</b>';
     }
-    echo trailingslashit( home_url() );
+    echo esc_html( trailingslashit( home_url() ) );
     $events_prefixes = get_option( 'eme_permalink_events_prefix', 'events' );
     if ( preg_match( '/,/', $events_prefixes ) ) {
         $events_prefixes     = explode( ',', $events_prefixes );
@@ -7063,7 +7063,7 @@ function eme_meta_box_div_event_name( $event, $edit_recurrence = 0 ) {
         $prefix = $event['event_prefix'] ? $event['event_prefix'] : '';
         echo eme_ui_select( $prefix, 'event_prefix', $events_prefixes_arr ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select()
     } else {
-        echo eme_permalink_convert( $events_prefixes );
+        echo esc_html( eme_permalink_convert( $events_prefixes ) );
     }
     if ( ! empty( $event['event_id'] ) && ! empty( $event['event_name'] ) != '' ) {
         $slug = $event['event_slug'] ? $event['event_slug'] : $event['event_name'];
@@ -7072,7 +7072,7 @@ function eme_meta_box_div_event_name( $event, $edit_recurrence = 0 ) {
             $slug = preg_replace( '/\-\d+$/', '', $slug );
         }
 ?>
-        <input type="text" id="event_slug" name="event_slug" value="<?php echo esc_attr( $slug ); ?>"><?php echo user_trailingslashit( '' ); ?>
+        <input type="text" id="event_slug" name="event_slug" value="<?php echo esc_attr( $slug ); ?>"><?php echo esc_html( user_trailingslashit( '' ) ); ?>
 <?php
     }
 ?>
@@ -8455,15 +8455,15 @@ function eme_meta_box_div_event_image( $event ) {
     </h3>
 <?php
     if ( ! empty( $event['event_image_url'] ) ) {
-        echo "<img id='eme_event_image_example' alt='" . esc_attr__( 'Event image', 'events-made-easy' ) . "' src='" . $event['event_image_url'] . "' width='200'>";
-        echo "<input type='hidden' name='event_image_url' id='event_image_url' value='" . $event['event_image_url'] . "'>";
+        echo "<img id='eme_event_image_example' alt='" . esc_attr__( 'Event image', 'events-made-easy' ) . "' src='" . esc_url( $event['event_image_url'] ) . "' width='200'>";
+        echo "<input type='hidden' name='event_image_url' id='event_image_url' value='" . esc_attr( $event['event_image_url'] ) . "'>";
     } else {
         # to prevent html validation errors, use a transparent small pixel
         echo "<img id='eme_event_image_example' src='data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNgYAAAAAMAASsJTYQAAAAASUVORK5CYII=' alt='" . esc_attr__( 'Event image', 'events-made-easy' ) . "' width='200'>";
         echo "<input type='hidden' name='event_image_url' id='event_image_url'>";
     }
     if ( ! empty( $event['event_image_id'] ) ) {
-        echo "<input type='hidden' name='event_image_id' id='event_image_id' value='" . $event['event_image_id'] . "'>";
+        echo "<input type='hidden' name='event_image_id' id='event_image_id' value='" . absint( $event['event_image_id'] ) . "'>";
     } else {
         echo "<input type='hidden' name='event_image_id' id='event_image_id'>";
     }
@@ -9033,18 +9033,18 @@ function eme_rss() {
 <channel>
 <title>
 <?php
-    echo eme_rss_cdata( $main_title );
+    echo eme_rss_cdata( $main_title ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- RSS CDATA output, escaping would break format
 ?>
 </title>
 <link>
 <?php
     $events_page_link = eme_get_events_page();
-    echo eme_rss_cdata( $events_page_link );
+    echo eme_rss_cdata( $events_page_link ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- RSS CDATA output, escaping would break format
 ?>
 </link>
 <description>
 <?php
-    echo eme_rss_cdata( eme_sanitize_request( $rss_options['main_description'] ) );
+    echo eme_rss_cdata( eme_sanitize_request( $rss_options['main_description'] ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- RSS CDATA output, escaping would break format
 ?>
 </description>
 <docs>
@@ -9075,6 +9075,7 @@ Weblog Editor 2.0
             } else {
                 $image_url = '';
             }
+            // phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped -- RSS XML output, escaping would break format
             echo "<item>\n";
             echo "<title>$title</title>\n";
             echo "<link>$event_link</link>\n";
@@ -9099,6 +9100,7 @@ Weblog Editor 2.0
                 echo "</image>\n";
             }
             echo "</item>\n";
+            // phpcs:enable WordPress.Security.EscapeOutput.OutputNotEscaped
         }
     }
 ?>

--- a/eme-functions.php
+++ b/eme-functions.php
@@ -3864,7 +3864,7 @@ function eme_unserialize( $data ) {
 function eme_prettyprint_assoc( $jsonData, $pre = '' ) {
     $pretty = '';
     foreach ( $jsonData as $key => $val ) {
-        $pretty .= $pre . htmlspecialchars( ucfirst( $key ) ) . ': ';
+        $pretty .= $pre . esc_html( ucfirst( $key ) ) . ': ';
         if ( strcmp( gettype( $val ), 'array' ) == 0 ) {
             $pretty .= "<br>\n";
             $sno     = 1;
@@ -3873,7 +3873,7 @@ function eme_prettyprint_assoc( $jsonData, $pre = '' ) {
                 $pretty .= eme_prettyprint_assoc( $value, $pre . '&nbsp;&nbsp;' );
             }
         } else {
-            $pretty .= htmlspecialchars( $val ) . "<br>\n";
+            $pretty .= esc_html( $val ) . "<br>\n";
         }
     }
     return $pretty;
@@ -4344,7 +4344,7 @@ function eme_merge_classes_into_attrs($class, $attributes) {
     $class_value = implode(' ', $merged_classes);
     
     // Build the class attribute if we have any classes
-    $class_att = !empty($merged_classes) ? "class='" . htmlspecialchars($class_value, ENT_QUOTES) . "'" : '';
+    $class_att = !empty($merged_classes) ? "class='" . esc_attr($class_value) . "'" : '';
     
     // Combine with other attributes
     return trim($class_att . ' ' . $attributes);

--- a/eme-gdpr.php
+++ b/eme-gdpr.php
@@ -404,7 +404,7 @@ function eme_cpi_form( $person_id ) {
 }
 
 function eme_gdpr_approve_show() {
-	print eme_translate( get_option( 'eme_gdpr_approve_page_content' ) );
+	print eme_kses_maybe_unfiltered( eme_translate( get_option( 'eme_gdpr_approve_page_content' ) ) );
 }
 
 function eme_show_personal_info( $email ) {

--- a/eme-ical.php
+++ b/eme-ical.php
@@ -185,6 +185,7 @@ function eme_ical_single() {
 	echo "PRODID:-//hacksw/handcal//NONSGML v1.0//EN\r\n";
 	$event = eme_get_event( eme_sanitize_request( $_GET['event_id'] ) );
 	if ( ! empty( $event ) ) {
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- iCal format output (text/calendar), not HTML
 		echo eme_ical_single_event( $event );
 	}
 	echo "END:VCALENDAR\r\n";
@@ -212,6 +213,7 @@ function eme_ical() {
 	$contact_person     = isset( $_GET['contact_person'] ) ? eme_sanitize_request( urldecode( $_GET['contact_person'] ) ) : '';
 	$events             = eme_get_events( scope: $scope, location_id: $location_id, category: $category, author: $author, contact_person: $contact_person, show_ongoing: 1, notcategory: $notcategory );
 	foreach ( $events as $event ) {
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- iCal format output (text/calendar), not HTML
 		echo eme_ical_single_event( $event );
 	}
 	echo "END:VCALENDAR\r\n";
@@ -221,6 +223,7 @@ function eme_sitemap() {
 	eme_nocache_headers();
 	header( 'Content-type: text/xml; charset=utf-8' );
 	header( 'Content-Disposition: inline; filename=eme_public.xml' );
+	// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- XML sitemap output (text/xml), not HTML
 	echo '<?xml version="1.0" encoding="UTF-8"?>' . "\n" . '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">' . "\n";
 	$events = eme_get_events( limit: 5000, scope: 'all', order: 'DESC' );
 	if ( ! empty( $events ) ) {

--- a/eme-locations.php
+++ b/eme-locations.php
@@ -497,7 +497,7 @@ function eme_meta_box_div_location_name( $location ) {
     } else {
         echo '<b>' . esc_html__( 'Permalink prefix: ', 'events-made-easy' ) . '</b>';
     }
-    echo trailingslashit( home_url() );
+    echo esc_html( trailingslashit( home_url() ) );
     $locations_prefixes = get_option( 'eme_permalink_locations_prefix', 'locations' );
     if ( preg_match( '/,/', $locations_prefixes ) ) {
         $locations_prefixes     = explode( ',', $locations_prefixes );
@@ -508,13 +508,13 @@ function eme_meta_box_div_location_name( $location ) {
         $prefix = $location['location_prefix'] ? $location['location_prefix'] : '';
         echo eme_ui_select( $prefix, 'location_prefix', $locations_prefixes_arr ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_select()
     } else {
-        echo eme_permalink_convert( $locations_prefixes );
+        echo esc_html( eme_permalink_convert( $locations_prefixes ) );
     }
     if ( $action == 'edit' ) {
         $slug = $location['location_slug'] ? $location['location_slug'] : $location['location_name'];
         $slug = eme_permalink_convert_noslash( $slug );
 ?>
-        <input type="text" id="slug" name="location_slug" value="<?php echo esc_attr( $slug ); ?>"><?php echo user_trailingslashit( '' ); ?>
+        <input type="text" id="slug" name="location_slug" value="<?php echo esc_attr( $slug ); ?>"><?php echo esc_html( user_trailingslashit( '' ) ); ?>
 <?php
     }
 ?>
@@ -552,11 +552,11 @@ function eme_meta_box_div_location_details( $location ) {
             </h3>
             <div class="inside" style="float:left; width:50%">
             <table><tr>
-            <td><label for="location_address1"><?php echo eme_translate( get_option( 'eme_address1_string' ) ); ?></label></td>
+            <td><label for="location_address1"><?php echo esc_html( eme_translate( get_option( 'eme_address1_string' ) ) ); ?></label></td>
             <td><input id="location_address1" name="location_address1" type="text" value="<?php echo esc_html( $location['location_address1'] ); ?>" size="40"></td>
             </tr>
             <tr>
-            <td><label for="location_address2"><?php echo eme_translate( get_option( 'eme_address2_string' ) ); ?></label></td>
+            <td><label for="location_address2"><?php echo esc_html( eme_translate( get_option( 'eme_address2_string' ) ) ); ?></label></td>
             <td><input id="location_address2" name="location_address2" type="text" value="<?php echo esc_html( $location['location_address2'] ); ?>" size="40"></td>
             </tr>
             <tr>
@@ -692,15 +692,15 @@ function eme_meta_box_div_location_image( $location ) {
     <div id="location_current_image_inside" class="inside">
 <?php
     if ( ! empty( $location['location_image_url'] ) ) {
-        echo "<img id='eme_location_image_example' alt='" . esc_attr__( 'Location image', 'events-made-easy' ) . "' src='" . $location['location_image_url'] . "' width='200'>";
-        echo "<input type='hidden' name='location_image_url' id='location_image_url' value='" . $location['location_image_url'] . "'>";
+        echo "<img id='eme_location_image_example' alt='" . esc_attr__( 'Location image', 'events-made-easy' ) . "' src='" . esc_url( $location['location_image_url'] ) . "' width='200'>";
+        echo "<input type='hidden' name='location_image_url' id='location_image_url' value='" . esc_attr( $location['location_image_url'] ) . "'>";
     } else {
         # to prevent html validation errors, use a transparent small pixel
         echo "<img id='eme_location_image_example' alt='" . esc_attr__( 'Location image', 'events-made-easy' ) . "' src='data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNgYAAAAAMAASsJTYQAAAAASUVORK5CYII=' width='200'>";
         echo "<input type='hidden' name='location_image_url' id='location_image_url'>";
     }
     if ( ! empty( $location['location_image_id'] ) ) {
-        echo "<input type='hidden' name='location_image_id' id='location_image_id' value='" . $location['location_image_id'] . "'>";
+        echo "<input type='hidden' name='location_image_id' id='location_image_id' value='" . absint( $location['location_image_id'] ) . "'>";
     } else {
         echo "<input type='hidden' name='location_image_id' id='location_image_id'>";
     }

--- a/eme-mailer.php
+++ b/eme-mailer.php
@@ -2034,7 +2034,7 @@ function eme_send_mails_ajax_actions( $action ) {
         if ( ! eme_is_email( $testmail_to ) ) {
             $ajaxResult['htmlmessage'] = "<div id='message' class='error eme-message-admin'><p>" . __( 'Please enter a valid email address', 'events-made-easy' ) . '</p></div>';
             $ajaxResult['Result']      = 'ERROR';
-            echo wp_json_encode( $ajaxResult );
+            echo wp_json_encode( $ajaxResult ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- wp_json_encode() returns safe JSON
             wp_die();
         }
 
@@ -2058,7 +2058,7 @@ function eme_send_mails_ajax_actions( $action ) {
             $ajaxResult['htmlmessage'] = "<div id='message' class='error eme-message-admin'><p>" . __( 'There were some problems while sending mail.', 'events-made-easy' ) . "</p><p>$extra_html</p></div>";
             $ajaxResult['Result']      = 'ERROR';
         }
-        echo wp_json_encode( $ajaxResult );
+        echo wp_json_encode( $ajaxResult ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- wp_json_encode() returns safe JSON
         wp_die();
     }
 
@@ -2095,7 +2095,7 @@ function eme_send_mails_ajax_actions( $action ) {
         if ( empty( $mail_subject ) || empty( $mail_message ) ) {
             $ajaxResult['htmlmessage'] = "<div id='message' class='error eme-message-admin'><p>" . __( 'Please enter both subject and message for the mail to be sent.', 'events-made-easy' ) . '</p></div>';
             $ajaxResult['Result']      = 'ERROR';
-            echo wp_json_encode( $ajaxResult );
+            echo wp_json_encode( $ajaxResult ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- wp_json_encode() returns safe JSON
             wp_die();
         }
 
@@ -2110,7 +2110,7 @@ function eme_send_mails_ajax_actions( $action ) {
         if ( empty( $contact_email ) ) {
             $ajaxResult['htmlmessage'] = "<div id='message' class='error eme-message-admin'><p>" . __( 'No default sender defined and no event contact email found, bailing out', 'events-made-easy' ) . '</p></div>';
             $ajaxResult['Result']      = 'ERROR';
-            echo wp_json_encode( $ajaxResult );
+            echo wp_json_encode( $ajaxResult ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- wp_json_encode() returns safe JSON
             wp_die();
         }
         $mailing_id = 0;
@@ -2144,7 +2144,7 @@ function eme_send_mails_ajax_actions( $action ) {
                     $ajaxResult['Result']      = 'ERROR';
                 }
             }
-            echo wp_json_encode( $ajaxResult );
+            echo wp_json_encode( $ajaxResult ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- wp_json_encode() returns safe JSON
             wp_die();
         } else {
             if ( ! empty( $_POST['genericmail_mailing_name'] ) ) {
@@ -2187,7 +2187,7 @@ function eme_send_mails_ajax_actions( $action ) {
             if ( ! $recipients_configured ) {
                 $ajaxResult['htmlmessage'] = "<div id='message' class='error eme-message-admin'><p>" . __( 'Please select at least one recipient.', 'events-made-easy' ) . '</p></div>';
                 $ajaxResult['Result']      = 'ERROR';
-                echo wp_json_encode( $ajaxResult );
+                echo wp_json_encode( $ajaxResult ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- wp_json_encode() returns safe JSON
                 wp_die();
             }
             if ( $queue && $fast_queue ) {
@@ -2229,7 +2229,7 @@ function eme_send_mails_ajax_actions( $action ) {
             }
             $ajaxResult['Result'] = 'ERROR';
         }
-        echo wp_json_encode( $ajaxResult );
+        echo wp_json_encode( $ajaxResult ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- wp_json_encode() returns safe JSON
         wp_die();
     }
 
@@ -2263,7 +2263,7 @@ function eme_send_mails_ajax_actions( $action ) {
         if ( empty( $mail_subject ) || empty( $mail_message ) ) {
             $ajaxResult['htmlmessage'] = "<div id='message' class='error eme-message-admin'><p>" . __( 'Please enter both subject and message for the mail to be sent.', 'events-made-easy' ) . '</p></div>';
             $ajaxResult['Result']      = 'ERROR';
-            echo wp_json_encode( $ajaxResult );
+            echo wp_json_encode( $ajaxResult ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- wp_json_encode() returns safe JSON
             wp_die();
         }
 
@@ -2271,7 +2271,7 @@ function eme_send_mails_ajax_actions( $action ) {
         if ( ! eme_is_numeric_array( $event_ids ) ) {
             $ajaxResult['htmlmessage'] = "<div id='message' class='error eme-message-admin'><p>" . __( 'Please select at least one event.', 'events-made-easy' ) . '</p></div>';
             $ajaxResult['Result']      = 'ERROR';
-            echo wp_json_encode( $ajaxResult );
+            echo wp_json_encode( $ajaxResult ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- wp_json_encode() returns safe JSON
             wp_die();
         }
 
@@ -2327,7 +2327,7 @@ function eme_send_mails_ajax_actions( $action ) {
                     $ajaxResult['Result']      = 'ERROR';
                 }
             }
-            echo wp_json_encode( $ajaxResult );
+            echo wp_json_encode( $ajaxResult ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- wp_json_encode() returns safe JSON
             wp_die();
         } else {
             if ( ! empty( $_POST['eme_eventmail_send_persons'] ) && eme_is_numeric_array( $_POST['eme_eventmail_send_persons'] ) ) {
@@ -2349,7 +2349,7 @@ function eme_send_mails_ajax_actions( $action ) {
             if ( empty( $eme_mail_type ) ) {
                 $ajaxResult['htmlmessage'] = "<div id='message' class='error eme-message-admin'><p>" . __( 'Please select the type of mail to be sent.', 'events-made-easy' ) . '</p></div>';
                 $ajaxResult['Result']      = 'ERROR';
-                echo wp_json_encode( $ajaxResult );
+                echo wp_json_encode( $ajaxResult ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- wp_json_encode() returns safe JSON
                 wp_die();
             }
             $conditions['eme_mail_type'] = $eme_mail_type;
@@ -2424,7 +2424,7 @@ function eme_send_mails_ajax_actions( $action ) {
             }
             $ajaxResult['Result'] = 'ERROR';
         }
-        echo wp_json_encode( $ajaxResult );
+        echo wp_json_encode( $ajaxResult ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- wp_json_encode() returns safe JSON
         wp_die();
     }
     wp_die();

--- a/eme-members.php
+++ b/eme-members.php
@@ -2944,7 +2944,7 @@ function eme_render_members_searchfields( $limit_to_group = 0, $group_to_edit = 
     }
 
     if ($limit_to_group) {
-        echo '<input type="hidden" name="search_groups" id="'.$id_prefix.'search_groups" value="' . esc_attr($limit_to_group) . '">';
+        echo '<input type="hidden" name="search_groups" id="'.esc_attr($id_prefix).'search_groups" value="' . esc_attr($limit_to_group) . '">';
         // currently we don't show the other filters anymore (double id's, need to fix that first)
         //return;
     }
@@ -2977,7 +2977,7 @@ function eme_render_members_searchfields( $limit_to_group = 0, $group_to_edit = 
     } else {
         $value = '';
     }
-    echo '<input type="search" value="' . esc_attr($value) . '" name="search_person" id="'.$id_prefix.'search_person" placeholder="' . esc_attr__( 'Filter on person', 'events-made-easy' ) . '" class="eme_searchfilter" size=15>';
+    echo '<input type="search" value="' . esc_attr($value) . '" name="search_person" id="'.esc_attr($id_prefix).'search_person" placeholder="' . esc_attr__( 'Filter on person', 'events-made-easy' ) . '" class="eme_searchfilter" size=15>';
 
     if ( $edit_group ) {
         echo '</td></tr><tr><td>' . esc_html__( 'Filter on member ID', 'events-made-easy' ) . '</td><td>';
@@ -2987,9 +2987,9 @@ function eme_render_members_searchfields( $limit_to_group = 0, $group_to_edit = 
     } else {
         $value = '';
     }
-    echo '<input type="number" value="' . esc_attr($value) . '" name="search_memberid" id="'.$id_prefix.'search_memberid" placeholder="' . esc_attr__( 'Filter on member ID', 'events-made-easy' ) . '" class="eme_searchfilter" size=15>';
-    echo '<input type="search" name="search_paymentid" id="'.$id_prefix.'search_paymentid" placeholder="' . esc_attr__( 'Filter on payment id', 'events-made-easy' ) . '" class="eme_searchfilter">';
-    echo '<input type="search" name="search_pg_pid" id="'.$id_prefix.'search_pg_pid" placeholder="' . esc_attr__( 'Filter on payment GW id', 'events-made-easy' ) . '" class="eme_searchfilter" size=15>';
+    echo '<input type="number" value="' . esc_attr($value) . '" name="search_memberid" id="'.esc_attr($id_prefix).'search_memberid" placeholder="' . esc_attr__( 'Filter on member ID', 'events-made-easy' ) . '" class="eme_searchfilter" size=15>';
+    echo '<input type="search" name="search_paymentid" id="'.esc_attr($id_prefix).'search_paymentid" placeholder="' . esc_attr__( 'Filter on payment id', 'events-made-easy' ) . '" class="eme_searchfilter">';
+    echo '<input type="search" name="search_pg_pid" id="'.esc_attr($id_prefix).'search_pg_pid" placeholder="' . esc_attr__( 'Filter on payment GW id', 'events-made-easy' ) . '" class="eme_searchfilter" size=15>';
 
     $formfields_searchable = eme_get_searchable_formfields( 'members', 1 );
     if ( ! empty( $formfields_searchable ) ) {

--- a/eme-options.php
+++ b/eme-options.php
@@ -2627,7 +2627,7 @@ case 'payments':
     eme_options_input_text( __( 'Extra charge', 'events-made-easy' ), 'eme_' . $gateway . '_cost', __( 'Extra charge added to the price. Can either be an absolute number or a percentage. E.g. 2 or 5%', 'events-made-easy' ) );
     eme_options_input_text( __( 'Extra charge 2', 'events-made-easy' ), 'eme_' . $gateway . '_cost2', __( 'Second extra charge added to the price. Can either be an absolute number or a percentage. E.g. 2 or 5%', 'events-made-easy' ) );
 ?>
-<tr><th colspan='2'><?php _e('Extra payment method information','events-made-easy');?></th></tr>
+<tr><th colspan='2'><?php esc_html_e('Extra payment method information','events-made-easy');?></th></tr>
 <tr><td colspan='2'><?php printf(esc_html__('Internal payment method name: %s','events-made-easy'), esc_html('offline'));?></td></tr>
 </table>
 </div>
@@ -2661,9 +2661,9 @@ case 'payments':
     eme_options_input_text( __( 'Text above payment button', 'events-made-easy' ), 'eme_' . $gateway . '_button_above', __( 'The text shown just above the payment button', 'events-made-easy' ) . '<br>' . esc_html__( 'For all possible placeholders, see ', 'events-made-easy' ) . "<a target='_blank' href='//www.e-dynamics.be/wordpress/category/documentation/7-placeholders/payment-gateways/'>" . esc_html__( 'the documentation', 'events-made-easy' ) . '</a>' );
     eme_options_input_text( __( 'Text below payment button', 'events-made-easy' ), 'eme_' . $gateway . '_button_below', __( 'The text shown just below the payment button', 'events-made-easy' ) . '<br>' . esc_html__( 'For all possible placeholders, see ', 'events-made-easy' ) . "<a target='_blank' href='//www.e-dynamics.be/wordpress/category/documentation/7-placeholders/payment-gateways/'>" . esc_html__( 'the documentation', 'events-made-easy' ) . '</a>' );
 ?>
-<tr><th colspan='2'><?php _e('Extra payment method information','events-made-easy'); ?></th></tr>
+<tr><th colspan='2'><?php esc_html_e('Extra payment method information','events-made-easy'); ?></th></tr>
 <tr><td colspan='2'><?php printf(esc_html__('The url for payment notifications is: %s','events-made-easy'), esc_html($notification_link)); ?></td></tr>
-<tr><td colspan='2'><?php _e('Refunding is possible.','events-made-easy'); ?></td></tr>
+<tr><td colspan='2'><?php esc_html_e('Refunding is possible.','events-made-easy'); ?></td></tr>
 <tr><td colspan='2'><?php printf(esc_html__('Internal payment method name: %s','events-made-easy'), esc_html($gateway)); ?></td></tr>
 <?php
 $webhook_id = get_option('eme_paypal_webhook_id');
@@ -2716,9 +2716,9 @@ if (!empty($webhook_id)) {
     eme_options_input_text( __( 'Text above payment button', 'events-made-easy' ), 'eme_' . $gateway . '_button_above', __( 'The text shown just above the payment button', 'events-made-easy' ) . '<br>' . esc_html__( 'For all possible placeholders, see ', 'events-made-easy' ) . "<a target='_blank' href='//www.e-dynamics.be/wordpress/category/documentation/7-placeholders/payment-gateways/'>" . esc_html__( 'the documentation', 'events-made-easy' ) . '</a>' );
     eme_options_input_text( __( 'Text below payment button', 'events-made-easy' ), 'eme_' . $gateway . '_button_below', __( 'The text shown just below the payment button', 'events-made-easy' ) . '<br>' . esc_html__( 'For all possible placeholders, see ', 'events-made-easy' ) . "<a target='_blank' href='//www.e-dynamics.be/wordpress/category/documentation/7-placeholders/payment-gateways/'>" . esc_html__( 'the documentation', 'events-made-easy' ) . '</a>' );
 ?>
-<tr><th colspan='2'><?php _e('Extra payment method information','events-made-easy'); ?></th></tr>
+<tr><th colspan='2'><?php esc_html_e('Extra payment method information','events-made-easy'); ?></th></tr>
 <tr><td colspan='2'><?php printf(esc_html__('The url for payment notifications is: %s','events-made-easy'), esc_html($notification_link)); ?></td></tr>
-<tr><td colspan='2'><?php _e('Refunding is possible.','events-made-easy'); ?></td></tr>
+<tr><td colspan='2'><?php esc_html_e('Refunding is possible.','events-made-easy'); ?></td></tr>
 <tr><td colspan='2'><?php printf(esc_html__('Internal payment method name: %s','events-made-easy'), esc_html($gateway)); ?></td></tr>
 </table>
 </div>
@@ -2752,9 +2752,9 @@ if (!empty($webhook_id)) {
     eme_options_input_text( __( 'Text above payment button', 'events-made-easy' ), 'eme_' . $gateway . '_button_above', __( 'The text shown just above the payment button', 'events-made-easy' ) . '<br>' . esc_html__( 'For all possible placeholders, see ', 'events-made-easy' ) . "<a target='_blank' href='//www.e-dynamics.be/wordpress/category/documentation/7-placeholders/payment-gateways/'>" . esc_html__( 'the documentation', 'events-made-easy' ) . '</a>' );
     eme_options_input_text( __( 'Text below payment button', 'events-made-easy' ), 'eme_' . $gateway . '_button_below', __( 'The text shown just below the payment button', 'events-made-easy' ) . '<br>' . esc_html__( 'For all possible placeholders, see ', 'events-made-easy' ) . "<a target='_blank' href='//www.e-dynamics.be/wordpress/category/documentation/7-placeholders/payment-gateways/'>" . esc_html__( 'the documentation', 'events-made-easy' ) . '</a>' );
 ?>
-<tr><th colspan='2'><?php _e('Extra payment method information','events-made-easy'); ?></th></tr>
+<tr><th colspan='2'><?php esc_html_e('Extra payment method information','events-made-easy'); ?></th></tr>
 <tr><td colspan='2'><?php printf(esc_html__('The url for payment notifications is: %s','events-made-easy'), esc_html($notification_link)); ?></td></tr>
-<tr><td colspan='2'><?php _e('Refunding not implemented.','events-made-easy'); ?></td></tr>
+<tr><td colspan='2'><?php esc_html_e('Refunding not implemented.','events-made-easy'); ?></td></tr>
 <tr><td colspan='2'><?php printf(esc_html__('Internal payment method name: %s','events-made-easy'), esc_html($gateway)); ?></td></tr>
 </table>
 </div>
@@ -2788,9 +2788,9 @@ if (!empty($webhook_id)) {
     eme_options_input_text( __( 'Text above payment button', 'events-made-easy' ), 'eme_' . $gateway . '_button_above', __( 'The text shown just above the payment button', 'events-made-easy' ) . '<br>' . esc_html__( 'For all possible placeholders, see ', 'events-made-easy' ) . "<a target='_blank' href='//www.e-dynamics.be/wordpress/category/documentation/7-placeholders/payment-gateways/'>" . esc_html__( 'the documentation', 'events-made-easy' ) . '</a>' );
     eme_options_input_text( __( 'Text below payment button', 'events-made-easy' ), 'eme_' . $gateway . '_button_below', __( 'The text shown just below the payment button', 'events-made-easy' ) . '<br>' . esc_html__( 'For all possible placeholders, see ', 'events-made-easy' ) . "<a target='_blank' href='//www.e-dynamics.be/wordpress/category/documentation/7-placeholders/payment-gateways/'>" . esc_html__( 'the documentation', 'events-made-easy' ) . '</a>' );
 ?>
-<tr><th colspan='2'><?php _e('Extra payment method information','events-made-easy'); ?></th></tr>
+<tr><th colspan='2'><?php esc_html_e('Extra payment method information','events-made-easy'); ?></th></tr>
 <tr><td colspan='2'><?php printf(esc_html__('The url for payment notifications is: %s','events-made-easy'), esc_html($notification_link)); ?></td></tr>
-<tr><td colspan='2'><?php _e('Refunding not implemented.','events-made-easy'); ?></td></tr>
+<tr><td colspan='2'><?php esc_html_e('Refunding not implemented.','events-made-easy'); ?></td></tr>
 <tr><td colspan='2'><?php printf(esc_html__('Internal payment method name: %s','events-made-easy'), esc_html($gateway)); ?></td></tr>
 </table>
 </div>
@@ -2811,9 +2811,9 @@ if (!empty($webhook_id)) {
     eme_options_input_text( __( 'Text above payment button', 'events-made-easy' ), 'eme_' . $gateway . '_button_above', __( 'The text shown just above the payment button', 'events-made-easy' ) . '<br>' . esc_html__( 'For all possible placeholders, see ', 'events-made-easy' ) . "<a target='_blank' href='//www.e-dynamics.be/wordpress/category/documentation/7-placeholders/payment-gateways/'>" . esc_html__( 'the documentation', 'events-made-easy' ) . '</a>' );
     eme_options_input_text( __( 'Text below payment button', 'events-made-easy' ), 'eme_' . $gateway . '_button_below', __( 'The text shown just below the payment button', 'events-made-easy' ) . '<br>' . esc_html__( 'For all possible placeholders, see ', 'events-made-easy' ) . "<a target='_blank' href='//www.e-dynamics.be/wordpress/category/documentation/7-placeholders/payment-gateways/'>" . esc_html__( 'the documentation', 'events-made-easy' ) . '</a>' );
 ?>
-<tr><th colspan='2'><?php _e('Extra payment method information','events-made-easy'); ?></th></tr>
+<tr><th colspan='2'><?php esc_html_e('Extra payment method information','events-made-easy'); ?></th></tr>
 <tr><td colspan='2'><?php printf(esc_html__('The url for payment notifications is: %s','events-made-easy'), esc_html($notification_link)); ?></td></tr>
-<tr><td colspan='2'><?php _e('Refunding is possible.','events-made-easy'); ?></td></tr>
+<tr><td colspan='2'><?php esc_html_e('Refunding is possible.','events-made-easy'); ?></td></tr>
 <tr><td colspan='2'><?php printf(esc_html__('Internal payment method name: %s','events-made-easy'), esc_html($gateway)); ?></td></tr>
 </table>
 </div>
@@ -2843,9 +2843,9 @@ if (!empty($webhook_id)) {
     eme_options_input_text( __( 'Text above payment button', 'events-made-easy' ), 'eme_' . $gateway . '_button_above', __( 'The text shown just above the payment button', 'events-made-easy' ) . '<br>' . esc_html__( 'For all possible placeholders, see ', 'events-made-easy' ) . "<a target='_blank' href='//www.e-dynamics.be/wordpress/category/documentation/7-placeholders/payment-gateways/'>" . esc_html__( 'the documentation', 'events-made-easy' ) . '</a>' );
     eme_options_input_text( __( 'Text below payment button', 'events-made-easy' ), 'eme_' . $gateway . '_button_below', __( 'The text shown just below the payment button', 'events-made-easy' ) . '<br>' . esc_html__( 'For all possible placeholders, see ', 'events-made-easy' ) . "<a target='_blank' href='//www.e-dynamics.be/wordpress/category/documentation/7-placeholders/payment-gateways/'>" . esc_html__( 'the documentation', 'events-made-easy' ) . '</a>' );
 ?>
-<tr><th colspan='2'><?php _e('Extra payment method information','events-made-easy'); ?></th></tr>
+<tr><th colspan='2'><?php esc_html_e('Extra payment method information','events-made-easy'); ?></th></tr>
 <tr><td colspan='2'><?php printf(esc_html__('The url for payment notifications is: %s','events-made-easy'), esc_html($notification_link)); ?></td></tr>
-<tr><td colspan='2'><?php _e('Refunding is possible if funds are available on the account.','events-made-easy'); ?></td></tr>
+<tr><td colspan='2'><?php esc_html_e('Refunding is possible if funds are available on the account.','events-made-easy'); ?></td></tr>
 <tr><td colspan='2'><?php printf(esc_html__('Internal payment method name: %s','events-made-easy'), esc_html($gateway)); ?></td></tr>
 </table>
 </div>
@@ -2882,9 +2882,9 @@ if (!empty($webhook_id)) {
     eme_options_input_text( __( 'Text above payment button', 'events-made-easy' ), 'eme_' . $gateway . '_button_above', __( 'The text shown just above the payment button', 'events-made-easy' ) . '<br>' . esc_html__( 'For all possible placeholders, see ', 'events-made-easy' ) . "<a target='_blank' href='//www.e-dynamics.be/wordpress/category/documentation/7-placeholders/payment-gateways/'>" . esc_html__( 'the documentation', 'events-made-easy' ) . '</a>' );
     eme_options_input_text( __( 'Text below payment button', 'events-made-easy' ), 'eme_' . $gateway . '_button_below', __( 'The text shown just below the payment button', 'events-made-easy' ) . '<br>' . esc_html__( 'For all possible placeholders, see ', 'events-made-easy' ) . "<a target='_blank' href='//www.e-dynamics.be/wordpress/category/documentation/7-placeholders/payment-gateways/'>" . esc_html__( 'the documentation', 'events-made-easy' ) . '</a>' );
 ?>
-<tr><th colspan='2'><?php _e('Extra payment method information','events-made-easy'); ?></th></tr>
+<tr><th colspan='2'><?php esc_html_e('Extra payment method information','events-made-easy'); ?></th></tr>
 <tr><td colspan='2'><?php printf(esc_html__('The url for payment notifications is: %s','events-made-easy'), esc_html($notification_link)); ?></td></tr>
-<tr><td colspan='2'><?php _e('Refunding not implemented.','events-made-easy'); ?></td></tr>
+<tr><td colspan='2'><?php esc_html_e('Refunding not implemented.','events-made-easy'); ?></td></tr>
 <tr><td colspan='2'><?php printf(esc_html__('Internal payment method name: %s','events-made-easy'), esc_html($gateway)); ?></td></tr>
 </table>
 </div>
@@ -2918,9 +2918,9 @@ if (!empty($webhook_id)) {
     eme_options_input_text( __( 'Text above payment button', 'events-made-easy' ), 'eme_' . $gateway . '_button_above', __( 'The text shown just above the payment button', 'events-made-easy' ) . '<br>' . esc_html__( 'For all possible placeholders, see ', 'events-made-easy' ) . "<a target='_blank' href='//www.e-dynamics.be/wordpress/category/documentation/7-placeholders/payment-gateways/'>" . esc_html__( 'the documentation', 'events-made-easy' ) . '</a>' );
     eme_options_input_text( __( 'Text below payment button', 'events-made-easy' ), 'eme_' . $gateway . '_button_below', __( 'The text shown just below the payment button', 'events-made-easy' ) . '<br>' . esc_html__( 'For all possible placeholders, see ', 'events-made-easy' ) . "<a target='_blank' href='//www.e-dynamics.be/wordpress/category/documentation/7-placeholders/payment-gateways/'>" . esc_html__( 'the documentation', 'events-made-easy' ) . '</a>' );
 ?>
-<tr><th colspan='2'><?php _e('Extra payment method information','events-made-easy'); ?></th></tr>
-<tr><td colspan='2'><?php _e( 'Info: for Opayo to work, your PHP installation must have the mcrypt module installed and activated. Search the internet for which extra PHP package to install and/or which line in php.ini to change.', 'events-made-easy' ); ?></td></tr>
-<tr><td colspan='2'><?php _e('Refunding not implemented.','events-made-easy'); ?></td></tr>
+<tr><th colspan='2'><?php esc_html_e('Extra payment method information','events-made-easy'); ?></th></tr>
+<tr><td colspan='2'><?php esc_html_e( 'Info: for Opayo to work, your PHP installation must have the mcrypt module installed and activated. Search the internet for which extra PHP package to install and/or which line in php.ini to change.', 'events-made-easy' ); ?></td></tr>
+<tr><td colspan='2'><?php esc_html_e('Refunding not implemented.','events-made-easy'); ?></td></tr>
 <tr><td colspan='2'><?php printf(esc_html__('Internal payment method name: %s','events-made-easy'), esc_html($gateway)); ?></td></tr>
 </table>
 </div>
@@ -2943,9 +2943,9 @@ if (!empty($webhook_id)) {
     eme_options_input_text( __( 'Text above payment button', 'events-made-easy' ), 'eme_' . $gateway . '_button_above', __( 'The text shown just above the payment button', 'events-made-easy' ) . '<br>' . esc_html__( 'For all possible placeholders, see ', 'events-made-easy' ) . "<a target='_blank' href='//www.e-dynamics.be/wordpress/category/documentation/7-placeholders/payment-gateways/'>" . esc_html__( 'the documentation', 'events-made-easy' ) . '</a>' );
     eme_options_input_text( __( 'Text below payment button', 'events-made-easy' ), 'eme_' . $gateway . '_button_below', __( 'The text shown just below the payment button', 'events-made-easy' ) . '<br>' . esc_html__( 'For all possible placeholders, see ', 'events-made-easy' ) . "<a target='_blank' href='//www.e-dynamics.be/wordpress/category/documentation/7-placeholders/payment-gateways/'>" . esc_html__( 'the documentation', 'events-made-easy' ) . '</a>' );
 ?>
-<tr><th colspan='2'><?php _e('Extra payment method information','events-made-easy'); ?></th></tr>
+<tr><th colspan='2'><?php esc_html_e('Extra payment method information','events-made-easy'); ?></th></tr>
 <tr><td colspan='2'><?php printf(esc_html__('The url for payment notifications is: %s','events-made-easy'), esc_html($notification_link)); ?></td></tr>
-<tr><td colspan='2'><?php _e('Refunding not implemented.','events-made-easy'); ?></td></tr>
+<tr><td colspan='2'><?php esc_html_e('Refunding not implemented.','events-made-easy'); ?></td></tr>
 <tr><td colspan='2'><?php printf(esc_html__('Internal payment method name: %s','events-made-easy'), esc_html($gateway)); ?></td></tr>
 </table>
 </div>
@@ -2987,9 +2987,9 @@ if (!empty($webhook_id)) {
     ];
     eme_options_multiselect( __( 'Stripe payment methods', 'events-made-easy' ), 'eme_stripe_payment_methods', $stripe_pms, __( "The different Stripe payment methods you want to handle/provide. Defaults to 'card'. See the <a href='https://stripe.com/docs/api/checkout/sessions/create#create_checkout_session-payment_method_types'>Stripe doc</a> for more info.", 'events-made-easy' ), false, 'eme_snapselect' );
 ?>
-<tr><th colspan='2'><?php _e('Extra payment method information','events-made-easy'); ?></th></tr>
+<tr><th colspan='2'><?php esc_html_e('Extra payment method information','events-made-easy'); ?></th></tr>
 <tr><td colspan='2'><?php printf(esc_html__('The url for payment notifications is: %s','events-made-easy'), esc_html($notification_link)); ?></td></tr>
-<tr><td colspan='2'><?php _e('Refunding is possible.','events-made-easy'); ?></td></tr>
+<tr><td colspan='2'><?php esc_html_e('Refunding is possible.','events-made-easy'); ?></td></tr>
 <tr><td colspan='2'><?php printf(esc_html__('Internal payment method name: %s','events-made-easy'), esc_html($gateway)); ?></td></tr>
 <?php
     $eme_stripe_private_key = get_option( 'eme_stripe_private_key' );
@@ -3039,8 +3039,8 @@ if (!empty($webhook_id)) {
     eme_options_input_text( __( 'Text above payment button', 'events-made-easy' ), 'eme_' . $gateway . '_button_above', __( 'The text shown just above the payment button', 'events-made-easy' ) . '<br>' . esc_html__( 'For all possible placeholders, see ', 'events-made-easy' ) . "<a target='_blank' href='//www.e-dynamics.be/wordpress/category/documentation/7-placeholders/payment-gateways/'>" . esc_html__( 'the documentation', 'events-made-easy' ) . '</a>' );
     eme_options_input_text( __( 'Text below payment button', 'events-made-easy' ), 'eme_' . $gateway . '_button_below', __( 'The text shown just below the payment button', 'events-made-easy' ) . '<br>' . esc_html__( 'For all possible placeholders, see ', 'events-made-easy' ) . "<a target='_blank' href='//www.e-dynamics.be/wordpress/category/documentation/7-placeholders/payment-gateways/'>" . esc_html__( 'the documentation', 'events-made-easy' ) . '</a>' );
 ?>
-<tr><th colspan='2'><?php _e('Extra payment method information','events-made-easy'); ?></th></tr>
-<tr><td colspan='2'><?php _e('Refunding is possible.','events-made-easy'); ?></td></tr>
+<tr><th colspan='2'><?php esc_html_e('Extra payment method information','events-made-easy'); ?></th></tr>
+<tr><td colspan='2'><?php esc_html_e('Refunding is possible.','events-made-easy'); ?></td></tr>
 <tr><td colspan='2'><?php printf(esc_html__('Internal payment method name: %s','events-made-easy'), esc_html($gateway)); ?></td></tr>
 </table>
 </div>
@@ -3075,9 +3075,9 @@ if (!empty($webhook_id)) {
     eme_options_input_text( __( 'Text above payment button', 'events-made-easy' ), 'eme_' . $gateway . '_button_above', __( 'The text shown just above the payment button', 'events-made-easy' ) . '<br>' . esc_html__( 'For all possible placeholders, see ', 'events-made-easy' ) . "<a target='_blank' href='//www.e-dynamics.be/wordpress/category/documentation/7-placeholders/payment-gateways/'>" . esc_html__( 'the documentation', 'events-made-easy' ) . '</a>' );
     eme_options_input_text( __( 'Text below payment button', 'events-made-easy' ), 'eme_' . $gateway . '_button_below', __( 'The text shown just below the payment button', 'events-made-easy' ) . '<br>' . esc_html__( 'For all possible placeholders, see ', 'events-made-easy' ) . "<a target='_blank' href='//www.e-dynamics.be/wordpress/category/documentation/7-placeholders/payment-gateways/'>" . esc_html__( 'the documentation', 'events-made-easy' ) . '</a>' );
 ?>
-<tr><th colspan='2'><?php _e('Extra payment method information','events-made-easy'); ?></th></tr>
+<tr><th colspan='2'><?php esc_html_e('Extra payment method information','events-made-easy'); ?></th></tr>
 <tr><td colspan='2'><?php printf(esc_html__('The url for payment notifications is: %s','events-made-easy'), esc_html($notification_link)); ?></td></tr>
-<tr><td colspan='2'><?php _e('Refunding is possible.','events-made-easy'); ?></td></tr>
+<tr><td colspan='2'><?php esc_html_e('Refunding is possible.','events-made-easy'); ?></td></tr>
 <tr><td colspan='2'><?php printf(esc_html__('Internal payment method name: %s','events-made-easy'), esc_html($gateway)); ?></td></tr>
 </table>
 </div>
@@ -3110,8 +3110,8 @@ if (!empty($webhook_id)) {
     eme_options_input_text( __( 'Text above payment button', 'events-made-easy' ), 'eme_' . $gateway . '_button_above', __( 'The text shown just above the payment button', 'events-made-easy' ) . '<br>' . esc_html__( 'For all possible placeholders, see ', 'events-made-easy' ) . "<a target='_blank' href='//www.e-dynamics.be/wordpress/category/documentation/7-placeholders/payment-gateways/'>" . esc_html__( 'the documentation', 'events-made-easy' ) . '</a>' );
     eme_options_input_text( __( 'Text below payment button', 'events-made-easy' ), 'eme_' . $gateway . '_button_below', __( 'The text shown just below the payment button', 'events-made-easy' ) . '<br>' . esc_html__( 'For all possible placeholders, see ', 'events-made-easy' ) . "<a target='_blank' href='//www.e-dynamics.be/wordpress/category/documentation/7-placeholders/payment-gateways/'>" . esc_html__( 'the documentation', 'events-made-easy' ) . '</a>' );
 ?>
-<tr><th colspan='2'><?php _e('Extra payment method information','events-made-easy'); ?></th></tr>
-<tr><td colspan='2'><?php _e('Refunding is possible.','events-made-easy'); ?></td></tr>
+<tr><th colspan='2'><?php esc_html_e('Extra payment method information','events-made-easy'); ?></th></tr>
+<tr><td colspan='2'><?php esc_html_e('Refunding is possible.','events-made-easy'); ?></td></tr>
 <tr><td colspan='2'><?php printf(esc_html__('Internal payment method name: %s','events-made-easy'), esc_html($gateway)); ?></td></tr>
 </table>
 </div>
@@ -3133,9 +3133,9 @@ if (!empty($webhook_id)) {
     eme_options_input_text( __( 'Text above payment button', 'events-made-easy' ), 'eme_' . $gateway . '_button_above', __( 'The text shown just above the payment button', 'events-made-easy' ) . '<br>' . esc_html__( 'For all possible placeholders, see ', 'events-made-easy' ) . "<a target='_blank' href='//www.e-dynamics.be/wordpress/category/documentation/7-placeholders/payment-gateways/'>" . esc_html__( 'the documentation', 'events-made-easy' ) . '</a>' );
     eme_options_input_text( __( 'Text below payment button', 'events-made-easy' ), 'eme_' . $gateway . '_button_below', __( 'The text shown just below the payment button', 'events-made-easy' ) . '<br>' . esc_html__( 'For all possible placeholders, see ', 'events-made-easy' ) . "<a target='_blank' href='//www.e-dynamics.be/wordpress/category/documentation/7-placeholders/payment-gateways/'>" . esc_html__( 'the documentation', 'events-made-easy' ) . '</a>' );
 ?>
-<tr><th colspan='2'><?php _e('Extra payment method information','events-made-easy'); ?></th></tr>
+<tr><th colspan='2'><?php esc_html_e('Extra payment method information','events-made-easy'); ?></th></tr>
 <tr><td colspan='2'><?php printf(esc_html__('The url for payment notifications is: %s','events-made-easy'), esc_html($notification_link)); ?></td></tr>
-<tr><td colspan='2'><?php _e('Refunding is possible.','events-made-easy'); ?></td></tr>
+<tr><td colspan='2'><?php esc_html_e('Refunding is possible.','events-made-easy'); ?></td></tr>
 <tr><td colspan='2'><?php printf(esc_html__('Internal payment method name: %s','events-made-easy'), esc_html($gateway)); ?></td></tr>
 </table>
 </div>
@@ -3162,7 +3162,7 @@ case 'emefs':
 <h2><?php esc_html_e( 'Frontend Submit options', 'events-made-easy' ); ?></h2>
 <?php printf( wp_kses_post( __( "For all information concerning frontend submit, see <a target='_blank' href='%s'>the documentation</a>", 'events-made-easy' ) ), esc_url( '//www.e-dynamics.be/wordpress/category/documentation/6-placeholders/eme_add_event_form/' ) );
 echo '<br><br>';
-_e("Also check out the 'Email templates' and the 'Payment' sections for some extra frontend submit settings.", 'events-made-easy' );
+esc_html_e("Also check out the 'Email templates' and the 'Payment' sections for some extra frontend submit settings.", 'events-made-easy' );
 ?>
 <table class='form-table'>
 <?php

--- a/eme-payments.php
+++ b/eme-payments.php
@@ -210,7 +210,7 @@ function eme_event_payment_form( $payment_id, $resultcode = 0, $standalone = 0 )
         } else {
             $ret_string     .= "<div id='eme-payment-handling' class='eme-payment-handling'>" . esc_html__( 'Payment handling', 'events-made-easy' ) . '</div>';
             $localized_price = eme_localized_price( $total_price, $cur );
-            $ret_string     .= "<div id='eme-payment-price-info' class='eme-payment-price-info'>" . sprintf( __( 'The amount to pay is %s', 'events-made-easy' ), $localized_price ) . '</div>';
+            $ret_string     .= "<div id='eme-payment-price-info' class='eme-payment-price-info'>" . sprintf( esc_html__( 'The amount to pay is %s', 'events-made-easy' ), esc_html( $localized_price ) ) . '</div>';
         }
     }
 
@@ -350,7 +350,7 @@ function eme_member_payment_form( $payment_id, $resultcode = 0, $standalone = 0 
         } else {
             $ret_string     .= "<div id='eme-payment-handling' class='eme-payment-handling'>" . esc_html__( 'Payment handling', 'events-made-easy' ) . '</div>';
             $localized_price = eme_localized_price( $total_price, $cur );
-            $ret_string     .= "<div id='eme-payment-price-info' class='eme-payment-price-info'>" . sprintf( __( 'The amount to pay is %s', 'events-made-easy' ), $localized_price ) . '</div>';
+            $ret_string     .= "<div id='eme-payment-price-info' class='eme-payment-price-info'>" . sprintf( esc_html__( 'The amount to pay is %s', 'events-made-easy' ), esc_html( $localized_price ) ) . '</div>';
         }
     }
 
@@ -477,7 +477,7 @@ function eme_fs_event_payment_form( $payment_id, $resultcode = 0, $standalone = 
         } else {
             $ret_string     .= "<div id='eme-payment-handling' class='eme-payment-handling'>" . esc_html__( 'Payment handling', 'events-made-easy' ) . '</div>';
             $localized_price = eme_localized_price( $total_price, $cur );
-            $ret_string     .= "<div id='eme-payment-price-info' class='eme-payment-price-info'>" . sprintf( __( 'The amount to pay is %s', 'events-made-easy' ), $localized_price ) . '</div>';
+            $ret_string     .= "<div id='eme-payment-price-info' class='eme-payment-price-info'>" . sprintf( esc_html__( 'The amount to pay is %s', 'events-made-easy' ), esc_html( $localized_price ) ) . '</div>';
         }
     }
 
@@ -758,7 +758,7 @@ function eme_payment_form_worldpay( $item_name, $payment, $baseprice, $cur, $mul
     $form_html .= "<input type='hidden' name='currency' value='$cur'>";
     // for worldpay notifications to work: enable dynamic payment response in your worldpay setup, using the param MC_callback
     // also: set the Payment Response password and if wanted, the MD5 secret and field combo
-    $form_html .= "<input type='hidden' name='MC_callback' value='$notification_link'>";
+    $form_html .= "<input type='hidden' name='MC_callback' value='" . esc_url( $notification_link ) . "'>";
 
     if ( $worldpay_md5_secret ) {
         require_once 'payment_gateways/worldpay/eme-worldpay.php';
@@ -1650,11 +1650,11 @@ function eme_complete_transaction_sumup( $payment ) {
         $accessToken = $sumup->getAccessToken();
         $value       = $accessToken->getValue();
     } catch ( \SumUp\Exceptions\SumUpAuthenticationException $e ) {
-        echo 'Authentication error: ' . $e->getMessage();
+        echo 'Authentication error: ' . esc_html( $e->getMessage() );
     } catch ( \SumUp\Exceptions\SumUpResponseException $e ) {
-        echo 'Response error: ' . $e->getMessage();
+        echo 'Response error: ' . esc_html( $e->getMessage() );
     } catch ( \SumUp\Exceptions\SumUpSDKException $e ) {
-        echo 'SumUp SDK error: ' . $e->getMessage();
+        echo 'SumUp SDK error: ' . esc_html( $e->getMessage() );
     }
 
     $checkout_id      = $payment['pg_pid'];
@@ -2104,11 +2104,11 @@ function eme_notification_sumup() {
             $accessToken = $sumup->getAccessToken();
             $value       = $accessToken->getValue();
     } catch ( \SumUp\Exceptions\SumUpAuthenticationException $e ) {
-            echo 'Authentication error: ' . $e->getMessage();
+            echo 'Authentication error: ' . esc_html( $e->getMessage() );
     } catch ( \SumUp\Exceptions\SumUpResponseException $e ) {
-            echo 'Response error: ' . $e->getMessage();
+            echo 'Response error: ' . esc_html( $e->getMessage() );
     } catch ( \SumUp\Exceptions\SumUpSDKException $e ) {
-            echo 'SumUp SDK error: ' . $e->getMessage();
+            echo 'SumUp SDK error: ' . esc_html( $e->getMessage() );
     }
 
     $checkout_id      = eme_sanitize_request( $_POST['id'] );
@@ -2596,7 +2596,7 @@ function eme_charge_instamojo() {
         $url = $instamojo_payment['longurl'];
     } catch ( Exception $e ) {
         $url = '';
-        print 'Instamojo API call failed: ' . htmlspecialchars( $e->getMessage() );
+        print 'Instamojo API call failed: ' . esc_html( $e->getMessage() );
     }
 
     if ( ! empty( $url ) ) {
@@ -2977,7 +2977,7 @@ function eme_charge_mollie() {
         $url = $mollie_payment->getCheckoutUrl();
     } catch ( \Mollie\Api\Exceptions\ApiException $e ) {
         $url = '';
-        print 'Mollie API call failed: ' . htmlspecialchars( $e->getMessage() );
+        print 'Mollie API call failed: ' . esc_html( $e->getMessage() );
     }
 
     if ( ! empty( $url ) ) {
@@ -3094,7 +3094,7 @@ function eme_charge_bancontactwero() {
         $url = $bancontactwero_payment->_links->checkout->href;
     } catch ( Exception $e ) {
         $url = '';
-        print 'BancontactWero API call failed: ' . htmlspecialchars( $e->getMessage() );
+        print 'BancontactWero API call failed: ' . esc_html( $e->getMessage() );
     }
 
     if ( ! empty( $url ) ) {

--- a/eme-people.php
+++ b/eme-people.php
@@ -1510,11 +1510,11 @@ function eme_printable_booking_report( $event_id ) {
             $price_arr = eme_convert_multi2array( $event['price'] );
             $multprice_desc_arr = eme_convert_multi2array( $event['event_properties']['multiprice_desc'] );
             foreach ($price_arr as $key=>$price) {
-                $res_arr[] = eme_localized_price( $price, $event['currency']) . " " . esc_html($multprice_desc_arr[$key]);
+                $res_arr[] = esc_html( eme_localized_price( $price, $event['currency']) ) . " " . esc_html($multprice_desc_arr[$key]);
             }
-            echo eme_convert_array2multi( $res_arr, '<br>');
+            echo eme_convert_array2multi( $res_arr, '<br>'); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- each element is esc_html() escaped, <br> is intentional HTML separator
         } else {
-            echo eme_localized_price( $event['price'], $event['currency']);
+            echo esc_html( eme_localized_price( $event['price'], $event['currency']) );
             if (!empty($event['event_properties']['price_desc'])) {
                 echo " ".esc_html($event['event_properties']['price_desc']);
             }
@@ -1561,7 +1561,7 @@ function eme_printable_booking_report( $event_id ) {
         if (!eme_is_empty_string($event['event_properties']['multiprice_desc'])) {
             esc_html_e( 'Seats', 'events-made-easy' );
             print "&nbsp; (";
-            print eme_convert_array2multi(eme_convert_multi2array($event['event_properties']['multiprice_desc']),', ');
+            print esc_html( eme_convert_array2multi(eme_convert_multi2array($event['event_properties']['multiprice_desc']),', ') );
             print ")";
         } else {
             esc_html_e( 'Seats (Multiprice)', 'events-made-easy' );
@@ -1695,10 +1695,10 @@ function eme_printable_booking_report( $event_id ) {
                 }
             }
         }
-        echo eme_localized_price( $booking['discount'], $event['currency'] ) .$discount_name;
+        echo esc_html( eme_localized_price( $booking['discount'], $event['currency'] ) ) . $discount_name;
 ?>
             </td>
-            <td class='eme_print_total_price'><?php echo eme_localized_price( eme_get_total_booking_price( $booking ), $event['currency'] ); ?></td>
+            <td class='eme_print_total_price'><?php echo esc_html( eme_localized_price( eme_get_total_booking_price( $booking ), $event['currency'] ) ); ?></td>
             <td class='eme_print_comment'><?php echo esc_html( $booking['booking_comment'] ); ?></td>
 <?php
         $answers = eme_get_nodyndata_booking_answers( $booking['booking_id'] );
@@ -1855,7 +1855,7 @@ function eme_person_verify_layout() {
             $person_ids = explode(',',$row['person_ids']);
             foreach ($person_ids as $person_id) {
                 print "<tr style='border-collapse: collapse;border: 1px solid black;'>";
-                print '<td>' . $person_id . '</td>';
+                print '<td>' . intval( $person_id ) . '</td>';
                 print "<td><a href='" . esc_url( admin_url( 'admin.php?page=eme-people&eme_admin_action=edit_person&person_id=' . $person_id ) ) . "' title='" . esc_attr__( 'Edit person', 'events-made-easy' ) . "'>" . esc_html( $row['lastname'] ) . '</a></td>';
                 print "<td><a href='" . esc_url( admin_url( 'admin.php?page=eme-people&eme_admin_action=edit_person&person_id=' . $person_id ) ) . "' title='" . esc_attr__( 'Edit person', 'events-made-easy' ) . "'>" . esc_html( $row['firstname'] ) . '</a></td>';
                 print "<td><a href='" . esc_url( admin_url( 'admin.php?page=eme-people&eme_admin_action=edit_person&person_id=' . $person_id ) ) . "' title='" . esc_attr__( 'Edit person', 'events-made-easy' ) . "'>" . esc_html( $row['email'] ) . '</a></td>';
@@ -1865,7 +1865,7 @@ function eme_person_verify_layout() {
                     print '<td>' . esc_html__('Non-existing WP user linked!!','events-made-easy' ) . '</td>';
                 }
                 $membership_names = eme_get_linked_activemembership_names_by_personid( $person_id );
-                print "<td>$membership_names</td>";
+                print '<td>' . $membership_names . '</td>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- pre-escaped HTML from eme_get_linked_activemembership_names_by_personid()
                 $future_bookings = eme_get_bookings_by_person_id( $person_id, "future" );
                 if (!empty($future_bookings)) {
                     print "<td>".esc_html__('Yes','events_made_easy')."</td>";
@@ -1903,12 +1903,12 @@ function eme_person_verify_layout() {
             $person_ids = explode(',',$row['person_ids']);
             foreach ($person_ids as $person_id) {
                 print "<tr style='border-collapse: collapse;border: 1px solid black;'>";
-                print '<td>' . $person_id . '</td>';
+                print '<td>' . intval( $person_id ) . '</td>';
                 print "<td><a href='" . esc_url( admin_url( 'admin.php?page=eme-people&eme_admin_action=edit_person&person_id=' . $person_id ) ) . "' title='" . esc_attr__( 'Edit person', 'events-made-easy' ) . "'>" . esc_html( $row['lastname'] ) . '</a></td>';
                 print "<td><a href='" . esc_url( admin_url( 'admin.php?page=eme-people&eme_admin_action=edit_person&person_id=' . $person_id ) ) . "' title='" . esc_attr__( 'Edit person', 'events-made-easy' ) . "'>" . esc_html( $row['firstname'] ) . '</a></td>';
                 print "<td><a href='" . esc_url( admin_url( 'admin.php?page=eme-people&eme_admin_action=edit_person&person_id=' . $person_id ) ) . "' title='" . esc_attr__( 'Edit person', 'events-made-easy' ) . "'>" . esc_html( $row['email'] ) . '</a></td>';
                 $membership_names = eme_get_linked_activemembership_names_by_personid( $person_id );
-                print "<td>$membership_names</td>";
+                print '<td>' . $membership_names . '</td>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- pre-escaped HTML from eme_get_linked_activemembership_names_by_personid()
                 $future_bookings = eme_get_bookings_by_person_id( $person_id, "future" );
                 if (!empty($future_bookings)) {
                     print "<td>".esc_html__('Yes','events_made_easy')."</td>";
@@ -1946,12 +1946,12 @@ function eme_person_verify_layout() {
             $person_ids = explode(',',$row['person_ids']);
             foreach ($person_ids as $person_id) {
                 print "<tr style='border-collapse: collapse;border: 1px solid black;'>";
-                print '<td>' . $person_id . '</td>';
+                print '<td>' . intval( $person_id ) . '</td>';
                 print "<td><a href='" . esc_url( admin_url( 'admin.php?page=eme-people&eme_admin_action=edit_person&person_id=' . $person_id ) ) . "' title='" . esc_attr__( 'Edit person', 'events-made-easy' ) . "'>" . esc_html( $row['lastname'] ) . '</a></td>';
                 print "<td><a href='" . esc_url( admin_url( 'admin.php?page=eme-people&eme_admin_action=edit_person&person_id=' . $person_id ) ) . "' title='" . esc_attr__( 'Edit person', 'events-made-easy' ) . "'>" . esc_html( $row['firstname'] ) . '</a></td>';
                 print "<td><a href='" . esc_url( admin_url( 'admin.php?page=eme-people&eme_admin_action=edit_person&person_id=' . $person_id ) ) . "' title='" . esc_attr__( 'Edit person', 'events-made-easy' ) . "'>" . esc_html( $row['email'] ) . '</a></td>';
                 $membership_names = eme_get_linked_activemembership_names_by_personid( $person_id );
-                print "<td>$membership_names</td>";
+                print '<td>' . $membership_names . '</td>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- pre-escaped HTML from eme_get_linked_activemembership_names_by_personid()
                 $future_bookings = eme_get_bookings_by_person_id( $person_id, "future" );
                 if (!empty($future_bookings)) {
                     print "<td>".esc_html__('Yes','events_made_easy')."</td>";
@@ -2114,10 +2114,10 @@ function eme_render_people_searchfields( $limit_to_group = 0, $group_to_edit = [
     } else {
         $value = '';
     }
-    echo '<input type="search" value="' . esc_attr($value) . '" name="search_person" id="'.$id_prefix.'search_person" placeholder="' . esc_attr__( 'Filter on person', 'events-made-easy' ) . '" class="eme_searchfilter" size=15>';
+    echo '<input type="search" value="' . esc_attr($value) . '" name="search_person" id="'.esc_attr($id_prefix).'search_person" placeholder="' . esc_attr__( 'Filter on person', 'events-made-easy' ) . '" class="eme_searchfilter" size=15>';
 
     if ($limit_to_group) {
-        echo '<input type="hidden" name="search_groups" id="'.$id_prefix.'search_groups" value="' . esc_attr($limit_to_group) . '">';
+        echo '<input type="hidden" name="search_groups" id="'.esc_attr($id_prefix).'search_groups" value="' . esc_attr($limit_to_group) . '">';
     } else {
         if ( $edit_group ) {
             echo '</td></tr><tr><td>' . esc_html__( 'Filter on group', 'events-made-easy' ) . '</td><td>';
@@ -2163,7 +2163,7 @@ function eme_render_people_searchfields( $limit_to_group = 0, $group_to_edit = [
         } else {
             $value = '';
         }
-        echo '<input type="search" value="' . esc_attr($value) . '" name="search_customfields" id="'.$id_prefix.'search_customfields" placeholder="' . esc_attr__( 'Custom field value to search', 'events-made-easy' ) . '" class="eme_searchfilter" size=20>';
+        echo '<input type="search" value="' . esc_attr($value) . '" name="search_customfields" id="'.esc_attr($id_prefix).'search_customfields" placeholder="' . esc_attr__( 'Custom field value to search', 'events-made-easy' ) . '" class="eme_searchfilter" size=20>';
 
         if ( $edit_group ) {
             echo '</td></tr><tr><td>' . esc_html__( 'Custom field to search', 'events-made-easy' ) . '</td><td>';
@@ -2483,7 +2483,7 @@ function eme_person_edit_layout( $person_id = 0, $message = '' ) {
         <table>
         <tr>
         <td style="vertical-align:top"><label for="firstname"><?php esc_html_e( 'First name', 'events-made-easy' ); ?></label></td>
-        <td><input id="firstname" name="firstname" type="text" value="<?php echo esc_html( $person['firstname'] ); ?>" size="40" <?php echo $wp_readonly; ?>><br>
+        <td><input id="firstname" name="firstname" type="text" value="<?php echo esc_html( $person['firstname'] ); ?>" size="40" <?php echo $wp_readonly; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- $wp_readonly is hardcoded '' or "readonly='readonly'" ?>><br>
 <?php
     if ( ! empty( $wp_readonly ) ) {
         esc_html_e( 'Since this person is linked to a WP user, this field is read-only', 'events-made-easy' );
@@ -2491,12 +2491,12 @@ function eme_person_edit_layout( $person_id = 0, $message = '' ) {
 ?>
         </td>
         <td rowspan=10>
-        <?php echo eme_person_replace_image_input( $person ); ?>
+        <?php echo eme_person_replace_image_input( $person ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML built with esc_url() and esc_html__() ?>
         </td>
         </tr>
         <tr>
         <td style="vertical-align:top"><label for="lastname"><?php esc_html_e( 'Last name', 'events-made-easy' ); ?></label></td>
-        <td><input id="lastname" name="lastname" type="text" value="<?php echo esc_html( $person['lastname'] ); ?>" size="40" <?php echo $wp_readonly; ?>><br>
+        <td><input id="lastname" name="lastname" type="text" value="<?php echo esc_html( $person['lastname'] ); ?>" size="40" <?php echo $wp_readonly; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- $wp_readonly is hardcoded '' or "readonly='readonly'" ?>><br>
 <?php
     if ( ! empty( $wp_readonly ) ) {
         esc_html_e( 'Since this person is linked to a WP user, this field is read-only', 'events-made-easy' );
@@ -2507,7 +2507,7 @@ function eme_person_edit_layout( $person_id = 0, $message = '' ) {
         </tr>
         <tr>
         <td style="vertical-align:top"><label for="email"><?php esc_html_e( 'Email', 'events-made-easy' ); ?></label></td>
-        <td><input id="email" name="email" type="email" value="<?php echo esc_html( $person['email'] ); ?>" size="40" <?php echo $wp_readonly; ?> autocomplete="off"><br>
+        <td><input id="email" name="email" type="email" value="<?php echo esc_html( $person['email'] ); ?>" size="40" <?php echo $wp_readonly; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- $wp_readonly is hardcoded '' or "readonly='readonly'" ?> autocomplete="off"><br>
 <?php
     if ( ! empty( $wp_readonly ) ) {
         esc_html_e( 'Since this person is linked to a WP user, this field is read-only', 'events-made-easy' );
@@ -2563,12 +2563,12 @@ function eme_person_edit_layout( $person_id = 0, $message = '' ) {
         <td></td>
         </tr>
         <tr>
-        <td><label for="address1"><?php echo get_option( 'eme_address1_string' ); ?></label></td>
+        <td><label for="address1"><?php echo esc_html( get_option( 'eme_address1_string' ) ); ?></label></td>
         <td><input id="address1" name="address1" type="text" value="<?php echo esc_html( $person['address1'] ); ?>" size="40"></td>
         <td></td>
         </tr>
         <tr>
-        <td><label for="address2"><?php echo get_option( 'eme_address2_string' ); ?></label></td>
+        <td><label for="address2"><?php echo esc_html( get_option( 'eme_address2_string' ) ); ?></label></td>
         <td><input id="address2" name="address2" type="text" value="<?php echo esc_html( $person['address2'] ); ?>" size="40"></td>
         <td></td>
         </tr>
@@ -2905,7 +2905,7 @@ function eme_person_replace_image_input_div( $person, $relative_div = 0 ) {
    </div>
    <div id='eme_person_current_image' class='postarea'>
    <img id='eme_person_image_example' alt='{$person_image}' title='{$person_image}' src='$image_url'>
-   <input type='hidden' name='properties[image_id]' id='eme_person_image_id' value='{$person['properties']['image_id']}'>
+   <input type='hidden' name='properties[image_id]' id='eme_person_image_id' value='" . absint($person['properties']['image_id']) . "'>
    </div>
    <br>
 
@@ -2937,7 +2937,7 @@ function eme_person_replace_image_input( $person, $relative_div = 0 ) {
    </span>
    <span id='eme_person_current_image' class='postarea'>
    <img id='eme_person_image_example' alt='{$person_image}' title='{$person_image}' src='$image_url'>
-   <input type='hidden' name='properties[image_id]' id='eme_person_image_id' value='{$person['properties']['image_id']}'>
+   <input type='hidden' name='properties[image_id]' id='eme_person_image_id' value='" . absint($person['properties']['image_id']) . "'>
    </span>
    <br>
 

--- a/eme-rsvp.php
+++ b/eme-rsvp.php
@@ -856,6 +856,7 @@ function eme_add_bookings_ajax() {
     // check for spammers as early as possible
     if ( ! isset( $_POST['honeypot_check'] ) || ! empty( $_POST['honeypot_check'] ) ) {
         $form_html = __( "Bot detected. If you believe you've received this message in error please contact the site owner.", 'events-made-easy' );
+        // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- wp_json_encode() returns safe JSON
         echo wp_json_encode(
             [
                 'Result'      => 'NOK',
@@ -867,6 +868,7 @@ function eme_add_bookings_ajax() {
 
     if ( ! isset( $_POST['eme_frontend_nonce'] ) || ! wp_verify_nonce( eme_sanitize_request($_POST['eme_frontend_nonce']), 'eme_frontend' ) ) {
         $form_html = __( "Form tampering detected. If you believe you've received this message in error please contact the site owner.", 'events-made-easy' );
+        // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- wp_json_encode() returns safe JSON
         echo wp_json_encode(
             [
                 'Result'      => 'NOK',
@@ -877,6 +879,7 @@ function eme_add_bookings_ajax() {
     }
     if ( empty( $_POST['eme_event_ids'] ) ) {
         $form_html = __( 'Please select at least one event.', 'events-made-easy' );
+        // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- wp_json_encode() returns safe JSON
         echo wp_json_encode(
             [
                 'Result'      => 'NOK',
@@ -892,6 +895,7 @@ function eme_add_bookings_ajax() {
     }
     if ( empty( $events ) ) {
         $form_html = __( 'Please select at least one event.', 'events-made-easy' );
+        // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- wp_json_encode() returns safe JSON
         echo wp_json_encode(
             [
                 'Result'      => 'NOK',
@@ -945,6 +949,7 @@ function eme_add_bookings_ajax() {
 
     if ( $memberships_failed == 1 ) {
         $form_html = __( 'No valid membership found.', 'events-made-easy' );
+        // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- wp_json_encode() returns safe JSON
         echo wp_json_encode(
             [
                 'Result'      => 'NOK',
@@ -1035,6 +1040,7 @@ function eme_add_bookings_ajax() {
                 $message              = get_option( 'eme_payment_booking_on_waitinglist_format' );
                 $message              = eme_replace_booking_placeholders( $message, $event, $booking, $is_multi );
                 $form_result_message .= '<br>' . $message;
+                // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- wp_json_encode() returns safe JSON
                 echo wp_json_encode(
                     [
                         'Result'      => 'OK',
@@ -1044,6 +1050,7 @@ function eme_add_bookings_ajax() {
                 );
             } elseif ( $pg_count == 1 && get_option( 'eme_pg_submit_immediately' ) ) {
                 $payment_form = eme_payment_form( $payment_id );
+                // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- wp_json_encode() returns safe JSON
                 echo wp_json_encode(
                     [
                         'Result'      => 'OK',
@@ -1061,6 +1068,7 @@ function eme_add_bookings_ajax() {
                     $redirect_msg         = str_replace( '#_PAYMENT_URL', $payment_url, $redirect_msg );
                     $form_result_message .= '<br>' . $redirect_msg;
                 }
+                // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- wp_json_encode() returns safe JSON
                 echo wp_json_encode(
                     [
                         'Result'          => 'OK',
@@ -1072,6 +1080,7 @@ function eme_add_bookings_ajax() {
                 );
             } else {
                 $payment_form = eme_payment_form( $payment_id );
+                // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- wp_json_encode() returns safe JSON
                 echo wp_json_encode(
                     [
                         'Result'      => 'OK',
@@ -1091,6 +1100,7 @@ function eme_add_bookings_ajax() {
                 $only_if_not_registered = 0;
             }
             if ( ! $only_if_not_registered && get_option( 'eme_rsvp_show_form_after_booking' ) && ! get_option( 'eme_rememberme' ) ) {
+                // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- wp_json_encode() returns safe JSON
                 echo wp_json_encode(
                     [
                         'Result'      => 'OK',
@@ -1099,6 +1109,7 @@ function eme_add_bookings_ajax() {
                     ]
                 );
             } else {
+                // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- wp_json_encode() returns safe JSON
                 echo wp_json_encode(
                     [
                         'Result'      => 'OK',
@@ -1120,6 +1131,7 @@ function eme_add_bookings_ajax() {
             $only_if_not_registered = 0;
         }
         if ( ! $only_if_not_registered && get_option( 'eme_rsvp_show_form_after_booking' ) && ! get_option( 'eme_rememberme' ) ) {
+            // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- wp_json_encode() returns safe JSON
             echo wp_json_encode(
                 [
                     'Result'      => 'OK',
@@ -1128,6 +1140,7 @@ function eme_add_bookings_ajax() {
                 ]
             );
         } else {
+            // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- wp_json_encode() returns safe JSON
             echo wp_json_encode(
                 [
                     'Result'      => 'OK',
@@ -1138,6 +1151,7 @@ function eme_add_bookings_ajax() {
         }
     } else {
         // booking failed
+        // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- wp_json_encode() returns safe JSON
         echo wp_json_encode(
             [
                 'Result'      => 'NOK',
@@ -1154,6 +1168,7 @@ function eme_cancel_bookings_ajax() {
     // check for spammers as early as possible
     if ( ! isset( $_POST['honeypot_check'] ) || ! empty( $_POST['honeypot_check'] ) ) {
         $form_html = __( "Bot detected. If you believe you've received this message in error please contact the site owner.", 'events-made-easy' );
+        // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- wp_json_encode() returns safe JSON
         echo wp_json_encode(
             [
                 'Result'      => 'NOK',
@@ -1165,6 +1180,7 @@ function eme_cancel_bookings_ajax() {
 
     if ( ! isset( $_POST['eme_frontend_nonce'] ) || ! wp_verify_nonce( eme_sanitize_request($_POST['eme_frontend_nonce']), 'eme_frontend' ) ) {
         $form_html = __( "Form tampering detected. If you believe you've received this message in error please contact the site owner.", 'events-made-easy' );
+        // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- wp_json_encode() returns safe JSON
         echo wp_json_encode(
             [
                 'Result'      => 'NOK',
@@ -1177,6 +1193,7 @@ function eme_cancel_bookings_ajax() {
     $event_id = intval( $_POST['event_id'] );
     if ( ! $event_id ) {
         $form_html = __( 'No event id detected', 'events-made-easy' );
+        // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- wp_json_encode() returns safe JSON
         echo wp_json_encode(
             [
                 'Result'      => 'NOK',
@@ -1189,6 +1206,7 @@ function eme_cancel_bookings_ajax() {
     $event = eme_get_event( $event_id );
     if ( empty( $event ) ) {
         $form_html = __( 'No event id detected', 'events-made-easy' );
+        // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- wp_json_encode() returns safe JSON
         echo wp_json_encode(
             [
                 'Result'      => 'NOK',
@@ -1253,6 +1271,7 @@ function eme_cancel_bookings_ajax() {
     if ( $event['event_properties']['selected_captcha'] == "captcha" ) {
         eme_captcha_remove ( $captcha_res );
     }
+    // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- wp_json_encode() returns safe JSON
     echo wp_json_encode(
         [
             'Result'      => 'OK',
@@ -5322,6 +5341,7 @@ function eme_registration_seats_form_table( $pending = 0 ) {
             if ( $key == 'future' ) {
                 $selected = "selected='selected'";
             }
+            // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- $selected is hardcoded selected attribute
             echo "<option value='".esc_attr($key)."' $selected>".esc_html($value)."</option>  ";
         }
 ?>

--- a/eme-tasks.php
+++ b/eme-tasks.php
@@ -599,6 +599,7 @@ function eme_task_signups_table_layout( $message = '' ) {
             if ( $key == 'future' ) {
                 $selected = "selected='selected'";
             }
+            // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- $selected is hardcoded selected attribute
             echo "<option value='".esc_attr($key)."' $selected>".esc_html($value)."</option>";
         }
         ?>
@@ -949,7 +950,7 @@ function eme_meta_box_div_event_tasks( $event, $edit_recurrence = 0 ) {
                 if (!empty($task['task_id'])) {
                     $count_signups = eme_count_task_signups($task['task_id']);
                     if ($count_signups>0) {
-                        echo "<span name='eme_tasks[$count][signup_count]' id='eme_tasks[$count][signup_count]'><br>";
+                        echo "<span name='eme_tasks[" . intval($count) . "][signup_count]' id='eme_tasks[" . intval($count) . "][signup_count]'><br>";
                         echo "<br>";
                         echo esc_html(sprintf( _n( 'One person already signed up for this task','%d persons already signed up for this task', $count_signups, 'events-made-easy' ), $count_signups ));
                         echo "</span>";
@@ -1848,6 +1849,7 @@ function eme_tasks_ajax() {
     // check for spammers as early as possible
     if ( ! isset( $_POST['honeypot_check'] ) || ! empty( $_POST['honeypot_check'] ) ) {
         $message = __( "Bot detected. If you believe you've received this message in error please contact the site owner.", 'events-made-easy' );
+        // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- wp_json_encode() returns safe JSON
         echo wp_json_encode(
             [
                 'Result'      => 'NOK',
@@ -1859,6 +1861,7 @@ function eme_tasks_ajax() {
 
     if ( ! isset( $_POST['eme_frontend_nonce'] ) || ! wp_verify_nonce( eme_sanitize_request($_POST['eme_frontend_nonce']), 'eme_frontend' ) ) {
         $message = __( "Form tampering detected. If you believe you've received this message in error please contact the site owner.", 'events-made-easy' );
+        // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- wp_json_encode() returns safe JSON
         echo wp_json_encode(
             [
                 'Result'      => 'NOK',
@@ -1869,6 +1872,7 @@ function eme_tasks_ajax() {
     }
     if ( ! isset( $_POST['eme_task_signups'] ) || empty( $_POST['eme_task_signups'] ) ) {
         $message = __( 'Please select at least one task.', 'events-made-easy' );
+        // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- wp_json_encode() returns safe JSON
         echo wp_json_encode(
             [
                 'Result'      => 'NOK',
@@ -2015,6 +2019,7 @@ function eme_tasks_ajax() {
     // if some task signups were ok, but others not, show ok
     if ( $ok && $nok ) {
         //echo wp_json_encode(array('Result'=>'OK','keep_form'=>1,'htmlmessage'=>$message));
+        // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- wp_json_encode() returns safe JSON
         echo wp_json_encode(
             [
                 'Result'      => 'OK',
@@ -2022,6 +2027,7 @@ function eme_tasks_ajax() {
             ]
         );
     } elseif ( $nok ) {
+        // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- wp_json_encode() returns safe JSON
         echo wp_json_encode(
             [
                 'Result'      => 'NOK',
@@ -2030,6 +2036,7 @@ function eme_tasks_ajax() {
         );
     } elseif ( $ok ) {
         //echo wp_json_encode(array('Result'=>'OK','keep_form'=>1,'htmlmessage'=>$message));
+        // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- wp_json_encode() returns safe JSON
         echo wp_json_encode(
             [
                 'Result'      => 'OK',

--- a/eme-templates.php
+++ b/eme-templates.php
@@ -234,12 +234,12 @@ function eme_templates_edit_layout( $template_id = 0, $message = '', $template =
     echo "
    <div class='wrap'>
       <div id='poststuff'>
-      <h1>" . $h1_string . '</h1>';
+      <h1>" . esc_html( $h1_string ) . '</h1>';
 
     if ( $message != '' ) {
         echo "
       <div id='message' class='updated notice notice-success is-dismissible'>
-         <p>$message</p>
+         <p>" . wp_kses_post( $message ) . "</p>
       </div>";
     }
 ?>
@@ -536,7 +536,7 @@ function eme_ajax_get_template() {
     } else {
         $ajaxResult['htmlmessage'] = '';
     }
-    echo wp_json_encode( $ajaxResult );
+    echo wp_json_encode( $ajaxResult ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- wp_json_encode() returns safe JSON
     wp_die();
 }
 


### PR DESCRIPTION
## Summary

Addresses the two observations from the PR #949 review, plus all remaining output escaping PCP errors:

**PR #949 follow-up (review by liedekef):**
- Fix payments inconsistency: escape the "The amount to pay is %s" strings in eme-payments.php that were flagged as missed adjacent to the "Payment handling" fixes
- Convert 32x `_e()` to `esc_html_e()` (the UnsafePrintingFunction follow-up, all verified plain-text translations)

**Remaining OutputNotEscaped fixes:**
- Replace `htmlspecialchars()` with `esc_html()`/`esc_attr()` (WP canonical equivalents)
- Add context-appropriate escaping to variables in output: `esc_html()`, `esc_url()`, `esc_attr()`, `intval()`, `absint()`
- Add `phpcs:disable` for non-HTML output files: class-qrcode.php (QR image generation), cli_mail.php (CLI terminal output)
- Add `phpcs:disable`/`phpcs:ignore` for iCal, RSS CDATA, XML sitemap, and wp_json_encode AJAX responses
- Use `eme_kses_maybe_unfiltered()` for rich editor content (eme-gdpr.php), `wp_kses_post()` for HTML translations (eme-actions.php)

## Files changed (22)

**phpcs:disable (non-HTML output):** class-qrcode.php, cli_mail.php
**_e() conversions:** eme-options.php (31x), eme-actions.php (1x)
**Variable escaping:** eme-events.php, eme-locations.php, eme-people.php, eme-members.php, eme-payments.php, eme-categories.php, eme-discounts.php, eme-cron.php, eme-functions.php, eme-gdpr.php, eme-attendances.php, eme-templates.php
**phpcs:ignore (trusted output):** eme-mailer.php, eme-rsvp.php, eme-tasks.php, eme-ical.php, eme-cleanup.php, eme-calendar.php

## Test plan

- [x] `php -l` syntax check on all 22 files: OK
- [x] `bash eme-tests/run-tests.sh`: 76/76 tests pass
- [x] `bash eme-tests/code-checks.sh --wpstore`: all metrics stable
- [x] Controleslag: adjacent lines checked, no double-escaping, feedback compliance verified