### PR TITLE
Fix text domain issues and replace eme_esc_html() with esc_html()

### DIFF
--- a/eme-actions.php
+++ b/eme-actions.php
@@ -240,7 +240,7 @@ function eme_add_events_locations_link_search( $results, $query ) {
     foreach ( $events as $event ) {
         $results[] = [
             'ID'        => $event['event_id'],
-            'title'     => trim( eme_esc_html( strip_tags( $event['event_name'] ) . ' (' . eme_localized_datetime( $event['event_start'], EME_TIMEZONE ) . ')' ) ),
+            'title'     => trim( esc_html( strip_tags( $event['event_name'] ) . ' (' . eme_localized_datetime( $event['event_start'], EME_TIMEZONE ) . ')' ) ),
             'permalink' => eme_event_url( $event ),
             'info'      => __( 'Event', 'events-made-easy' ),
         ];
@@ -249,7 +249,7 @@ function eme_add_events_locations_link_search( $results, $query ) {
     foreach ( $locations as $location ) {
         $results[] = [
             'ID'        => $location['location_id'],
-            'title'     => trim( eme_esc_html( strip_tags( $location['location_name'] ) ) ),
+            'title'     => trim( esc_html( strip_tags( $location['location_name'] ) ) ),
             'permalink' => eme_location_url( $location ),
             'info'      => __( 'Location', 'events-made-easy' ),
         ];

--- a/eme-attendances.php
+++ b/eme-attendances.php
@@ -241,7 +241,7 @@ function eme_ajax_attendances_list() {
 				$person_info_shown .= ' ' . $person['firstname'];
 			}
 			$person_info_shown           .= ' (' . $person['email'] . ')';
-			$rows[ $key ]['person']       = "<a href='" . esc_url( admin_url( 'admin.php?page=eme-people&eme_admin_action=edit_person&person_id=' . $person['person_id'] ) ) . "' title='" . esc_attr__( 'Edit person', 'events-made-easy' ) . "'>" . eme_esc_html( $person_info_shown ) . '</a>';
+			$rows[ $key ]['person']       = "<a href='" . esc_url( admin_url( 'admin.php?page=eme-people&eme_admin_action=edit_person&person_id=' . $person['person_id'] ) ) . "' title='" . esc_attr__( 'Edit person', 'events-made-easy' ) . "'>" . esc_html( $person_info_shown ) . '</a>';
 			$rows[ $key ]['related_name'] = '';
 			if ( $row['type'] == 'event' ) {
 				$event = eme_get_event( $row['related_id'] );

--- a/eme-calendar.php
+++ b/eme-calendar.php
@@ -390,7 +390,7 @@ function eme_get_calendar( $category=0, $notcategory=0, $full=0, $month='', $yea
 		if ( $holidays ) {
 			foreach ( $holidays as $day_key => $info ) {
 				if ( ! empty( $info['name'] ) ) {
-					$holiday_title = trim( eme_esc_html( $info['name'] ) );
+					$holiday_title = trim( esc_html( $info['name'] ) );
 					$eme_holiday_class = 'eme-cal-holidays';
 					if ( empty( $info['class'] ) ) {
 						$class = $eme_holiday_class;
@@ -580,6 +580,7 @@ function eme_get_calendar( $category=0, $notcategory=0, $full=0, $month='', $yea
 		$sCalDivRows .= "</div>\n";
 	}
 
+	// phpcs:ignore WordPress.WP.I18n.MissingArgDomain -- WordPress core weekday translations for $wp_locale
 	$weekday_names        = [ __( 'Sunday' ), __( 'Monday' ), __( 'Tuesday' ), __( 'Wednesday' ), __( 'Thursday' ), __( 'Friday' ), __( 'Saturday' ) ];
 	$weekday_header_class = [ 'Sun_header', 'Mon_header', 'Tue_header', 'Wed_header', 'Thu_header', 'Fri_header', 'Sat_header' ];
 	$sCalTblDayNames      = '';

--- a/eme-categories.php
+++ b/eme-categories.php
@@ -513,7 +513,7 @@ function eme_replace_categories_placeholders( $format, $cat = '', $target = 'htm
 				$replacement = apply_filters( 'eme_text', $replacement );
 			}
 			if ( $need_escape ) {
-				$replacement = eme_esc_html( preg_replace( '/\n|\r/', '', $replacement ) );
+				$replacement = esc_html( preg_replace( '/\n|\r/', '', $replacement ) );
 			}
 			if ( $need_urlencode ) {
 				$replacement = rawurlencode( $replacement );

--- a/eme-countries.php
+++ b/eme-countries.php
@@ -1030,7 +1030,7 @@ function eme_ajax_state_edit() {
 			$record = eme_get_state( $res );
 			// for the new record, we also need to provide the lang (as done in eme_get_states)
 			$record['lang']         = eme_get_state_lang( $res );
-			$fTableResult['Record'] = eme_esc_html( $record );
+			$fTableResult['Record'] = array_map( 'esc_html', $record );
 		}
 	}
 

--- a/eme-discounts.php
+++ b/eme-discounts.php
@@ -156,7 +156,7 @@ function eme_discounts_page() {
 									++$inserted;
 								} else {
 									++$errors;
-									$error_msg .= '<br>' . eme_esc_html( sprintf( __( 'Not imported: %s', 'events-made-easy' ), implode( ',', $row ) ) );
+									$error_msg .= '<br>' . esc_html( sprintf( __( 'Not imported: %s', 'events-made-easy' ), implode( ',', $row ) ) );
 								}
 							}
 							$message = sprintf( __( 'Import finished: %d inserts, %d errors', 'events-made-easy' ), $inserted, $errors );
@@ -215,7 +215,7 @@ function eme_discounts_page() {
 									++$inserted;
 								} else {
 									++$errors;
-									$error_msg .= '<br>' . eme_esc_html( sprintf( __( 'Not imported: %s', 'events-made-easy' ), implode( ',', $row ) ) );
+									$error_msg .= '<br>' . esc_html( sprintf( __( 'Not imported: %s', 'events-made-easy' ), implode( ',', $row ) ) );
 								}
 							}
 							$message = sprintf( __( 'Import finished: %d inserts, %d errors', 'events-made-easy' ), $inserted, $errors );

--- a/eme-events.php
+++ b/eme-events.php
@@ -1118,7 +1118,7 @@ function eme_events_page_content() {
                 $format .= "<div class='eme-message-error eme-attendance-message-error'>$img" . sprintf( __( 'Error updating attendance count, but ignoring', 'events-made-easy' ) ) . '</div>';
             }
 
-            $format .= '<br>' . sprintf( __( 'Event : %s', 'events-made-easy' ), eme_esc_html( $event['event_name'] ) );
+            $format .= '<br>' . sprintf( __( 'Event : %s', 'events-made-easy' ), esc_html( $event['event_name'] ) );
             if ( $event['event_properties']['attendancerecord'] || $event['event_properties']['attendanceperday']) {
                 $res = eme_db_insert_attendance( 'event', $booking['person_id'], '', $booking['event_id'] );
                 if ( $res ) {
@@ -2241,7 +2241,7 @@ function eme_replace_generic_placeholders( $format, $target = 'html' ) {
             if (!empty($t_person) && !empty($t_person['person_id']))
                 $replacement = join( ', ', eme_get_persongroup_names( $t_person['person_id'] ) );
             if ( $target == 'html' ) {
-                $replacement = eme_esc_html( $replacement );
+                $replacement = esc_html( $replacement );
                 $replacement = apply_filters( 'eme_general', $replacement );
             } else {
                 $replacement = apply_filters( 'eme_text', $replacement );
@@ -2255,7 +2255,7 @@ function eme_replace_generic_placeholders( $format, $target = 'html' ) {
             if (!empty($t_person) && !empty($t_person['person_id']))
                 $replacement = eme_get_activemembership_names_by_personid( $t_person['person_id'] );
             if ( $target == 'html' ) {
-                $replacement = eme_esc_html( $replacement );
+                $replacement = esc_html( $replacement );
                 $replacement = apply_filters( 'eme_general', $replacement );
             } else {
                 $replacement = apply_filters( 'eme_text', $replacement );
@@ -2325,7 +2325,7 @@ function eme_replace_generic_placeholders( $format, $target = 'html' ) {
                 $replacement = "";
             }
             if ( $need_escape ) {
-                $replacement = eme_esc_html( preg_replace( '/\n|\r/', '', $replacement ) );
+                $replacement = esc_html( preg_replace( '/\n|\r/', '', $replacement ) );
             }
             if ( $need_urlencode ) {
                 $replacement = rawurlencode( $replacement );
@@ -2399,7 +2399,7 @@ function eme_replace_event_placeholders( $format, $event, $target = 'html', $lan
         }
 
         if ( $need_escape ) {
-            $replacement = eme_esc_html( preg_replace( '/\n|\r/', '', $replacement ) );
+            $replacement = esc_html( preg_replace( '/\n|\r/', '', $replacement ) );
         }
         if ( $need_urlencode ) {
             $replacement = rawurlencode( $replacement );
@@ -4034,7 +4034,7 @@ function eme_replace_event_placeholders( $format, $event, $target = 'html', $lan
                     $replacement = "";
                 }
                 if ( $need_escape ) {
-                    $replacement = eme_esc_html( preg_replace( '/\n|\r/', '', $replacement ) );
+                    $replacement = esc_html( preg_replace( '/\n|\r/', '', $replacement ) );
                 }
                 if ( $need_urlencode ) {
                     $replacement = rawurlencode( $replacement );
@@ -4079,7 +4079,7 @@ function eme_replace_event_placeholders( $format, $event, $target = 'html', $lan
             $replacement = eme_localized_date( $event[ $my_dt ], EME_TIMEZONE, substr( $result, $offset, ( strlen( $result ) - ( $offset + 1 ) ) ) );
 
             if ( $need_escape ) {
-                $replacement = eme_esc_html( preg_replace( '/\n|\r/', '', $replacement ) );
+                $replacement = esc_html( preg_replace( '/\n|\r/', '', $replacement ) );
             }
             if ( $need_urlencode ) {
                 $replacement = rawurlencode( $replacement );
@@ -4208,7 +4208,7 @@ function eme_replace_notes_placeholders( $format, $event = '', $target = 'html' 
                     $replacement = "";
                 }
                 if ( $need_escape ) {
-                    $replacement = eme_esc_html( preg_replace( '/\n|\r/', '', $replacement ) );
+                    $replacement = esc_html( preg_replace( '/\n|\r/', '', $replacement ) );
                 }
                 $format         = substr_replace( $format, $replacement, $orig_result_needle, $orig_result_length );
                 $needle_offset += $orig_result_length - strlen( $replacement );
@@ -5892,13 +5892,13 @@ function eme_import_csv_events() {
                     // location_id is returned if update is ok, and we use the location id later on
                     $location_id = eme_update_location( $line, $location_id );
                     if ( ! $location_id ) {
-                        $error_msg .= '<br>' . eme_esc_html( sprintf( __( 'Location not imported: %s', 'events-made-easy' ), implode( ',', $row ) ) );
+                        $error_msg .= '<br>' . esc_html( sprintf( __( 'Location not imported: %s', 'events-made-easy' ), implode( ',', $row ) ) );
                     }
                 } else {
                     $location_id = eme_insert_location( $line );
                     if ( ! $location_id ) {
                         ++$errors;
-                        $error_msg .= '<br>' . eme_esc_html( sprintf( __( 'Location not imported: %s', 'events-made-easy' ), implode( ',', $row ) ) );
+                        $error_msg .= '<br>' . esc_html( sprintf( __( 'Location not imported: %s', 'events-made-easy' ), implode( ',', $row ) ) );
                     }
                 }
                 if ( $location_id ) {
@@ -5922,10 +5922,10 @@ function eme_import_csv_events() {
 
             if ( ! empty( $line['event_start_date'] ) && ! eme_is_date( $line['event_start_date'] ) ) {
                 ++$errors;
-                $error_msg .= '<br>' . eme_esc_html( sprintf( __( 'Not imported (field %s not valid): %s', 'events-made-easy' ), 'event_start_date', implode( ',', $row ) ) );
+                $error_msg .= '<br>' . esc_html( sprintf( __( 'Not imported (field %s not valid): %s', 'events-made-easy' ), 'event_start_date', implode( ',', $row ) ) );
             } elseif ( ! empty( $line['event_end_date'] ) && ! eme_is_date( $line['event_end_date'] ) ) {
                 ++$errors;
-                $error_msg .= '<br>' . eme_esc_html( sprintf( __( 'Not imported (field %s not valid): %s', 'events-made-easy' ), 'event_end_date', implode( ',', $row ) ) );
+                $error_msg .= '<br>' . esc_html( sprintf( __( 'Not imported (field %s not valid): %s', 'events-made-easy' ), 'event_end_date', implode( ',', $row ) ) );
             } elseif ( isset( $line['event_name'] ) ) {
                 if ( ! isset( $line['location_id'] ) ) {
                     $line['location_id'] = $location_id;
@@ -5967,7 +5967,7 @@ function eme_import_csv_events() {
                         ++$updated;
                     } else {
                         ++$errors;
-                        $error_msg .= '<br>' . eme_esc_html( sprintf( __( 'Not imported (problem updating the event in the db): %s', 'events-made-easy' ), implode( ',', $row ) ) );
+                        $error_msg .= '<br>' . esc_html( sprintf( __( 'Not imported (problem updating the event in the db): %s', 'events-made-easy' ), implode( ',', $row ) ) );
                     }
                 } else {
                     $event_id = eme_db_insert_event( $line );
@@ -5975,7 +5975,7 @@ function eme_import_csv_events() {
                         ++$inserted;
                     } else {
                         ++$errors;
-                        $error_msg .= '<br>' . eme_esc_html( sprintf( __( 'Not imported (problem inserting the event in the db): %s', 'events-made-easy' ), implode( ',', $row ) ) );
+                        $error_msg .= '<br>' . esc_html( sprintf( __( 'Not imported (problem inserting the event in the db): %s', 'events-made-easy' ), implode( ',', $row ) ) );
                     }
                 }
                 if ( $event_id ) {
@@ -5997,7 +5997,7 @@ function eme_import_csv_events() {
                 }
             } else {
                 ++$errors;
-                $error_msg .= '<br>' . eme_esc_html( sprintf( __( 'Not imported (not all required fields are present): %s', 'events-made-easy' ), implode( ',', $row ) ) );
+                $error_msg .= '<br>' . esc_html( sprintf( __( 'Not imported (not all required fields are present): %s', 'events-made-easy' ), implode( ',', $row ) ) );
             }
         }
         $result = sprintf( __( 'Import finished: %d inserts, %d updates, %d errors', 'events-made-easy' ), $inserted, $updated, $errors );
@@ -6121,7 +6121,7 @@ function eme_events_table( $message = '' ) {
     if ( ! empty( $formfields_searchable ) ) {
         echo '<input type="search" name="search_customfields" id="search_customfields" placeholder="' . esc_attr__( 'Custom field value to search', 'events-made-easy' ) . '" class="eme_searchfilter" size=20>';
         $label = __( 'Custom fields to filter on', 'events-made-easy' );
-        $extra_attributes = 'aria-label="' . eme_esc_html( $label ) . '" data-placeholder="' . eme_esc_html( $label ) . '"';
+        $extra_attributes = 'aria-label="' . esc_html( $label ) . '" data-placeholder="' . esc_html( $label ) . '"';
         echo eme_ui_multiselect_key_value( '', 'search_customfieldids', $formfields_searchable, 'field_id', 'field_name', 5, '', 0, 'eme_snapselect', $extra_attributes, 1 ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_multiselect_key_value()
     }
 ?>
@@ -7142,6 +7142,7 @@ function eme_meta_box_div_recurrence_info( $recurrence, $edit_recurrence = 0 ) {
         'specific' => __( 'Specific days', 'events-made-easy' ),
         'specific_months' => __( 'Specific months', 'events-made-easy' ),
     ];
+    // phpcs:ignore WordPress.WP.I18n.MissingArgDomain -- WordPress core weekday translations for $wp_locale
     $days_names           = [
         1 => $wp_locale->get_weekday_abbrev( __( 'Monday' ) ),
         2 => $wp_locale->get_weekday_abbrev( __( 'Tuesday' ) ),

--- a/eme-filters.php
+++ b/eme-filters.php
@@ -220,7 +220,7 @@ function eme_replace_filter_form_placeholders( $format, $multiple, $multisize, $
 			} else {
 				$label = __( 'Select a category', 'events-made-easy' );
 			}
-			$aria_label = 'aria-label="' . eme_esc_html( $label ) . '"';
+			$aria_label = 'aria-label="' . esc_html( $label ) . '"';
 
 			$categories = eme_get_categories( $eventful, 'future', $extra_conditions );
 			if ( $categories ) {
@@ -255,7 +255,7 @@ function eme_replace_filter_form_placeholders( $format, $multiple, $multisize, $
 			} else {
 				$label = __( 'Select a location', 'events-made-easy' );
 			}
-			$aria_label = 'aria-label="' . eme_esc_html( $label ) . '"';
+			$aria_label = 'aria-label="' . esc_html( $label ) . '"';
 			$locations  = eme_get_locations( eventful: $eventful, scope: 'future', ignore_filter: true );
 			if ( ! empty( $locations ) ) {
 				$loc_list = [];
@@ -289,7 +289,7 @@ function eme_replace_filter_form_placeholders( $format, $multiple, $multisize, $
 			} else {
 				$label = __( 'Select a city', 'events-made-easy' );
 			}
-			$aria_label = 'aria-label="' . eme_esc_html( $label ) . '"';
+			$aria_label = 'aria-label="' . esc_html( $label ) . '"';
 			$cities     = eme_get_locations( eventful: $eventful, scope: 'future', ignore_filter: true );
 			if ( ! empty( $cities ) ) {
 				$city_list = [];
@@ -323,7 +323,7 @@ function eme_replace_filter_form_placeholders( $format, $multiple, $multisize, $
 			} else {
 				$label = __( 'Select a country', 'events-made-easy' );
 			}
-			$aria_label = 'aria-label="' . eme_esc_html( $label ) . '"';
+			$aria_label = 'aria-label="' . esc_html( $label ) . '"';
 			$countries  = eme_get_locations( eventful: $eventful, scope: 'future', ignore_filter: true );
 			if ( ! empty( $countries ) ) {
 				$country_list = [];
@@ -363,7 +363,7 @@ function eme_replace_filter_form_placeholders( $format, $multiple, $multisize, $
 			}
 			if ( $scope_fieldcount == 0 ) {
 				$label       = __( 'Select Week', 'events-made-easy' );
-				$aria_label  = 'aria-label="' . eme_esc_html( $label ) . '"';
+				$aria_label  = 'aria-label="' . esc_html( $label ) . '"';
 				$replacement = eme_ui_select( $selected_scope, $scope_post_name, eme_create_week_scope( $past_count, $future_count, $eventful ), $label, 0, '', $aria_label );
 				++$scope_fieldcount;
 			}
@@ -425,7 +425,7 @@ function eme_replace_filter_form_placeholders( $format, $multiple, $multisize, $
 			$args = [
 				'echo'             => 0,
 				'name'             => $contact_post_name,
-				'show_option_none' => eme_esc_html( $label ),
+				'show_option_none' => esc_html( $label ),
                 'option_none_value'=> '',
 				'selected'         => $selected_contact,
 				'class'            => 'eme_snapselect_allow_empty',
@@ -454,7 +454,7 @@ function eme_replace_filter_form_placeholders( $format, $multiple, $multisize, $
 			$args = [
 				'echo'             => 0,
 				'name'             => $author_post_name,
-				'show_option_none' => eme_esc_html( $label ),
+				'show_option_none' => esc_html( $label ),
                 'option_none_value'=> '',
 				'selected'         => $selected_author,
 				'class'            => 'eme_snapselect_allow_empty',

--- a/eme-formfields.php
+++ b/eme-formfields.php
@@ -69,7 +69,7 @@ function eme_formfields_page() {
             $formfield                   = [];
             $field_id                    = intval( $_POST['field_id'] );
             $formfield['field_name']     = trim( eme_sanitize_request( $_POST['field_name'] ) );
-            $formfield['field_type']     = trim( eme_esc_html( eme_sanitize_request( $_POST['field_type'] ) ) );
+            $formfield['field_type']     = trim( esc_html( eme_sanitize_request( $_POST['field_type'] ) ) );
             $formfield['extra_charge']   = intval( $_POST['extra_charge'] );
             $formfield['searchable']     = intval( $_POST['searchable'] );
             $formfield['field_required'] = intval( $_POST['field_required'] );
@@ -305,7 +305,7 @@ function eme_formfields_edit_layout( $field_id = 0, $message = '', $t_formfield 
       <table class='form-table'>
             <tr class='form-field'>
                <th scope='row' style='vertical-align:top'><label for='field_name'>" . __( 'Field name', 'events-made-easy' ) . "</label></th>
-               <td><input name='field_name' id='field_name' type='text' value='" . eme_esc_html( $formfield['field_name'] ) . "' size='40' required='required'></td>
+               <td><input name='field_name' id='field_name' type='text' value='" . esc_html( $formfield['field_name'] ) . "' size='40' required='required'></td>
             </tr>
             <tr class='form-field'>
                <th scope='row' style='vertical-align:top'><label for='field_type'>" . __( 'Field type', 'events-made-easy' ) . '</label></th>
@@ -376,7 +376,7 @@ function eme_formfields_edit_layout( $field_id = 0, $message = '', $t_formfield 
             <tr id='tr_field_values' class='form-field'>
            <th scope='row' style='vertical-align:top'><label for='field_values'>" . __( 'Field values', 'events-made-easy' ) . '</label></th>';
 
-    $layout .= "<td><div id='field_values_container'><input name='field_values' id='field_values' type='text' value='" . eme_esc_html( $formfield['field_values'] ) . "' size='40'></div>";
+    $layout .= "<td><div id='field_values_container'><input name='field_values' id='field_values' type='text' value='" . esc_html( $formfield['field_values'] ) . "' size='40'></div>";
     $layout .= '
                   <br>' . __( 'Enter here the default value a field should have, or enter the list of values for fields that support multiple values.', 'events-made-easy' ) . '
                   <br>' . __( 'For fields that support multiple values (like Dropdown or Checkbox), enter one value per line. To include an empty first option (e.g., for a blank default in a dropdown), start with an empty line at the top.', 'events-made-easy' ) . '
@@ -386,7 +386,7 @@ function eme_formfields_edit_layout( $field_id = 0, $message = '', $t_formfield 
             </tr>
             <tr id='tr_field_tags' class='form-field'>
                <th scope='row' style='vertical-align:top'><label for='field_tags'>" . __( 'Field tags', 'events-made-easy' ) . '</label></th>';
-    $layout .= "<td><div id='field_tags_container'><input name='field_tags' id='field_tags' type='text' value='" . eme_esc_html( $formfield['field_tags'] ) . "' size='40'></div>";
+    $layout .= "<td><div id='field_tags_container'><input name='field_tags' id='field_tags' type='text' value='" . esc_html( $formfield['field_tags'] ) . "' size='40'></div>";
     $layout .= '
           <br>' . __( 'This option determines the "visible" value people will see for the field.', 'events-made-easy' ) . '
           <br>' . __( 'For multivalue fields, you can here enter the "visible" tag people will see per value (so, if "Field values" contain e.g. "a1||a2||a3", you can use here e.g. "Text a1||Text a2||Text a3").', 'events-made-easy' ) . '
@@ -395,7 +395,7 @@ function eme_formfields_edit_layout( $field_id = 0, $message = '', $t_formfield 
             </tr>
             <tr id='tr_admin_values' class='form-field'>
                <th scope='row' style='vertical-align:top'><label for='admin_values'>" . __( 'Admin Field values', 'events-made-easy' ) . '</label></th>';
-    $layout .= "<td><div id='admin_values_container'><input name='admin_values' id='admin_values' type='text' value='" . eme_esc_html( $formfield['admin_values'] ) . "' size='40'></div>";
+    $layout .= "<td><div id='admin_values_container'><input name='admin_values' id='admin_values' type='text' value='" . esc_html( $formfield['admin_values'] ) . "' size='40'></div>";
     $layout .= '
                   <br>' . __( 'If you want a bigger number of choices for e.g. dropdown fields in the admin interface, enter the possible values here', 'events-made-easy' ) . '
                   <br>' . __( "For the type 'File' you can optionally enter a maximum upload size in MB.", 'events-made-easy' ) . "
@@ -403,14 +403,14 @@ function eme_formfields_edit_layout( $field_id = 0, $message = '', $t_formfield 
             </tr>
             <tr id='tr_admin_tags' class='form-field'>
                <th scope='row' style='vertical-align:top'><label for='admin_tags'>" . __( 'Admin Field tags', 'events-made-easy' ) . '</label></th>';
-    $layout .= "<td><div id='admin_tags_container'><input name='admin_tags' id='admin_tags' type='text' value='" . eme_esc_html( $formfield['admin_tags'] ) . "' size='40'></div>";
+    $layout .= "<td><div id='admin_tags_container'><input name='admin_tags' id='admin_tags' type='text' value='" . esc_html( $formfield['admin_tags'] ) . "' size='40'></div>";
     $layout .= '
                   <br>' . __( 'If you want a bigger number of choices for e.g. dropdown fields in the admin interface, enter the possible tags here', 'events-made-easy' ) . "
                </td>
             </tr>
             <tr id='tr_field_attributes' class='form-field'>
                <th scope='row' style='vertical-align:top'><label for='field_attributes'>" . __( 'HTML field attributes', 'events-made-easy' ) . "</label></th>
-               <td><input name='field_attributes' id='field_attributes' type='text' value='" . eme_esc_html( $formfield['field_attributes'] ) . "' size='40'>
+               <td><input name='field_attributes' id='field_attributes' type='text' value='" . esc_html( $formfield['field_attributes'] ) . "' size='40'>
                    <br>" . __( 'Here you can specify extra html attributes for your field (like size, maxlength, pattern, ...).', 'events-made-easy' ) . '
                    <br>' . __( "For the types 'Date (Javascript)', 'Datetime (Javascript)' and 'Time (Javascript)' enter a valid PHP-format of the date you like to see when entering/showing the value (unrecognized characters in the format will cause the result to be empty). If left empty, the WordPress settings for date format will be used.", 'events-made-easy' ) . "
                     <br>" . __( "For the types 'Dropdown' and 'Dropdown (multiple)' you can optionally enter a placeholder by using data-placeholder: data-placeholder='my placeholder value'. Be sure to add an empty first line (value & tag) then, otherwise the placeholder might not show.", 'events-made-easy' ) . __('EME uses a custom snapselect version for dropdowns, see https://github.com/liedekef/snapselect for all data-related possibilities.','events-made-easy') . "
@@ -418,7 +418,7 @@ function eme_formfields_edit_layout( $field_id = 0, $message = '', $t_formfield 
             </tr>
             <tr id='tr_admin_attributes' class='form-field'>
                <th scope='row' style='vertical-align:top'><label for='admin_attributes'>" . __( 'Admin HTML field attributes', 'events-made-easy' ) . "</label></th>
-               <td><input name='admin_attributes' id='admin_attributes' type='text' value='" . eme_esc_html( $formfield['admin_attributes'] ) . "' size='40'>
+               <td><input name='admin_attributes' id='admin_attributes' type='text' value='" . esc_html( $formfield['admin_attributes'] ) . "' size='40'>
                    <br>" . __( 'If you want different HTML attributes in the admin interface, enter these here.', 'events-made-easy' ) . "
                </td>
             </tr>
@@ -703,7 +703,7 @@ function eme_get_formfield_html( $formfield, $field_name, $entered_val, $require
             if ( empty( $value ) ) {
                 $value = $field_values;
             }
-            $value = eme_esc_html( $value );
+            $value = esc_html( $value );
             $html  = "<input $readonly $required_att type='" . $formfield['field_type'] . "' name='$field_name' id='$field_name' value='$value' $field_attributes>";
             break;
         case 'hidden':
@@ -711,7 +711,7 @@ function eme_get_formfield_html( $formfield, $field_name, $entered_val, $require
             if ( empty( $value ) ) {
                 $value = $field_values;
             }
-            $value = eme_esc_html( $value );
+            $value = esc_html( $value );
             if ( eme_is_admin_request() ) {
                     $html  = "<input $readonly $required_att type='text' name='$field_name' id='$field_name' value='$value' $field_attributes><br>";
                     $html .= __( 'This is a hidden field, but in the backend it is shown as text so an admin can see its value and optionally change it', 'events-made-easy' );
@@ -720,19 +720,19 @@ function eme_get_formfield_html( $formfield, $field_name, $entered_val, $require
             }
             break;
         case 'password':
-            $value = eme_esc_html( $entered_val );
+            $value = esc_html( $entered_val );
             $new_attrs = eme_merge_classes_into_attrs('eme_passwordfield', $field_attributes);
             $html = "<input $readonly $required_att type='text' autocomplete='off' name='$field_name' id='$field_name' value='$value' $new_attrs>";
             break;
         case 'readonly':
-            $value = eme_esc_html( $entered_val );
+            $value = esc_html( $entered_val );
             if ( empty( $value ) ) {
                 $value = eme_translate( $field_tags );
             }
             if ( empty( $value ) ) {
                 $value = $field_values;
             }
-            $value = eme_esc_html( $value );
+            $value = esc_html( $value );
             $html  = "<input readonly='readonly' $required_att type='text' name='$field_name' id='$field_name' value='$value' $field_attributes>";
             break;
         case 'dropdown':
@@ -783,7 +783,7 @@ function eme_get_formfield_html( $formfield, $field_name, $entered_val, $require
             if ( empty( $value ) ) {
                 $value = $field_values;
             }
-            $value = eme_esc_html( $value );
+            $value = esc_html( $value );
             $html  = "<textarea $required_att name='$field_name' id='$field_name' $field_attributes $readonly>$value</textarea>";
             break;
         case 'radiobox':
@@ -926,7 +926,7 @@ function eme_get_formfield_html( $formfield, $field_name, $entered_val, $require
                 $value        = $eme_date_obj->getDate();
             }
 
-            $value = eme_esc_html( $value );
+            $value = esc_html( $value );
             $dateformat = $formfield['field_attributes'];
             if ( empty( $dateformat ) ) {
                 $dateformat = EME_WP_DATE_FORMAT;
@@ -947,7 +947,7 @@ function eme_get_formfield_html( $formfield, $field_name, $entered_val, $require
                 $eme_date_obj = new emeExpressiveDate( 'now', EME_TIMEZONE );
                 $value        = $eme_date_obj->getDateTime();
             }
-            $value    = eme_esc_html( $value );
+            $value    = esc_html( $value );
             $js_value = eme_js_datetime( $value, EME_TIMEZONE );
             $dateformat = $formfield['field_attributes'];
             if ( empty( $dateformat ) ) {
@@ -970,7 +970,7 @@ function eme_get_formfield_html( $formfield, $field_name, $entered_val, $require
                 $eme_date_obj = new emeExpressiveDate( 'now', EME_TIMEZONE );
                 $value        = $eme_date_obj->getTime();
             }
-            $value    = eme_esc_html( $value );
+            $value    = esc_html( $value );
             $js_value = eme_js_datetime( $value, EME_TIMEZONE );
             $dateformat = $formfield['field_attributes'];
             if ( empty( $dateformat ) ) {
@@ -982,15 +982,15 @@ function eme_get_formfield_html( $formfield, $field_name, $entered_val, $require
         case 'datalist':
             # for text fields
             $value = $entered_val;
-            $value = eme_esc_html( $entered_val );
+            $value = esc_html( $entered_val );
             $html  = "<input $readonly $required_att type='text' list='list_$field_name' name='$field_name' id='$field_name' value='$value' $field_attributes>";
             // now the datalist
             $html  .= "<datalist id='list_$field_name'>";
             $values = eme_convert_multi2array( $field_values );
             $tags   = eme_convert_multi2array( $field_tags );
             foreach ( $values as $key => $val ) {
-                $val  = eme_esc_html($val);
-                $tag  = eme_esc_html($tags[ $key ]);
+                $val  = esc_html($val);
+                $tag  = esc_html($tags[ $key ]);
                 $html .= "<option value='$val'>$tag</option>";
             }
             $html  .= "</datalist>";
@@ -1130,18 +1130,18 @@ function eme_replace_task_signupformfields_placeholders( $form_id, $format ) {
         if ( empty( $person ) ) {
             $person = eme_fake_person_by_wp_id( $current_user->ID );
         }
-        $bookerLastName     = eme_esc_html( $person['lastname'] );
-        $bookerFirstName    = eme_esc_html( $person['firstname'] );
-        $bookerBirthdate    = eme_is_date( $person['birthdate'] ) ? eme_esc_html( $person['birthdate'] ) : '';
-        $bookerBirthplace   = eme_esc_html( $person['birthplace'] );
-        $bookerAddress1     = eme_esc_html( $person['address1'] );
-        $bookerAddress2     = eme_esc_html( $person['address2'] );
-        $bookerCity         = eme_esc_html( $person['city'] );
-        $bookerZip          = eme_esc_html( $person['zip'] );
-        $bookerState_code   = eme_esc_html( $person['state_code'] );
-        $bookerCountry_code = eme_esc_html( $person['country_code'] );
-        $bookerEmail        = eme_esc_html( $person['email'] );
-        $bookerPhone        = eme_esc_html( $person['phone'] );
+        $bookerLastName     = esc_html( $person['lastname'] );
+        $bookerFirstName    = esc_html( $person['firstname'] );
+        $bookerBirthdate    = eme_is_date( $person['birthdate'] ) ? esc_html( $person['birthdate'] ) : '';
+        $bookerBirthplace   = esc_html( $person['birthplace'] );
+        $bookerAddress1     = esc_html( $person['address1'] );
+        $bookerAddress2     = esc_html( $person['address2'] );
+        $bookerCity         = esc_html( $person['city'] );
+        $bookerZip          = esc_html( $person['zip'] );
+        $bookerState_code   = esc_html( $person['state_code'] );
+        $bookerCountry_code = esc_html( $person['country_code'] );
+        $bookerEmail        = esc_html( $person['email'] );
+        $bookerPhone        = esc_html( $person['phone'] );
         $bd_email           = intval( $person['bd_email'] );
         $gdpr               = intval( $person['gdpr'] );
     }
@@ -1329,7 +1329,7 @@ function eme_replace_task_signupformfields_placeholders( $form_id, $format ) {
             $fieldname         = 'task_massmail';
             $replacement       = eme_ui_select_binary( $selected_massmail, $fieldname, 0, 'eme_snapselect' );
             if ( ! $eme_is_admin_request && get_option( 'eme_massmail_popup' ) ) {
-                $popup   = eme_esc_html( get_option( 'eme_massmail_popup_text' ) );
+                $popup   = esc_html( get_option( 'eme_massmail_popup_text' ) );
                 $confirm = esc_html__('Yes','events-made-easy');
                 $cancel  = esc_html__('No','events-made-easy');
                 if (!eme_is_empty_string($popup))
@@ -1340,7 +1340,7 @@ function eme_replace_task_signupformfields_placeholders( $form_id, $format ) {
             $fieldname         = 'task_massmail';
             $replacement       = eme_ui_select_binary( $selected_massmail, $fieldname, 0, 'eme_snapselect' );
             if ( ! $eme_is_admin_request && get_option( 'eme_massmail_popup' ) ) {
-                $popup   = eme_esc_html( get_option( 'eme_massmail_popup_text' ) );
+                $popup   = esc_html( get_option( 'eme_massmail_popup_text' ) );
                 $confirm = esc_html__('Yes','events-made-easy');
                 $cancel  = esc_html__('No','events-made-easy');
                 if (!eme_is_empty_string($popup))
@@ -1478,9 +1478,9 @@ function eme_replace_cancelformfields_placeholders( $event ) {
         if ( empty( $person ) ) {
             $person = eme_fake_person_by_wp_id( $current_user->ID );
         }
-        $bookerLastName  = eme_esc_html($person['lastname']);
-        $bookerFirstName = eme_esc_html($person['firstname']);
-        $bookerEmail     = eme_esc_html($person['email']);
+        $bookerLastName  = esc_html($person['lastname']);
+        $bookerFirstName = esc_html($person['firstname']);
+        $bookerEmail     = esc_html($person['email']);
     }
 
     // the 2 placeholders that can contain extra text are treated separately first
@@ -1751,18 +1751,18 @@ function eme_replace_extra_multibooking_formfields_placeholders( $form_id, $form
         if ( empty( $person ) ) {
             $person = eme_fake_person_by_wp_id( $current_user->ID );
         }
-        $bookerLastName     = eme_esc_html( $person['lastname'] );
-        $bookerFirstName    = eme_esc_html( $person['firstname'] );
-        $bookerBirthdate    = eme_is_date( $person['birthdate'] ) ? eme_esc_html( $person['birthdate'] ) : '';
-        $bookerBirthplace   = eme_esc_html( $person['birthplace'] );
-        $bookerAddress1     = eme_esc_html( $person['address1'] );
-        $bookerAddress2     = eme_esc_html( $person['address2'] );
-        $bookerCity         = eme_esc_html( $person['city'] );
-        $bookerZip          = eme_esc_html( $person['zip'] );
-        $bookerState_code   = eme_esc_html( $person['state_code'] );
-        $bookerCountry_code = eme_esc_html( $person['country_code'] );
-        $bookerEmail        = eme_esc_html( $person['email'] );
-        $bookerPhone        = eme_esc_html( $person['phone'] );
+        $bookerLastName     = esc_html( $person['lastname'] );
+        $bookerFirstName    = esc_html( $person['firstname'] );
+        $bookerBirthdate    = eme_is_date( $person['birthdate'] ) ? esc_html( $person['birthdate'] ) : '';
+        $bookerBirthplace   = esc_html( $person['birthplace'] );
+        $bookerAddress1     = esc_html( $person['address1'] );
+        $bookerAddress2     = esc_html( $person['address2'] );
+        $bookerCity         = esc_html( $person['city'] );
+        $bookerZip          = esc_html( $person['zip'] );
+        $bookerState_code   = esc_html( $person['state_code'] );
+        $bookerCountry_code = esc_html( $person['country_code'] );
+        $bookerEmail        = esc_html( $person['email'] );
+        $bookerPhone        = esc_html( $person['phone'] );
         $bd_email           = intval( $person['bd_email'] );
         $gdpr               = intval( $person['gdpr'] );
 
@@ -1974,13 +1974,13 @@ function eme_replace_extra_multibooking_formfields_placeholders( $form_id, $form
             $selected_massmail = 1;
             $replacement = eme_ui_select_binary( $selected_massmail, 'massmail', 0, 'eme_snapselect' );
             if ( get_option( 'eme_massmail_popup' ) ) {
-                $popup       = eme_esc_html( get_option( 'eme_massmail_popup_text' ) );
+                $popup       = esc_html( get_option( 'eme_massmail_popup_text' ) );
             }
         } elseif ( preg_match( '/#_OPT_IN$/', $result ) ) {
             $selected_massmail = 0;
             $replacement = eme_ui_select_binary( $selected_massmail, 'massmail', 0, 'eme_snapselect' );
             if ( get_option( 'eme_massmail_popup' ) ) {
-                $popup       = eme_esc_html( get_option( 'eme_massmail_popup_text' ) );
+                $popup       = esc_html( get_option( 'eme_massmail_popup_text' ) );
             }
         } elseif ( preg_match( '/#_GDPR(\{.+?\})?/', $result, $matches ) ) {
             if ( isset( $matches[1] ) ) {
@@ -2021,7 +2021,7 @@ function eme_replace_extra_multibooking_formfields_placeholders( $form_id, $form
                     }
                     $replacement = "<input id='subscribe_groups_$group_id' name='subscribe_groups[]' value='$group_id' type='checkbox' class='nodynamicupdates'>";
                     if ( ! empty( $label ) ) {
-                        $replacement .= "<label for='subscribe_groups_$group_id'>" . eme_esc_html( $label ) . '</label>';
+                        $replacement .= "<label for='subscribe_groups_$group_id'>" . esc_html( $label ) . '</label>';
                     }
                 }
             } else {
@@ -2443,18 +2443,18 @@ function eme_replace_rsvp_formfields_placeholders( $form_id, $event, $booking, $
         if ( empty( $person ) ) {
             $person = eme_fake_person_by_wp_id( $current_user->ID );
         }
-        $bookerLastName     = eme_esc_html( $person['lastname'] );
-        $bookerFirstName    = eme_esc_html( $person['firstname'] );
-        $bookerBirthdate    = eme_is_date( $person['birthdate'] ) ? eme_esc_html( $person['birthdate'] ) : '';
-        $bookerBirthplace   = eme_esc_html( $person['birthplace'] );
-        $bookerAddress1     = eme_esc_html( $person['address1'] );
-        $bookerAddress2     = eme_esc_html( $person['address2'] );
-        $bookerCity         = eme_esc_html( $person['city'] );
-        $bookerZip          = eme_esc_html( $person['zip'] );
-        $bookerState_code   = eme_esc_html( $person['state_code'] );
-        $bookerCountry_code = eme_esc_html( $person['country_code'] );
-        $bookerEmail        = eme_esc_html( $person['email'] );
-        $bookerPhone        = eme_esc_html( $person['phone'] );
+        $bookerLastName     = esc_html( $person['lastname'] );
+        $bookerFirstName    = esc_html( $person['firstname'] );
+        $bookerBirthdate    = eme_is_date( $person['birthdate'] ) ? esc_html( $person['birthdate'] ) : '';
+        $bookerBirthplace   = esc_html( $person['birthplace'] );
+        $bookerAddress1     = esc_html( $person['address1'] );
+        $bookerAddress2     = esc_html( $person['address2'] );
+        $bookerCity         = esc_html( $person['city'] );
+        $bookerZip          = esc_html( $person['zip'] );
+        $bookerState_code   = esc_html( $person['state_code'] );
+        $bookerCountry_code = esc_html( $person['country_code'] );
+        $bookerEmail        = esc_html( $person['email'] );
+        $bookerPhone        = esc_html( $person['phone'] );
         $massmail           = intval( $person['massmail'] );
         $bd_email           = intval( $person['bd_email'] );
         $gdpr               = intval( $person['gdpr'] );
@@ -2464,24 +2464,24 @@ function eme_replace_rsvp_formfields_placeholders( $form_id, $event, $booking, $
         if ( ! empty( $booking['person_id'] ) ) {
             $person = eme_get_person( $booking['person_id'] );
             // when editing a booking
-            $bookerLastName     = eme_esc_html( $person['lastname'] );
-            $bookerFirstName    = eme_esc_html( $person['firstname'] );
-            $bookerBirthdate    = eme_is_date( $person['birthdate'] ) ? eme_esc_html( $person['birthdate'] ) : '';
-            $bookerBirthplace   = eme_esc_html( $person['birthplace'] );
-            $bookerAddress1     = eme_esc_html( $person['address1'] );
-            $bookerAddress2     = eme_esc_html( $person['address2'] );
-            $bookerCity         = eme_esc_html( $person['city'] );
-            $bookerZip          = eme_esc_html( $person['zip'] );
-            $bookerState_code   = eme_esc_html( $person['state_code'] );
-            $bookerCountry_code = eme_esc_html( $person['country_code'] );
-            $bookerEmail        = eme_esc_html( $person['email'] );
-            $bookerPhone        = eme_esc_html( $person['phone'] );
+            $bookerLastName     = esc_html( $person['lastname'] );
+            $bookerFirstName    = esc_html( $person['firstname'] );
+            $bookerBirthdate    = eme_is_date( $person['birthdate'] ) ? esc_html( $person['birthdate'] ) : '';
+            $bookerBirthplace   = esc_html( $person['birthplace'] );
+            $bookerAddress1     = esc_html( $person['address1'] );
+            $bookerAddress2     = esc_html( $person['address2'] );
+            $bookerCity         = esc_html( $person['city'] );
+            $bookerZip          = esc_html( $person['zip'] );
+            $bookerState_code   = esc_html( $person['state_code'] );
+            $bookerCountry_code = esc_html( $person['country_code'] );
+            $bookerEmail        = esc_html( $person['email'] );
+            $bookerPhone        = esc_html( $person['phone'] );
             $massmail           = intval( $person['massmail'] );
             $bd_email           = intval( $person['bd_email'] );
             $gdpr               = intval( $person['gdpr'] );
         }
-        $bookerComment = eme_esc_html( $booking['booking_comment'] );
-        $bookedSeats   = eme_esc_html( $booking['booking_seats'] );
+        $bookerComment = esc_html( $booking['booking_comment'] );
+        $bookedSeats   = esc_html( $booking['booking_seats'] );
         if ( $booking['booking_seats_mp'] ) {
             $booking_seats_mp = eme_convert_multi2array( $booking['booking_seats_mp'] );
         }
@@ -2795,7 +2795,7 @@ function eme_replace_rsvp_formfields_placeholders( $form_id, $event, $booking, $
         }
 
         if ( $need_escape ) {
-            $replacement = eme_esc_html( preg_replace( '/\n|\r/', '', $replacement ) );
+            $replacement = esc_html( preg_replace( '/\n|\r/', '', $replacement ) );
         }
         if ( $need_urlencode ) {
             $replacement = rawurlencode( $replacement );
@@ -3069,7 +3069,7 @@ function eme_replace_rsvp_formfields_placeholders( $form_id, $event, $booking, $
                 $fieldname         = 'massmail';
                 $replacement       = eme_ui_select_binary( $selected_massmail, $fieldname, 0, $dynamic_field_class_basic . ' eme_snapselect', $disabled );
                 if ( ! $eme_is_admin_request && get_option( 'eme_massmail_popup' ) ) {
-                    $popup   = eme_esc_html( get_option( 'eme_massmail_popup_text' ) );
+                    $popup   = esc_html( get_option( 'eme_massmail_popup_text' ) );
                     $confirm = esc_html__('Yes','events-made-easy');
                     $cancel  = esc_html__('No','events-made-easy');
                     if (!eme_is_empty_string($popup))
@@ -3082,7 +3082,7 @@ function eme_replace_rsvp_formfields_placeholders( $form_id, $event, $booking, $
                 $fieldname         = 'massmail';
                 $replacement       = eme_ui_select_binary( $selected_massmail, $fieldname, 0, $dynamic_field_class_basic . ' eme_snapselect', $disabled );
                 if ( ! $eme_is_admin_request && get_option( 'eme_massmail_popup' ) ) {
-                    $popup   = eme_esc_html( get_option( 'eme_massmail_popup_text' ) );
+                    $popup   = esc_html( get_option( 'eme_massmail_popup_text' ) );
                     $confirm = esc_html__('Yes','events-made-easy');
                     $cancel  = esc_html__('No','events-made-easy');
                     if (!eme_is_empty_string($popup))
@@ -3134,7 +3134,7 @@ function eme_replace_rsvp_formfields_placeholders( $form_id, $event, $booking, $
                         }
                         $replacement = "<input id='subscribe_groups_$group_id' name='subscribe_groups[]' value='$group_id' type='checkbox' class='nodynamicupdates'>";
                         if ( ! empty( $label ) ) {
-                            $replacement .= "<label for='subscribe_groups_$group_id'>" . eme_esc_html( $label ) . '</label>';
+                            $replacement .= "<label for='subscribe_groups_$group_id'>" . esc_html( $label ) . '</label>';
                         }
                     }
                 } else {
@@ -3356,7 +3356,7 @@ function eme_replace_rsvp_formfields_placeholders( $form_id, $event, $booking, $
                     if ( $booking['dgroupid'] ) {
                         $dgroup = eme_get_discountgroup( $booking['dgroupid'] );
                         if ( $dgroup && isset( $dgroup['name'] ) ) {
-                            $replacement .= '<li>' . sprintf( __( 'Discountgroup %s', 'events-made-easy' ), eme_esc_html( $dgroup['name'] ) ) . '</li>';
+                            $replacement .= '<li>' . sprintf( __( 'Discountgroup %s', 'events-made-easy' ), esc_html( $dgroup['name'] ) ) . '</li>';
                         } else {
                             $replacement .= '<li>' . sprintf( __( 'Applied discount group %d no longer exists', 'events-made-easy' ), $booking['dgroupid'] ) . '</li>';
                         }
@@ -3371,7 +3371,7 @@ function eme_replace_rsvp_formfields_placeholders( $form_id, $event, $booking, $
                         foreach ( $applied_discountids as $discount_id ) {
                             $discount = eme_get_discount( $discount_id );
                             if ( $discount && isset( $discount['name'] ) ) {
-                                $replacement .= '<li>' . eme_esc_html( $discount['name'] ) . '</li>';
+                                $replacement .= '<li>' . esc_html( $discount['name'] ) . '</li>';
                             } else {
                                 $replacement .= '<li>' . sprintf( __( 'Applied discount %d no longer exists', 'events-made-easy' ), $discount_id ) . '</li>';
                             }
@@ -3710,18 +3710,18 @@ function eme_replace_membership_formfields_placeholders( $form_id, $membership, 
         }
     }
     if ( ! empty( $person ) ) {
-        $bookerLastName     = eme_esc_html( $person['lastname'] );
-        $bookerFirstName    = eme_esc_html( $person['firstname'] );
-        $bookerBirthdate    = eme_is_date( $person['birthdate'] ) ? eme_esc_html( $person['birthdate'] ) : '';
-        $bookerBirthplace   = eme_esc_html( $person['birthplace'] );
-        $bookerAddress1     = eme_esc_html( $person['address1'] );
-        $bookerAddress2     = eme_esc_html( $person['address2'] );
-        $bookerCity         = eme_esc_html( $person['city'] );
-        $bookerZip          = eme_esc_html( $person['zip'] );
-        $bookerState_code   = eme_esc_html( $person['state_code'] );
-        $bookerCountry_code = eme_esc_html( $person['country_code'] );
-        $bookerEmail        = eme_esc_html( $person['email'] );
-        $bookerPhone        = eme_esc_html( $person['phone'] );
+        $bookerLastName     = esc_html( $person['lastname'] );
+        $bookerFirstName    = esc_html( $person['firstname'] );
+        $bookerBirthdate    = eme_is_date( $person['birthdate'] ) ? esc_html( $person['birthdate'] ) : '';
+        $bookerBirthplace   = esc_html( $person['birthplace'] );
+        $bookerAddress1     = esc_html( $person['address1'] );
+        $bookerAddress2     = esc_html( $person['address2'] );
+        $bookerCity         = esc_html( $person['city'] );
+        $bookerZip          = esc_html( $person['zip'] );
+        $bookerState_code   = esc_html( $person['state_code'] );
+        $bookerCountry_code = esc_html( $person['country_code'] );
+        $bookerEmail        = esc_html( $person['email'] );
+        $bookerPhone        = esc_html( $person['phone'] );
         $massmail           = intval( $person['massmail'] );
         $bd_email           = intval( $person['bd_email'] );
         $gdpr               = intval( $person['gdpr'] );
@@ -4016,7 +4016,7 @@ function eme_replace_membership_formfields_placeholders( $form_id, $membership, 
             $fieldname         = 'massmail';
             $replacement       = eme_ui_select_binary( $selected_massmail, $fieldname, 0, "$dynamic_field_class_basic $personal_info_class eme_snapselect", $disabled );
             if ( ! $eme_is_admin_request && get_option( 'eme_massmail_popup' ) ) {
-                $popup   = eme_esc_html( get_option( 'eme_massmail_popup_text' ) );
+                $popup   = esc_html( get_option( 'eme_massmail_popup_text' ) );
                 $confirm = esc_html__('Yes','events-made-easy');
                 $cancel  = esc_html__('No','events-made-easy');
                 if (!eme_is_empty_string($popup))
@@ -4027,7 +4027,7 @@ function eme_replace_membership_formfields_placeholders( $form_id, $membership, 
             $fieldname         = 'massmail';
             $replacement       = eme_ui_select_binary( $selected_massmail, $fieldname, 0, "$dynamic_field_class_basic $personal_info_class eme_snapselect", $disabled );
             if ( ! $eme_is_admin_request && get_option( 'eme_massmail_popup' ) ) {
-                $popup   = eme_esc_html( get_option( 'eme_massmail_popup_text' ) );
+                $popup   = esc_html( get_option( 'eme_massmail_popup_text' ) );
                 $confirm = esc_html__('Yes','events-made-easy');
                 $cancel  = esc_html__('No','events-made-easy');
                 if (!eme_is_empty_string($popup))
@@ -4073,7 +4073,7 @@ function eme_replace_membership_formfields_placeholders( $form_id, $membership, 
                     }
                     $replacement = "<input id='subscribe_groups_$group_id' name='subscribe_groups[]' value='$group_id' type='checkbox' class='nodynamicupdates $personal_info_class'>";
                     if ( ! empty( $label ) ) {
-                        $replacement .= "<label for='subscribe_groups_$group_id'>" . eme_esc_html( $label ) . '</label>';
+                        $replacement .= "<label for='subscribe_groups_$group_id'>" . esc_html( $label ) . '</label>';
                     }
                 }
             } else {
@@ -4107,7 +4107,7 @@ function eme_replace_membership_formfields_placeholders( $form_id, $membership, 
                     if ( $member['dgroupid'] ) {
                         $dgroup = eme_get_discountgroup( $member['dgroupid'] );
                         if ( $dgroup && isset( $dgroup['name'] ) ) {
-                            $replacement .= '<li>' . sprintf( __( 'Discountgroup %s', 'events-made-easy' ), eme_esc_html( $dgroup['name'] ) ) . '</li>';
+                            $replacement .= '<li>' . sprintf( __( 'Discountgroup %s', 'events-made-easy' ), esc_html( $dgroup['name'] ) ) . '</li>';
                         } else {
                             $replacement .= '<li>' . sprintf( __( 'Applied discount group %d no longer exists', 'events-made-easy' ), $member['dgroupid'] ) . '</li>';
                         }
@@ -4124,7 +4124,7 @@ function eme_replace_membership_formfields_placeholders( $form_id, $membership, 
                         foreach ( $discount_ids as $discount_id ) {
                             $discount = eme_get_discount( $discount_id );
                             if ( $discount && isset( $discount['name'] ) ) {
-                                $replacement .= '<li>' . eme_esc_html( $discount['name'] ) . '</li>';
+                                $replacement .= '<li>' . esc_html( $discount['name'] ) . '</li>';
                             } else {
                                 $replacement .= '<li>' . sprintf( __( 'Applied discount %d no longer exists', 'events-made-easy' ), $discount_id ) . '</li>';
                             }
@@ -4302,7 +4302,7 @@ function eme_replace_subscribeform_placeholders( $format, $unsubscribe = 0 ) {
         $bookerEmail     = $person['email'];
         $gdpr            = intval( $person['gdpr'] );
     } elseif ( isset( $_GET['eme_email'] ) ) {
-        $bookerEmail = eme_esc_html( eme_sanitize_email( $_GET['eme_email'] ) );
+        $bookerEmail = esc_html( eme_sanitize_email( $_GET['eme_email'] ) );
     }
 
     // We need at least #_EMAIL
@@ -4397,7 +4397,7 @@ function eme_replace_subscribeform_placeholders( $format, $unsubscribe = 0 ) {
                     $subscribable_groups['-1'] = esc_html__( 'Newsletter concerning new events', 'events-made-easy' );
                 }
                 foreach ( $tmp_groups as $group ) {
-                    $subscribable_groups[ $group['group_id'] ] = eme_esc_html( $group['name'] );
+                    $subscribable_groups[ $group['group_id'] ] = esc_html( $group['name'] );
                 }
 
                 if ( ! empty( $subscribable_groups ) ) {
@@ -4483,18 +4483,18 @@ function eme_replace_cpiform_placeholders( $format, $person ) {
         $format = eme_add_captcha_submit( $format, $selected_captcha );
     }
 
-    $bookerLastName     = eme_esc_html( $person['lastname'] );
-    $bookerFirstName    = eme_esc_html( $person['firstname'] );
-    $bookerBirthdate    = eme_is_date( $person['birthdate'] ) ? eme_esc_html( $person['birthdate'] ) : '';
-    $bookerBirthplace   = eme_esc_html( $person['birthplace'] );
-    $bookerAddress1     = eme_esc_html( $person['address1'] );
-    $bookerAddress2     = eme_esc_html( $person['address2'] );
-    $bookerCity         = eme_esc_html( $person['city'] );
-    $bookerZip          = eme_esc_html( $person['zip'] );
-    $bookerState_code   = eme_esc_html( $person['state_code'] );
-    $bookerCountry_code = eme_esc_html( $person['country_code'] );
-    $bookerEmail        = eme_esc_html( $person['email'] );
-    $bookerPhone        = eme_esc_html( $person['phone'] );
+    $bookerLastName     = esc_html( $person['lastname'] );
+    $bookerFirstName    = esc_html( $person['firstname'] );
+    $bookerBirthdate    = eme_is_date( $person['birthdate'] ) ? esc_html( $person['birthdate'] ) : '';
+    $bookerBirthplace   = esc_html( $person['birthplace'] );
+    $bookerAddress1     = esc_html( $person['address1'] );
+    $bookerAddress2     = esc_html( $person['address2'] );
+    $bookerCity         = esc_html( $person['city'] );
+    $bookerZip          = esc_html( $person['zip'] );
+    $bookerState_code   = esc_html( $person['state_code'] );
+    $bookerCountry_code = esc_html( $person['country_code'] );
+    $bookerEmail        = esc_html( $person['email'] );
+    $bookerPhone        = esc_html( $person['phone'] );
     $massmail           = intval( $person['massmail'] );
     $bd_email           = intval( $person['bd_email'] );
 
@@ -4668,7 +4668,7 @@ function eme_replace_cpiform_placeholders( $format, $person ) {
         } elseif ( preg_match( '/#_MASSMAIL$/', $result ) ) {
             $replacement = eme_ui_select_binary( $massmail, 'massmail', 0, 'eme_snapselect' );
             if ( get_option( 'eme_massmail_popup' ) ) {
-                $popup       = eme_esc_html( get_option( 'eme_massmail_popup_text' ) );
+                $popup       = esc_html( get_option( 'eme_massmail_popup_text' ) );
                 $confirm = esc_html__('Yes','events-made-easy');
                 $cancel = esc_html__('No','events-made-easy');
                 if (!eme_is_empty_string($popup))
@@ -4678,7 +4678,7 @@ function eme_replace_cpiform_placeholders( $format, $person ) {
             $selected_massmail = ( isset( $massmail ) ) ? $massmail : 1;
             $replacement       = eme_ui_select_binary( $selected_massmail, 'massmail', 0, 'eme_snapselect' );
             if ( get_option( 'eme_massmail_popup' ) ) {
-                $popup   = eme_esc_html( get_option( 'eme_massmail_popup_text' ) );
+                $popup   = esc_html( get_option( 'eme_massmail_popup_text' ) );
                 $confirm = esc_html__('Yes','events-made-easy');
                 $cancel  = esc_html__('No','events-made-easy');
                 if (!eme_is_empty_string($popup))
@@ -4688,7 +4688,7 @@ function eme_replace_cpiform_placeholders( $format, $person ) {
             $selected_massmail = ( isset( $massmail ) ) ? $massmail : 0;
             $replacement       = eme_ui_select_binary( $selected_massmail, 'massmail', 0, 'eme_snapselect' );
             if ( get_option( 'eme_massmail_popup' ) ) {
-                $popup   = eme_esc_html( get_option( 'eme_massmail_popup_text' ) );
+                $popup   = esc_html( get_option( 'eme_massmail_popup_text' ) );
                 $confirm = esc_html__('Yes','events-made-easy');
                 $cancel  = esc_html__('No','events-made-easy');
                 if (!eme_is_empty_string($popup))
@@ -4856,7 +4856,7 @@ function eme_answer2readable( $answer, $formfield=[], $convert_val = 1, $sep = '
                 foreach ( $values as $key => $val ) {
                     if ( $val === $ans ) {
                         if ( $target == 'html' ) {
-                            $my_arr[] = eme_esc_html( $tags[ $key ] );
+                            $my_arr[] = esc_html( $tags[ $key ] );
                         } else {
                             $my_arr[] = $tags[ $key ];
                         }
@@ -4867,7 +4867,7 @@ function eme_answer2readable( $answer, $formfield=[], $convert_val = 1, $sep = '
         } else {
             $answers = eme_convert_multi2array( $answer );
             if ( $target == 'html' ) {
-                $answers = eme_esc_html( $answers );
+                $answers = array_map( 'esc_html', $answers );
             }
             return eme_convert_array2multi( $answers, $sep );
         }

--- a/eme-functions.php
+++ b/eme-functions.php
@@ -699,7 +699,7 @@ function eme_for_shortcode( $atts, $content ) {
         $array_values = explode( $atts['sep'], $list );
         foreach ( $array_values as $val ) {
             $url_val     = rawurlencode( $val );
-            $esc_val     = eme_sanitize_request( eme_esc_html( preg_replace( '/\n|\r/', '', $val ) ) );
+            $esc_val     = eme_sanitize_request( esc_html( preg_replace( '/\n|\r/', '', $val ) ) );
             $replace     = [ $esc_val, $url_val, $loopcounter ];
             $tmp_content = str_replace( $search, $replace, $content );
             $result     .= do_shortcode( $tmp_content );
@@ -757,7 +757,7 @@ function eme_get_events_page( $justurl = 1, $text = '' ) {
     if ( $justurl || empty( $text ) ) {
         $result = esc_url( $page_link );
     } else {
-        $text   = eme_esc_html( $text );
+        $text   = esc_html( $text );
         $result = "<a href='" . esc_url( $page_link ) . "' title='$text'>$text</a>";
     }
     return $result;
@@ -845,7 +845,7 @@ function eme_ascii_encode( $e, $target = 'html' ) {
 }
 function eme_email_obfuscate( $e, $target = 'html' ) {
     if ( $target == 'htmlmail' ) {
-        return eme_esc_html( $e );
+        return esc_html( $e );
     } elseif ( $target == 'text' ) {
         return $e;
     } else {
@@ -2311,9 +2311,9 @@ function eme_dyndata_people_ajax() {
         $fields = eme_get_dyndata_people_fields( 'group:' . $group_id );
         if ( ! empty( $fields ) ) {
             if ( ! $group_id ) {
-                $form_html .= "<hr><div><span id='eme-people-dyndata-group-" . $group_id . "'>" . eme_esc_html( __( 'Extra info', 'events-made-easy' ) ) . '</span><table>';
+                $form_html .= "<hr><div><span id='eme-people-dyndata-group-" . $group_id . "'>" . esc_html( __( 'Extra info', 'events-made-easy' ) ) . '</span><table>';
             } else {
-                $form_html .= "<hr><div><span id='eme-people-dyndata-group-" . $group_id . "'>" . eme_esc_html( __( 'Group', 'events-made-easy' ) . ' ' . $group['name'] ) . '</span><table>';
+                $form_html .= "<hr><div><span id='eme-people-dyndata-group-" . $group_id . "'>" . esc_html( __( 'Group', 'events-made-easy' ) . ' ' . $group['name'] ) . '</span><table>';
             }
             foreach ( $fields as $formfield ) {
                 $field_id       = $formfield['field_id'];
@@ -2424,7 +2424,7 @@ function eme_dyndata_rsvp_ajax() {
 
                 if ( $condition['field'] == '#_GROUPS' ) {
                     $wp_id       = eme_get_wpid_by_post();
-                    $entered_val = join( ',', eme_esc_html( eme_get_persongroup_names( 0, $wp_id ) ) );
+                    $entered_val = join( ',', array_map( 'esc_html', eme_get_persongroup_names( 0, $wp_id ) ) );
                 } else {
                     // indicate "1" to make sure the answers are taken from the POST, and not from the existing member
                     $entered_val = eme_replace_booking_placeholders( $condition['field'], $event, $fake_booking, 0, 'html', '', 1 );
@@ -3231,7 +3231,7 @@ function eme_upload_files( $id, $type = 'bookings' ) {
         }
     }
     if ( ! empty( $errors ) ) {
-        return '<p>' . __( 'Errors encountered while uploading files', 'events-made-easy' ) . '<br>' . join( '<br>', eme_esc_html( $errors ) ) . '</p>';
+        return '<p>' . __( 'Errors encountered while uploading files', 'events-made-easy' ) . '<br>' . join( '<br>', array_map( 'esc_html', $errors ) ) . '</p>';
     } else {
         return '';
     }
@@ -3498,7 +3498,7 @@ function eme_ajax_record_edit( $tablename, $cap, $id_column, $record, $record_fu
                 } else {
                     $record[ $id_column ] = $record_id;
                 }
-                $fTableResult['Record'] = eme_esc_html( $record );
+                $fTableResult['Record'] = array_map( 'esc_html', $record );
             }
         }
     } else {

--- a/eme-gdpr.php
+++ b/eme-gdpr.php
@@ -97,7 +97,7 @@ function eme_rpi_ajax() {
 function eme_rpi_shortcode( $atts ) {
 	eme_enqueue_frontend();
 	if ( isset( $_GET['eme_email'] ) ) {
-		$email = eme_esc_html( eme_sanitize_email( $_GET['eme_email'] ) );
+		$email = esc_html( eme_sanitize_email( $_GET['eme_email'] ) );
 	} else {
 		$email = '';
 	}
@@ -186,7 +186,7 @@ function eme_gdpr_approve_ajax() {
 function eme_gdpr_approve_shortcode() {
 	eme_enqueue_frontend();
 	if ( isset( $_GET['eme_email'] ) ) {
-		$email = eme_esc_html( eme_sanitize_email( $_GET['eme_email'] ) );
+		$email = esc_html( eme_sanitize_email( $_GET['eme_email'] ) );
 	} else {
 		$email = '';
 	}
@@ -257,7 +257,7 @@ function eme_cpi_request_ajax() {
 				$first_person_name = $person_name;
 			}
 			if ( $mail_text_html == 'htmlmail' ) {
-				$change_info .= "<tr><td style='border: 1px solid black;padding: 5px;'>" . eme_esc_html( $person['firstname'] ) . "</td><td style='border: 1px solid black;padding: 5px;'>" . eme_esc_html( $person['lastname'] ) . "</td><td style='border: 1px solid black;padding: 5px;'><a href='" . esc_url( $change_link ) . "'>" . esc_html__( 'Click here to change the info for this person', 'events-made-easy' ) . '</a></td></tr>';
+				$change_info .= "<tr><td style='border: 1px solid black;padding: 5px;'>" . esc_html( $person['firstname'] ) . "</td><td style='border: 1px solid black;padding: 5px;'>" . esc_html( $person['lastname'] ) . "</td><td style='border: 1px solid black;padding: 5px;'><a href='" . esc_url( $change_link ) . "'>" . esc_html__( 'Click here to change the info for this person', 'events-made-easy' ) . '</a></td></tr>';
 			} else {
 				$change_info .= "$person_name: $change_link " . __( '(copy/paste this link in your browser to change the info for this person)', 'events-made-easy' );
 			}
@@ -285,7 +285,7 @@ function eme_cpi_request_ajax() {
 function eme_cpi_shortcode( $atts ) {
 	eme_enqueue_frontend();
 	if ( isset( $_GET['eme_email'] ) ) {
-		$email = eme_esc_html( eme_sanitize_email( $_GET['eme_email'] ) );
+		$email = esc_html( eme_sanitize_email( $_GET['eme_email'] ) );
 	} else {
 		$email = '';
 	}
@@ -423,23 +423,23 @@ function eme_show_personal_info( $email ) {
 			$gdpr     = $person['gdpr'] ? __( 'Yes', 'events-made-easy' ) : __( 'No', 'events-made-easy' );
 			$output  .= '<table>';
 			$output  .= '<tr><td>' . __( 'ID', 'events-made-easy' ) . '</td><td>' . intval( $person['person_id'] ) . '</td></tr>';
-			$output  .= '<tr><td>' . __( 'Last name', 'events-made-easy' ) . '</td><td>' . eme_esc_html( $person['lastname'] ) . '</td></tr>';
-			$output  .= '<tr><td>' . __( 'First name', 'events-made-easy' ) . '</td><td>' . eme_esc_html( $person['firstname'] ) . '</td></tr>';
-			$output  .= '<tr><td>' . __( 'Email', 'events-made-easy' ) . '</td><td>' . eme_esc_html( $person['email'] ) . '</td></tr>';
-			$output  .= '<tr><td>' . $eme_address1_string . '</td><td>' . eme_esc_html( $person['address1'] ) . '</td></tr>';
-			$output  .= '<tr><td>' . $eme_address2_string . '</td><td>' . eme_esc_html( $person['address2'] ) . '</td></tr>';
-			$output  .= '<tr><td>' . __( 'City', 'events-made-easy' ) . '</td><td>' . eme_esc_html( $person['city'] ) . '</td></tr>';
-			$output  .= '<tr><td>' . __( 'Postal code', 'events-made-easy' ) . '</td><td>' . eme_esc_html( $person['zip'] ) . '</td></tr>';
-			$output  .= '<tr><td>' . __( 'State', 'events-made-easy' ) . '</td><td>' . eme_esc_html( eme_get_state_name( $person['state_code'], $person['country_code'], $person['lang'] ) ) . '</td></tr>';
-			$output  .= '<tr><td>' . __( 'Country', 'events-made-easy' ) . '</td><td>' . eme_esc_html( eme_get_country_name( $person['country_code'], $person['lang'] ) ) . '</td></tr>';
-			$output  .= '<tr><td>' . __( 'Phone number', 'events-made-easy' ) . '</td><td>' . eme_esc_html( $person['phone'] ) . '</td></tr>';
+			$output  .= '<tr><td>' . __( 'Last name', 'events-made-easy' ) . '</td><td>' . esc_html( $person['lastname'] ) . '</td></tr>';
+			$output  .= '<tr><td>' . __( 'First name', 'events-made-easy' ) . '</td><td>' . esc_html( $person['firstname'] ) . '</td></tr>';
+			$output  .= '<tr><td>' . __( 'Email', 'events-made-easy' ) . '</td><td>' . esc_html( $person['email'] ) . '</td></tr>';
+			$output  .= '<tr><td>' . $eme_address1_string . '</td><td>' . esc_html( $person['address1'] ) . '</td></tr>';
+			$output  .= '<tr><td>' . $eme_address2_string . '</td><td>' . esc_html( $person['address2'] ) . '</td></tr>';
+			$output  .= '<tr><td>' . __( 'City', 'events-made-easy' ) . '</td><td>' . esc_html( $person['city'] ) . '</td></tr>';
+			$output  .= '<tr><td>' . __( 'Postal code', 'events-made-easy' ) . '</td><td>' . esc_html( $person['zip'] ) . '</td></tr>';
+			$output  .= '<tr><td>' . __( 'State', 'events-made-easy' ) . '</td><td>' . esc_html( eme_get_state_name( $person['state_code'], $person['country_code'], $person['lang'] ) ) . '</td></tr>';
+			$output  .= '<tr><td>' . __( 'Country', 'events-made-easy' ) . '</td><td>' . esc_html( eme_get_country_name( $person['country_code'], $person['lang'] ) ) . '</td></tr>';
+			$output  .= '<tr><td>' . __( 'Phone number', 'events-made-easy' ) . '</td><td>' . esc_html( $person['phone'] ) . '</td></tr>';
 			$output  .= '<tr><td>' . __( 'MassMail', 'events-made-easy' ) . '</td><td>' . $massmail . '</td></tr>';
 			$output  .= '<tr><td>' . __( 'GDPR approval', 'events-made-easy' ) . '</td><td>' . $gdpr . '</td></tr>';
 			if ( ! empty( $person['properties']['image_id'] ) ) {
 				$img = wp_get_attachment_image( $person['properties']['image_id'], 'full', 0, [ 'class' => 'eme_person_image' ] );
 				$output             .= '<tr><td>' . __( 'Image', 'events-made-easy' ) . '</td><td>' . $img . '</td></tr>';
 			}
-			$output .= '<tr><td>' . __( 'Member of group(s)', 'events-made-easy' ) . '</td><td>' . eme_esc_html( $groups ) . '</td></tr>';
+			$output .= '<tr><td>' . __( 'Member of group(s)', 'events-made-easy' ) . '</td><td>' . esc_html( $groups ) . '</td></tr>';
 			foreach ( $answers as $answer ) {
 				$formfield = eme_get_formfield( $answer['field_id'] );
 				if ( ! empty( $formfield ) ) {
@@ -452,7 +452,7 @@ function eme_show_personal_info( $email ) {
 			$files = eme_get_uploaded_files( $person_id, 'people' );
 			if ( ! empty( $files ) ) {
 				foreach ( $files as $file ) {
-					$output .= '<tr><td>' . esc_html( eme_translate( $file['field_name'] ) ) . '</td><td>' . "<a href='" . $file['url'] . "'>" . eme_esc_html( $file['name'] ) . '</a></td></tr>';
+					$output .= '<tr><td>' . esc_html( eme_translate( $file['field_name'] ) ) . '</td><td>' . "<a href='" . $file['url'] . "'>" . esc_html( $file['name'] ) . '</a></td></tr>';
 				}
 			}
 			$output .= '</table>';
@@ -463,7 +463,7 @@ function eme_show_personal_info( $email ) {
 					$end_date           = eme_localized_date( $member['end_date'] );
 					$output            .= '<table>';
 					$output            .= '<tr><td>' . __( 'ID', 'events-made-easy' ) . '</td><td>' . intval( $member['member_id'] ) . '</td></tr>';
-					$output            .= '<tr><td>' . __( 'Membership', 'events-made-easy' ) . '</td><td>' . eme_esc_html( $member['membership_name'] ) . '</td></tr>';
+					$output            .= '<tr><td>' . __( 'Membership', 'events-made-easy' ) . '</td><td>' . esc_html( $member['membership_name'] ) . '</td></tr>';
 					$output            .= '<tr><td>' . __( 'Start', 'events-made-easy' ) . '</td><td>' . $start_date . '</td></tr>';
 					$output            .= '<tr><td>' . __( 'End', 'events-made-easy' ) . '</td><td>' . $end_date . '</td></tr>';
 					$related_member_ids = eme_get_family_member_ids( $member['member_id'] );
@@ -473,7 +473,7 @@ function eme_show_personal_info( $email ) {
 							if ( $related_member ) {
 								$related_person = eme_get_person( $related_member['person_id'] );
 								if ( $related_person ) {
-									$output .= '<tr><td>' . __( 'Main family account for', 'events-made-easy' ) . '</td><td>' . eme_esc_html( eme_format_full_name( $related_person['firstname'], $related_person['lastname'], $related_person['email'] ) ) . ' (' . eme_esc_html( $related_person['email'] ) . ')</td></tr>';
+									$output .= '<tr><td>' . __( 'Main family account for', 'events-made-easy' ) . '</td><td>' . esc_html( eme_format_full_name( $related_person['firstname'], $related_person['lastname'], $related_person['email'] ) ) . ' (' . esc_html( $related_person['email'] ) . ')</td></tr>';
 								}
 							}
 						}
@@ -491,7 +491,7 @@ function eme_show_personal_info( $email ) {
 					$files = eme_get_uploaded_files( $member['member_id'], 'members' );
 					if ( ! empty( $files ) ) {
 						foreach ( $files as $file ) {
-							$output .= '<tr><td>' . esc_html( eme_translate( $file['field_name'] ) ) . '</td><td>' . "<a href='" . $file['url'] . "'>" . eme_esc_html( $file['name'] ) . '</a></td></tr>';
+							$output .= '<tr><td>' . esc_html( eme_translate( $file['field_name'] ) ) . '</td><td>' . "<a href='" . $file['url'] . "'>" . esc_html( $file['name'] ) . '</a></td></tr>';
 						}
 					}
 					$output .= '</table>';
@@ -523,7 +523,7 @@ function eme_gdpr_add_suggested_privacy_content() {
 
 function eme_gdpr_register_exporters( $exporters ) {
 	$exporters[] = [
-		'exporter_friendly_name' => __( 'Events Made Easy' ),
+		'exporter_friendly_name' => __( 'Events Made Easy', 'events-made-easy' ),
 		'callback'               => 'eme_gdpr_user_data_exporter',
 	];
 	return $exporters;
@@ -609,7 +609,7 @@ function eme_gdpr_user_data_exporter( $email, $page = 1 ) {
 			}
 			// Add this group of items to the exporters data array.
 			$group_id       = 'eme-personal-data';
-			$group_label    = __( 'Events Made Easy Personal Data', 'event-made-easy' );
+			$group_label    = __( 'Events Made Easy Personal Data', 'events-made-easy' );
 			$export_items[] = [
 				'group_id'    => $group_id,
 				'group_label' => $group_label,
@@ -621,7 +621,7 @@ function eme_gdpr_user_data_exporter( $email, $page = 1 ) {
 			$files = eme_get_uploaded_files( $person_id, 'people' );
 			if ( ! empty( $files ) ) {
 				$group_id    = 'eme-personal-data-media';
-				$group_label = __( 'Events Made Easy Uploaded files linked to the person', 'event-made-easy' );
+				$group_label = __( 'Events Made Easy Uploaded files linked to the person', 'events-made-easy' );
 				$data        = [];
 				foreach ( $files as $file ) {
 					$data[] = [
@@ -684,7 +684,7 @@ function eme_gdpr_user_data_exporter( $email, $page = 1 ) {
 						}
 					}
 					$group_id       = 'eme-member-data';
-					$group_label    = __( 'Events Made Easy Member Data', 'event-made-easy' );
+					$group_label    = __( 'Events Made Easy Member Data', 'events-made-easy' );
 					$export_items[] = [
 						'group_id'    => $group_id,
 						'group_label' => $group_label,
@@ -695,7 +695,7 @@ function eme_gdpr_user_data_exporter( $email, $page = 1 ) {
 					$files = eme_get_uploaded_files( $member['member_id'], 'members' );
 					if ( ! empty( $files ) ) {
 						$group_id    = 'eme-member-data-media';
-						$group_label = __( 'Events Made Easy Uploaded files linked to the member', 'event-made-easy' );
+						$group_label = __( 'Events Made Easy Uploaded files linked to the member', 'events-made-easy' );
 						$data        = [];
 						foreach ( $files as $file ) {
 							$data[] = [
@@ -724,7 +724,7 @@ function eme_gdpr_user_data_exporter( $email, $page = 1 ) {
 
 function eme_gdpr_register_erasers( $erasers = [] ) {
 	$erasers[] = [
-		'eraser_friendly_name' => __( 'Events Made Easy' ),
+		'eraser_friendly_name' => __( 'Events Made Easy', 'events-made-easy' ),
 		'callback'             => 'eme_gdpr_user_data_eraser',
 	];
 	return $erasers;

--- a/eme-holidays.php
+++ b/eme-holidays.php
@@ -135,12 +135,12 @@ function eme_holidays_edit_layout() {
       <table class='form-table'>
             <tr class='form-field'>
                <th scope='row' style='vertical-align:top'><label for='name'>" . __( 'Holidays listname', 'events-made-easy' ) . "</label></th>
-               <td><input name='name' id='name' required='required' type='text' value='" . eme_esc_html( $holidays['name'] ) . "' size='40'><br>
+               <td><input name='name' id='name' required='required' type='text' value='" . esc_html( $holidays['name'] ) . "' size='40'><br>
                  " . __( 'The name of the holidays list', 'events-made-easy' ) . "</td>
             </tr>
             <tr class='form-field'>
                <th scope='row' style='vertical-align:top'><label for='description'>" . __( 'Holidays list', 'events-made-easy' ) . "</label></th>
-               <td><textarea name='list' id='description' rows='5' >" . eme_esc_html( $holidays['list'] ) . '</textarea><br>
+               <td><textarea name='list' id='description' rows='5' >" . esc_html( $holidays['list'] ) . '</textarea><br>
                  ' . __( 'Basic format: YYYY-MM-DD, one per line', 'events-made-easy' ) . '<br>' . esc_html__( 'For more information about holidays, see ', 'events-made-easy' ) . " <a target='_blank' href='https://www.e-dynamics.be/wordpress/?cat=6086'>" . esc_html__( 'the documentation', 'events-made-easy' ) . "</a></td>
             </tr>
          </table>

--- a/eme-locations.php
+++ b/eme-locations.php
@@ -307,7 +307,7 @@ function eme_import_csv_locations() {
                         ++$updated;
                     } else {
                         ++$errors;
-                        $error_msg .= '<br>' . eme_esc_html( sprintf( __( 'Not imported (problem updating the location in the db): %s', 'events-made-easy' ), implode( ',', $row ) ) );
+                        $error_msg .= '<br>' . esc_html( sprintf( __( 'Not imported (problem updating the location in the db): %s', 'events-made-easy' ), implode( ',', $row ) ) );
                     }
                 } else {
                     $location_id = eme_insert_location( $line );
@@ -315,7 +315,7 @@ function eme_import_csv_locations() {
                         ++$inserted;
                     } else {
                         ++$errors;
-                        $error_msg .= '<br>' . eme_esc_html( sprintf( __( 'Not imported (problem inserting the location in the db): %s', 'events-made-easy' ), implode( ',', $row ) ) );
+                        $error_msg .= '<br>' . esc_html( sprintf( __( 'Not imported (problem inserting the location in the db): %s', 'events-made-easy' ), implode( ',', $row ) ) );
                     }
                 }
                 if ( $location_id ) {
@@ -337,7 +337,7 @@ function eme_import_csv_locations() {
                 }
             } else {
                 ++$errors;
-                $error_msg .= '<br>' . eme_esc_html( sprintf( __( 'Not imported (not all required fields are present): %s', 'events-made-easy' ), implode( ',', $row ) ) );
+                $error_msg .= '<br>' . esc_html( sprintf( __( 'Not imported (not all required fields are present): %s', 'events-made-easy' ), implode( ',', $row ) ) );
             }
         }
         $result = sprintf( __( 'Import finished: %d inserts, %d updates, %d errors', 'events-made-easy' ), $inserted, $updated, $errors );
@@ -872,7 +872,7 @@ function eme_locations_table( $message = '' ) {
     if ( ! empty( $formfields_searchable ) ) {
         echo '<input type="search" name="search_customfields" id="search_customfields" placeholder="' . esc_attr__( 'Custom field value to search', 'events-made-easy' ) . '" size=20>';
         $label = __( 'Custom fields to filter on', 'events-made-easy' );
-        $extra_attributes = 'aria-label="' . eme_esc_html( $label ) . '" data-placeholder="' . eme_esc_html( $label ) . '"';
+        $extra_attributes = 'aria-label="' . esc_html( $label ) . '" data-placeholder="' . esc_html( $label ) . '"';
         echo eme_ui_multiselect_key_value( '', 'search_customfieldids', $formfields_searchable, 'field_id', 'field_name', 5, '', 0, 'eme_snapselect', $extra_attributes, 1 ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_multiselect_key_value()
     }
 ?>
@@ -1937,7 +1937,7 @@ function eme_replace_locations_placeholders( $format, $location = '', $target = 
             }
 
             if ( $need_escape ) {
-                $replacement = eme_esc_html( preg_replace( '/\n|\r/', '', $replacement ) );
+                $replacement = esc_html( preg_replace( '/\n|\r/', '', $replacement ) );
             }
             if ( $need_urlencode ) {
                 $replacement = rawurlencode( $replacement );
@@ -2524,7 +2524,7 @@ function eme_replace_locations_placeholders( $format, $location = '', $target = 
                     $replacement = "";
                 }
                 if ( $need_escape ) {
-                    $replacement = eme_esc_html( preg_replace( '/\n|\r/', '', $replacement ) );
+                    $replacement = esc_html( preg_replace( '/\n|\r/', '', $replacement ) );
                 }
                 if ( $need_urlencode ) {
                     $replacement = rawurlencode( $replacement );
@@ -2651,7 +2651,7 @@ function eme_replace_locationnotes_placeholders( $format, $location, $target = '
                     $replacement = "";
                 }
                 if ( $need_escape ) {
-                    $replacement = eme_esc_html( preg_replace( '/\n|\r/', '', $replacement ) );
+                    $replacement = esc_html( preg_replace( '/\n|\r/', '', $replacement ) );
                 }
                 $format         = substr_replace( $format, $replacement, $orig_result_needle, $orig_result_length );
                 $needle_offset += $orig_result_length - strlen( $replacement );
@@ -2714,7 +2714,7 @@ function eme_global_map_json( $locations, $marker_clustering, $letter_icons ) {
                 $value                 = eme_nl2br( $value );
                 $json_location[ $key ] = esc_html( eme_translate( $value ) );
             }
-            $json_location['map_icon'] = eme_esc_html( $location['location_properties']['map_icon'] );
+            $json_location['map_icon'] = esc_html( $location['location_properties']['map_icon'] );
         }
         $json_locations[] = $json_location;
     }
@@ -2798,7 +2798,7 @@ function eme_single_location_map( $location, $width = 0, $height = 0, $zoom_fact
         $data    = "data-lat='" . $location['location_latitude'] . "'";
         $data   .= " data-lon='" . $location['location_longitude'] . "'";
         $data   .= " data-map_icon='" . $location['location_properties']['map_icon'] . "'";
-        $data   .= " data-map_text='" . eme_esc_html( $map_text ) . "'";
+        $data   .= " data-map_text='" . esc_html( $map_text ) . "'";
         $data   .= " data-enable_zooming='$enable_zooming'";
         $data   .= " data-gestures='$gestures'";
         $data   .= " data-default_map_icon='$map_icon'";

--- a/eme-mailer.php
+++ b/eme-mailer.php
@@ -1569,7 +1569,7 @@ function eme_mailingreport_list() {
         $record['receiveremail'] = $item['receiveremail'];
         $record['receivername']  = $item['receivername'];
         $record['status']        = $states[ $item['status'] ];
-        $record['error_msg']     = eme_esc_html( $item['error_msg'] );
+        $record['error_msg']     = esc_html( $item['error_msg'] );
 
         if ( $item['status'] != EME_MAIL_STATUS_PLANNED && $item['status'] != EME_MAIL_STATUS_DELAYED ) {
             $record['read_count']    = $item['read_count'];
@@ -1692,19 +1692,19 @@ function eme_ajax_mailings_list() {
 
         $record = [];
         $record['id'] = $id;
-        $record['name'] = eme_esc_html( $mailing['name'] );
-        $record['subject'] = eme_esc_html( $mailing['subject'] );
+        $record['name'] = esc_html( $mailing['name'] );
+        $record['subject'] = esc_html( $mailing['subject'] );
         $record['planned_on'] = eme_localized_datetime( $mailing['planned_on'] );
         $record['creation_date'] = eme_localized_datetime( $mailing['creation_date'] );
-        $record['status'] = eme_esc_html( $status );
+        $record['status'] = esc_html( $status );
         $record['read_count'] = intval( $mailing['read_count'] );
         $record['total_read_count'] = intval( $mailing['total_read_count'] );
         if ( $mailing['status'] == 'planned' ) {
-            $planned_estimation_title = eme_esc_html( sprintf(__('The number of emails to be sent was estimated the moment the mailing was created (%s). This will be re-evaluated at send time.','events-made-easy'), $record['creation_date']) ) ;
-            $record['extra_info'] = eme_esc_html( $extra ) . "&nbsp;<img style='vertical-align: middle;' src='" . esc_url(EME_PLUGIN_URL) . "images/warning.png' alt='warning' title='$planned_estimation_title'>";
+            $planned_estimation_title = esc_html( sprintf(__('The number of emails to be sent was estimated the moment the mailing was created (%s). This will be re-evaluated at send time.','events-made-easy'), $record['creation_date']) ) ;
+            $record['extra_info'] = esc_html( $extra ) . "&nbsp;<img style='vertical-align: middle;' src='" . esc_url(EME_PLUGIN_URL) . "images/warning.png' alt='warning' title='$planned_estimation_title'>";
             $record['report'] = '';
         } else {
-            $record['extra_info'] = eme_esc_html( $extra );
+            $record['extra_info'] = esc_html( $extra );
             $record['report'] = "<a title='".esc_attr__( 'Show mailing report', 'events-made-easy' )."' href='" . esc_url( wp_nonce_url( admin_url( 'admin.php?page=eme-emails&eme_admin_action=report_mailing&id=' . $id ), 'eme_admin', 'eme_admin_nonce' ) ) . "'>" . esc_html__( 'Report', 'events-made-easy' ) . '</a>';
         }
         $record['action'] = $action;
@@ -1800,12 +1800,12 @@ function eme_ajax_archivedmailings_list() {
 
         $record = [];
         $record['id'] = $id;
-        $record['name'] = eme_esc_html( $mailing['name'] );
-        $record['subject'] = eme_esc_html( $mailing['subject'] );
+        $record['name'] = esc_html( $mailing['name'] );
+        $record['subject'] = esc_html( $mailing['subject'] );
         $record['planned_on'] = eme_localized_datetime( $mailing['planned_on'] );
         $record['read_count'] = intval( $mailing['read_count'] );
         $record['total_read_count'] = intval( $mailing['total_read_count'] );
-        $record['extra_info'] = eme_esc_html( $extra );
+        $record['extra_info'] = esc_html( $extra );
         $record['action'] = $action;
         $records[] = $record;
     }
@@ -1899,11 +1899,11 @@ function eme_ajax_mails_list() {
         $record  = [];
         $record['id'] = $row['id'];
         $record['person_id'] = $row['person_id'];
-        $record['fromname'] = eme_esc_html( $row['fromname'] );
-        $record['fromemail'] = eme_esc_html( $row['fromemail'] );
-        $record['receivername'] = eme_esc_html( $row['receivername'] );
-        $record['receiveremail'] = eme_esc_html( $row['receiveremail'] );
-        $record['subject'] = eme_esc_html( $row['subject'] );
+        $record['fromname'] = esc_html( $row['fromname'] );
+        $record['fromemail'] = esc_html( $row['fromemail'] );
+        $record['receivername'] = esc_html( $row['receivername'] );
+        $record['receiveremail'] = esc_html( $row['receiveremail'] );
+        $record['subject'] = esc_html( $row['subject'] );
         $record['status'] = $states[ $row['status'] ];
         $record['creation_date'] = eme_localized_datetime( $row['creation_date'] );
         // if status >0, then the mail is already treated
@@ -1920,7 +1920,7 @@ function eme_ajax_mails_list() {
                 $record['last_read_on'] = eme_localized_datetime( $row['last_read_on'] );
                 $record['read_count'] = $row['read_count'];
             }
-            $record['error_msg'] = eme_esc_html( $row['error_msg'] );
+            $record['error_msg'] = esc_html( $row['error_msg'] );
             $record['action'] = "<a title='".esc_attr__( 'Reuse this mail', 'events-made-easy' )."' href='" . esc_url( wp_nonce_url( admin_url( 'admin.php?page=eme-emails&eme_admin_action=reuse_mail&id=' . $row['id'] ), 'eme_admin', 'eme_admin_nonce' ) ) . "'>" . esc_html__( 'Reuse', 'events-made-easy' ) . '</a>';
         } else {
             //$record['action'] = "";
@@ -2046,10 +2046,10 @@ function eme_send_mails_ajax_actions( $action ) {
         $tmp_message   = 'This is a test message from Events Made Easy.';
         $mail_res_arr  = eme_send_mail( $tmp_subject, $tmp_message, $testmail_to, $person_name, $contact_email, $contact_name );
         $mail_res      = $mail_res_arr[0];
-        $extra_html    = eme_esc_html( $mail_res_arr[1] );
+        $extra_html    = esc_html( $mail_res_arr[1] );
         if ( ! empty( $mail_res_arr[2] ) ) {
             // this contains debug messages
-            $extra_html .= nl2br( eme_esc_html( $mail_res_arr[2] ) );
+            $extra_html .= nl2br( esc_html( $mail_res_arr[2] ) );
         }
         if ( $mail_res ) {
             $ajaxResult['htmlmessage'] = "<div id='message' class='updated eme-message-admin'><p>" . __( 'The mail has been sent.', 'events-made-easy' ) . "</p><p>$extra_html</p></div>";
@@ -2219,12 +2219,12 @@ function eme_send_mails_ajax_actions( $action ) {
             if ( $queue ) {
                 $ajaxResult['htmlmessage'] = "<div id='message' class='updated eme-message-admin'><p>" . __( 'The mailing has been put on the queue, but not all persons will receive it.', 'events-made-easy' ) . '</p></div>';
                 if ( ! empty( $res['not_sent'] ) ) {
-                    $ajaxResult['htmlmessage'] .= "<div id='message' class='error eme-message-admin'><p>" . __( 'The following persons will not receive the mail:', 'events-made-easy' ) . ' ' . eme_esc_html( $res['not_sent'] ) . '</p></div>';
+                    $ajaxResult['htmlmessage'] .= "<div id='message' class='error eme-message-admin'><p>" . __( 'The following persons will not receive the mail:', 'events-made-easy' ) . ' ' . esc_html( $res['not_sent'] ) . '</p></div>';
                 }
             } else {
                 $ajaxResult['htmlmessage'] = "<div id='message' class='error eme-message-admin'><p>" . __( 'There were some problems while sending mail.', 'events-made-easy' ) . '</p></div>';
                 if ( ! empty( $res['not_sent'] ) ) {
-                    $ajaxResult['htmlmessage'] .= "<div id='message' class='error eme-message-admin'><p>" . __( 'Email to the following persons has not been sent:', 'events-made-easy' ) . ' ' . eme_esc_html( $res['not_sent'] ) . '</p></div>';
+                    $ajaxResult['htmlmessage'] .= "<div id='message' class='error eme-message-admin'><p>" . __( 'Email to the following persons has not been sent:', 'events-made-easy' ) . ' ' . esc_html( $res['not_sent'] ) . '</p></div>';
                 }
             }
             $ajaxResult['Result'] = 'ERROR';
@@ -2419,7 +2419,7 @@ function eme_send_mails_ajax_actions( $action ) {
             } else {
                 $ajaxResult['htmlmessage'] = "<div id='message' class='error eme-message-admin'><p>" . __( 'There were some problems while sending mail.', 'events-made-easy' ) . '</p></div>';
                 if ( ! empty( $not_sent ) ) {
-                    $ajaxResult['htmlmessage'] .= "<div class='error eme-message-admin'><p>" . __( 'Email to the following persons has not been sent:', 'events-made-easy' ) . ' ' . join( ', ', eme_esc_html( $not_sent ) ) . '</p></div>';
+                    $ajaxResult['htmlmessage'] .= "<div class='error eme-message-admin'><p>" . __( 'Email to the following persons has not been sent:', 'events-made-easy' ) . ' ' . join( ', ', array_map( 'esc_html', $not_sent ) ) . '</p></div>';
                 }
             }
             $ajaxResult['Result'] = 'ERROR';
@@ -2812,7 +2812,7 @@ function eme_emails_page() {
         <tr id="eme_people_row">
         <td>
 <?php
-    $label      = eme_esc_html( 'Send to a number of people', 'events-made-easy' );
+    $label      = esc_html__( 'Send to a number of people', 'events-made-easy' );
     $aria_label = 'aria-label="' . $label . '"';
     echo $label; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- already escaped at assignment
 ?>
@@ -2822,7 +2822,7 @@ function eme_emails_page() {
         <tr id="eme_groups_row">
         <td class="eme-wsnobreak">
 <?php
-    $label      = eme_esc_html( 'Send to a number of groups', 'events-made-easy' );
+    $label      = esc_html__( 'Send to a number of groups', 'events-made-easy' );
     $extra_attributes = 'aria-label="' . esc_attr( $label ) . '" data-placeholder="' . esc_attr( __( 'Select one or more groups', 'events-made-easy' ) ) . '"';
     echo $label; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- already escaped at assignment
 ?>
@@ -2831,7 +2831,7 @@ function eme_emails_page() {
         </tr>
     <tr id="eme_members_row1"><td class="eme-wsnobreak">
 <?php
-    $label      = eme_esc_html( 'Send to a number of members', 'events-made-easy' );
+    $label      = esc_html__( 'Send to a number of members', 'events-made-easy' );
     $aria_label = 'aria-label="' . $label . '"';
     echo $label; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- already escaped at assignment
 ?>
@@ -2839,7 +2839,7 @@ function eme_emails_page() {
     <td><?php echo eme_ui_multiselect( $member_ids, 'eme_eventmail_send_members', $mymembergroups, 5, '', 0, 'eme_snapselect_members_class', $aria_label ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_multiselect() ?></td></tr>
     <tr id="eme_members_row2"><td class="eme-wsnobreak">
 <?php
-    $label      = eme_esc_html( 'Send to a number of member groups', 'events-made-easy' );
+    $label      = esc_html__( 'Send to a number of member groups', 'events-made-easy' );
     $aria_label = 'aria-label="' . $label . '"';
     $extra_attributes = 'aria-label="' . esc_attr( $label ) . '" data-placeholder="' . esc_attr( __( 'Select one or more groups', 'events-made-easy' ) ) . '"';
     echo $label; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- already escaped at assignment
@@ -2848,7 +2848,7 @@ function eme_emails_page() {
     <td><?php echo eme_ui_multiselect_key_value( $membergroup_ids, 'eme_eventmail_send_membergroups', $membergroups, 'group_id', 'name', 5, '', 0, 'eme_snapselect', $extra_attributes ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_multiselect_key_value() ?></td></tr>
     <tr id="eme_members_row3"><td class="eme-wsnobreak">
 <?php
-    $label      = eme_esc_html( 'Send to active members belonging to', 'events-made-easy' );
+    $label      = esc_html__( 'Send to active members belonging to', 'events-made-easy' );
     $aria_label = 'aria-label="' . $label . '"';
     $extra_attributes = 'aria-label="' . esc_attr( $label ) . '" data-placeholder="' . esc_attr( __( 'Select one or more memberships', 'events-made-easy' ) ) . '"';
     echo $label; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- already escaped at assignment
@@ -2984,7 +2984,7 @@ function eme_emails_page() {
         <div id='div_eme_send_groups'><table class='widefat'>
         <tr><td class="eme-wsnobreak">
 <?php
-        $label      = eme_esc_html( 'Send to a number of people', 'events-made-easy' );
+        $label      = esc_html__( 'Send to a number of people', 'events-made-easy' );
         $aria_label = 'aria-label="' . $label . '"';
         echo $label; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- already escaped at assignment
 ?>
@@ -2992,7 +2992,7 @@ function eme_emails_page() {
                 <td><?php echo eme_ui_multiselect( $person_ids, 'eme_genericmail_send_persons', $mygroups, 5, '', 0, 'eme_snapselect_people_class', $aria_label ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_multiselect() ?></td></tr>
         <tr><td class="eme-wsnobreak">
 <?php
-        $label      = eme_esc_html( 'Send to a number of groups', 'events-made-easy' );
+        $label      = esc_html__( 'Send to a number of groups', 'events-made-easy' );
         $aria_label = 'aria-label="' . $label . '"';
         $extra_attributes = 'aria-label="' . esc_attr( $label ) . '" data-placeholder="' . esc_attr( __( 'Select one or more groups', 'events-made-easy' ) ) . '"';
         echo $label; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- already escaped at assignment
@@ -3001,7 +3001,7 @@ function eme_emails_page() {
         <td><?php echo eme_ui_multiselect_key_value( $persongroup_ids, 'eme_genericmail_send_peoplegroups', $peoplegroups, 'group_id', 'name', 5, '', 0, 'eme_snapselect', $extra_attributes ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_multiselect_key_value() ?></td></tr>
         <tr><td class="eme-wsnobreak">
 <?php
-        $label      = eme_esc_html( 'Send to a number of members', 'events-made-easy' );
+        $label      = esc_html__( 'Send to a number of members', 'events-made-easy' );
         $aria_label = 'aria-label="' . $label . '"';
         echo $label; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- already escaped at assignment
 ?>
@@ -3009,7 +3009,7 @@ function eme_emails_page() {
         <td><?php echo eme_ui_multiselect( $member_ids, 'eme_send_members', $mymembergroups, 5, '', 0, 'eme_snapselect_members_class', $aria_label ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_multiselect() ?></td></tr>
         <tr><td class="eme-wsnobreak">
 <?php
-        $label      = eme_esc_html( 'Send to a number of member groups', 'events-made-easy' );
+        $label      = esc_html__( 'Send to a number of member groups', 'events-made-easy' );
         $aria_label = 'aria-label="' . $label . '"';
         $extra_attributes = 'aria-label="' . esc_attr( $label ) . '" data-placeholder="' . esc_attr( __( 'Select one or more groups', 'events-made-easy' ) ) . '"';
         echo $label; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- already escaped at assignment
@@ -3018,7 +3018,7 @@ function eme_emails_page() {
         <td><?php echo eme_ui_multiselect_key_value( $membergroup_ids, 'eme_genericmail_send_membergroups', $membergroups, 'group_id', 'name', 5, '', 0, 'eme_snapselect', $extra_attributes ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_multiselect_key_value() ?></td></tr>
         <tr><td class="eme-wsnobreak">
 <?php
-        $label      = eme_esc_html( 'Send to active members belonging to', 'events-made-easy' );
+        $label      = esc_html__( 'Send to active members belonging to', 'events-made-easy' );
         $aria_label = 'aria-label="' . $label . '"';
         $extra_attributes = 'aria-label="' . esc_attr( $label ) . '" data-placeholder="' . esc_attr( __( 'Select one or more memberships', 'events-made-easy' ) ) . '"';
         echo $label; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- already escaped at assignment

--- a/eme-members.php
+++ b/eme-members.php
@@ -645,7 +645,7 @@ function eme_get_linked_activemembership_names_by_personid( $person_id ) {
     $rows = $wpdb->get_results( $prepared_sql, ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
     $memberships_list = '';
     foreach ($rows as $item) {
-        $memberships_list .= "<a href='" . esc_url( admin_url( 'admin.php?page=eme-members&eme_admin_action=edit_member&member_id=' . $item['member_id'] ) ) . "' title='" . esc_attr__( 'Edit member', 'events-made-easy' ) . "'>" . eme_esc_html( $item['name'] ) . '</a><br>';
+        $memberships_list .= "<a href='" . esc_url( admin_url( 'admin.php?page=eme-members&eme_admin_action=edit_member&member_id=' . $item['member_id'] ) ) . "' title='" . esc_attr__( 'Edit member', 'events-made-easy' ) . "'>" . esc_html( $item['name'] ) . '</a><br>';
     }
     return $memberships_list;
 }
@@ -1617,7 +1617,7 @@ function eme_admin_edit_memberform( $member, $membership_id, $limited = 0 ) {
                      if ( $related_member ) {
                          $related_person = eme_get_person( $related_member['person_id'] );
                          if ( $related_person ) {
-                             $preselected_text = eme_esc_html( eme_format_full_name( $related_person['firstname'], $related_person['lastname'], $related_person['email'] ) );
+                             $preselected_text = esc_html( eme_format_full_name( $related_person['firstname'], $related_person['lastname'], $related_person['email'] ) );
                              $preselected_option = '<option value="' . intval( $member['related_member_id'] ) . '" selected>' . $preselected_text . '</option>';
                          }
                      }
@@ -3011,7 +3011,7 @@ function eme_render_members_searchfields( $limit_to_group = 0, $group_to_edit = 
             $value = '';
         }
         $label = __( 'Custom fields to filter on', 'events-made-easy' );
-        $extra_attributes = 'aria-label="' . eme_esc_html( $label ) . '" data-placeholder="' . eme_esc_html( $label ) . '"';
+        $extra_attributes = 'aria-label="' . esc_html( $label ) . '" data-placeholder="' . esc_html( $label ) . '"';
         echo eme_ui_multiselect_key_value( $value, 'search_customfieldids', $formfields_searchable, 'field_id', 'field_name', 5, '', 0, 'eme_snapselect', $extra_attributes, 1, id_prefix: $id_prefix ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_multiselect_key_value()
         if ( $edit_group ) {
             echo '</td></tr><tr><td>' . esc_html__( 'Exact custom field search match', 'events-made-easy' ) . '</td><td>';
@@ -3514,7 +3514,7 @@ function eme_dyndata_member_ajax() {
                 }
                 if ( $condition['field'] == '#_GROUPS' ) {
                     $wp_id 	     = eme_get_wpid_by_post();
-                    $entered_val = join( ',', eme_esc_html( eme_get_persongroup_names( 0, $wp_id ) ) );
+                    $entered_val = join( ',', array_map( 'esc_html', eme_get_persongroup_names( 0, $wp_id ) ) );
                 } else {
                     // indicate "1" to make sure the answers are taken from the POST, and not from the existing member
                     $entered_val = eme_replace_member_placeholders( $condition['field'], $membership, $member, 'html', '', 1 );
@@ -5248,7 +5248,7 @@ function eme_replace_member_placeholders( $format, $membership, $member, $target
         if ( preg_match( '/#_ID/', $result ) ) {
             $replacement = $member['member_id'];
             if ( $target == 'html' ) {
-                $replacement = eme_esc_html( $replacement );
+                $replacement = esc_html( $replacement );
                 $replacement = apply_filters( 'eme_general', $replacement );
             } else {
                 $replacement = apply_filters( 'eme_text', $replacement );
@@ -5271,7 +5271,7 @@ function eme_replace_member_placeholders( $format, $membership, $member, $target
                 foreach ( $applied_discountids as $discount_id ) {
                     $discount = eme_get_discount( $discount_id );
                     if ( $discount && isset( $discount['name'] ) ) {
-                        $discount_names[] = eme_esc_html( $discount['name'] );
+                        $discount_names[] = esc_html( $discount['name'] );
                     } else {
                         $discount_names[] = sprintf( __( 'Applied discount %d no longer exists', 'events-made-easy' ), $discount_id );
                     }
@@ -5292,7 +5292,7 @@ function eme_replace_member_placeholders( $format, $membership, $member, $target
         } elseif ( preg_match( '/#_PRICE$/', $result ) ) {
             $replacement = eme_localized_price( $total_member_price, $membership['properties']['currency'], $target );
             if ( $target == 'html' ) {
-                $replacement = eme_esc_html( $replacement );
+                $replacement = esc_html( $replacement );
                 $replacement = apply_filters( 'eme_general', $replacement );
             } else {
                 $replacement = apply_filters( 'eme_text', $replacement );
@@ -5301,7 +5301,7 @@ function eme_replace_member_placeholders( $format, $membership, $member, $target
             $price       = $total_member_price / ( 1 + $membership['properties']['vat_pct'] / 100 );
             $replacement = eme_localized_price( $price, $membership['properties']['currency'], $target );
             if ( $target == 'html' ) {
-                $replacement = eme_esc_html( $replacement );
+                $replacement = esc_html( $replacement );
                 $replacement = apply_filters( 'eme_general', $replacement );
             } else {
                 $replacement = apply_filters( 'eme_text', $replacement );
@@ -5310,7 +5310,7 @@ function eme_replace_member_placeholders( $format, $membership, $member, $target
             $price       = $total_member_price - $total_member_price / ( 1 + $membership['properties']['vat_pct'] / 100 );
             $replacement = eme_localized_price( $price, $membership['properties']['currency'], $target );
             if ( $target == 'html' ) {
-                $replacement = eme_esc_html( $replacement );
+                $replacement = esc_html( $replacement );
                 $replacement = apply_filters( 'eme_general', $replacement );
             } else {
                 $replacement = apply_filters( 'eme_text', $replacement );
@@ -5336,7 +5336,7 @@ function eme_replace_member_placeholders( $format, $membership, $member, $target
         } elseif ( preg_match( '/#_TRANSFER_NBR_BE97|UNIQUE_NBR/', $result ) ) {
             $replacement = eme_unique_nbr_formatted( $member['unique_nbr'] );
             if ( $target == 'html' ) {
-                $replacement = eme_esc_html( $replacement );
+                $replacement = esc_html( $replacement );
                 $replacement = apply_filters( 'eme_general', $replacement );
             } else {
                 $replacement = apply_filters( 'eme_text', $replacement );
@@ -5348,7 +5348,7 @@ function eme_replace_member_placeholders( $format, $membership, $member, $target
                 $replacement = __( 'Never', 'events-made-easy' );
             }
             if ( $target == 'html' ) {
-                $replacement = eme_esc_html( $replacement );
+                $replacement = esc_html( $replacement );
                 $replacement = apply_filters( 'eme_general', $replacement );
             } else {
                 $replacement = apply_filters( 'eme_text', $replacement );
@@ -5356,7 +5356,7 @@ function eme_replace_member_placeholders( $format, $membership, $member, $target
         } elseif ( preg_match( '/#_CREATIONDATE\{(.+?)\}/', $result, $matches ) ) {
             $replacement = eme_localized_date( $member['creation_date'], EME_TIMEZONE, $matches[1] );
             if ( $target == 'html' ) {
-                $replacement = eme_esc_html( $replacement );
+                $replacement = esc_html( $replacement );
                 $replacement = apply_filters( 'eme_general', $replacement );
             } else {
                 $replacement = apply_filters( 'eme_text', $replacement );
@@ -5364,7 +5364,7 @@ function eme_replace_member_placeholders( $format, $membership, $member, $target
         } elseif ( preg_match( '/#_STARTDATE\{(.+?)\}/', $result, $matches ) ) {
             $replacement = eme_localized_date( $member['start_date'], EME_TIMEZONE, $matches[1] );
             if ( $target == 'html' ) {
-                $replacement = eme_esc_html( $replacement );
+                $replacement = esc_html( $replacement );
                 $replacement = apply_filters( 'eme_general', $replacement );
             } else {
                 $replacement = apply_filters( 'eme_text', $replacement );
@@ -5382,7 +5382,7 @@ function eme_replace_member_placeholders( $format, $membership, $member, $target
                 $replacement = eme_localized_date( $member['end_date'], EME_TIMEZONE, $matches[1] );
             }
             if ( $target == 'html' ) {
-                $replacement = eme_esc_html( $replacement );
+                $replacement = esc_html( $replacement );
                 $replacement = apply_filters( 'eme_general', $replacement );
             } else {
                 $replacement = apply_filters( 'eme_text', $replacement );
@@ -5405,7 +5405,7 @@ function eme_replace_member_placeholders( $format, $membership, $member, $target
                 $replacement       = eme_localized_date( $next_end_date, EME_TIMEZONE, $matches[1] );
             }
             if ( $target == 'html' ) {
-                $replacement = eme_esc_html( $replacement );
+                $replacement = esc_html( $replacement );
                 $replacement = apply_filters( 'eme_general', $replacement );
             } else {
                 $replacement = apply_filters( 'eme_text', $replacement );
@@ -5413,7 +5413,7 @@ function eme_replace_member_placeholders( $format, $membership, $member, $target
         } elseif ( preg_match( '/#_CREATIONDATE$/', $result ) ) {
             $replacement = eme_localized_date( $member['creation_date'], EME_TIMEZONE );
             if ( $target == 'html' ) {
-                $replacement = eme_esc_html( $replacement );
+                $replacement = esc_html( $replacement );
                 $replacement = apply_filters( 'eme_general', $replacement );
             } else {
                 $replacement = apply_filters( 'eme_text', $replacement );
@@ -5421,7 +5421,7 @@ function eme_replace_member_placeholders( $format, $membership, $member, $target
         } elseif ( preg_match( '/#_STARTDATE$/', $result ) ) {
             $replacement = eme_localized_date( $member['start_date'], EME_TIMEZONE );
             if ( $target == 'html' ) {
-                $replacement = eme_esc_html( $replacement );
+                $replacement = esc_html( $replacement );
                 $replacement = apply_filters( 'eme_general', $replacement );
             } else {
                 $replacement = apply_filters( 'eme_text', $replacement );
@@ -5439,7 +5439,7 @@ function eme_replace_member_placeholders( $format, $membership, $member, $target
                 $replacement = eme_localized_date( $member['end_date'], EME_TIMEZONE );
             }
             if ( $target == 'html' ) {
-                $replacement = eme_esc_html( $replacement );
+                $replacement = esc_html( $replacement );
                 $replacement = apply_filters( 'eme_general', $replacement );
             } else {
                 $replacement = apply_filters( 'eme_text', $replacement );
@@ -5466,7 +5466,7 @@ function eme_replace_member_placeholders( $format, $membership, $member, $target
                 $replacement       = eme_localized_date( $next_end_date, EME_TIMEZONE );
             }
             if ( $target == 'html' ) {
-                $replacement = eme_esc_html( $replacement );
+                $replacement = esc_html( $replacement );
                 $replacement = apply_filters( 'eme_general', $replacement );
             } else {
                 $replacement = apply_filters( 'eme_text', $replacement );
@@ -5522,7 +5522,7 @@ function eme_replace_member_placeholders( $format, $membership, $member, $target
                     if ( $related_member ) {
                         $related_person = eme_get_person( $related_member['person_id'] );
                         if ( $related_person ) {
-                            $replacement .= "<tr class='eme_dyndata_row'><td style='border: 1px solid black;padding: 5px;' class='eme_dyndata_column_left'>" . eme_esc_html( eme_format_full_name( $related_person['firstname'], $related_person['lastname'], $related_person['email'] ) ) . "</td><td style='border: 1px solid black;padding: 5px;' class='eme_dyndata_column_right'>" . eme_esc_html( $related_person['email'] ) . '</td></tr>';
+                            $replacement .= "<tr class='eme_dyndata_row'><td style='border: 1px solid black;padding: 5px;' class='eme_dyndata_column_left'>" . esc_html( eme_format_full_name( $related_person['firstname'], $related_person['lastname'], $related_person['email'] ) ) . "</td><td style='border: 1px solid black;padding: 5px;' class='eme_dyndata_column_right'>" . esc_html( $related_person['email'] ) . '</td></tr>';
                         }
                     }
                 }
@@ -5537,7 +5537,7 @@ function eme_replace_member_placeholders( $format, $membership, $member, $target
         } elseif ( preg_match( '/#_PAYMENTID/', $result ) ) {
             $replacement = $member['payment_id'];
             if ( $target == 'html' ) {
-                $replacement = eme_esc_html( $replacement );
+                $replacement = esc_html( $replacement );
                 $replacement = apply_filters( 'eme_general', $replacement );
             } else {
                 $replacement = apply_filters( 'eme_text', $replacement );
@@ -5605,7 +5605,7 @@ function eme_replace_member_placeholders( $format, $membership, $member, $target
                                 $old_grouping  = $grouping;
                                 $old_occurence = $occurence;
                             }
-                            $replacement .= "<tr class='eme_dyndata_row'><td style='border: 1px solid black;padding: 5px;' class='eme_dyndata_column_left'>" . eme_esc_html( $tmp_formfield['field_name'] ) . ":</td><td style='border: 1px solid black;padding: 5px;' class='eme_dyndata_column_right'> " . eme_answer2readable( $answer['answer'], $tmp_formfield, 1, '<br>', $target ) . '</td></tr>';
+                            $replacement .= "<tr class='eme_dyndata_row'><td style='border: 1px solid black;padding: 5px;' class='eme_dyndata_column_left'>" . esc_html( $tmp_formfield['field_name'] ) . ":</td><td style='border: 1px solid black;padding: 5px;' class='eme_dyndata_column_right'> " . eme_answer2readable( $answer['answer'], $tmp_formfield, 1, '<br>', $target ) . '</td></tr>';
                         } else {
                             $replacement .= $tmp_formfield['field_name'] . ': ' . eme_answer2readable( $answer['answer'], $tmp_formfield, 1, '||', $target ) . "\n";
                         }
@@ -5836,7 +5836,7 @@ function eme_replace_membership_placeholders( $format, $membership, $target = 'h
         if ( preg_match( '/#_NAME/', $result ) ) {
             $replacement = $membership['name'];
             if ( $target == 'html' ) {
-                $replacement = eme_esc_html( $replacement );
+                $replacement = esc_html( $replacement );
                 $replacement = apply_filters( 'eme_general', $replacement );
             } else {
                 $replacement = apply_filters( 'eme_text', $replacement );
@@ -5844,7 +5844,7 @@ function eme_replace_membership_placeholders( $format, $membership, $target = 'h
         } elseif ( preg_match( '/#_DESCRIPTION/', $result ) ) {
             $replacement = $membership['description'];
             if ( $target == 'html' ) {
-                $replacement = eme_esc_html( $replacement );
+                $replacement = esc_html( $replacement );
                 $replacement = apply_filters( 'eme_general', $replacement );
             } else {
                 $replacement = apply_filters( 'eme_text', $replacement );
@@ -5854,7 +5854,7 @@ function eme_replace_membership_placeholders( $format, $membership, $target = 'h
             $currency    = $membership['properties']['currency'];
             $replacement = eme_localized_price( $price, $currency );
             if ( $target == 'html' ) {
-                $replacement = eme_esc_html( $replacement );
+                $replacement = esc_html( $replacement );
                 $replacement = apply_filters( 'eme_general', $replacement );
             } else {
                 $replacement = apply_filters( 'eme_text', $replacement );
@@ -5864,7 +5864,7 @@ function eme_replace_membership_placeholders( $format, $membership, $target = 'h
             $currency    = $membership['properties']['currency'];
             $replacement = eme_localized_price( $price, $currency );
             if ( $target == 'html' ) {
-                $replacement = eme_esc_html( $replacement );
+                $replacement = esc_html( $replacement );
                 $replacement = apply_filters( 'eme_general', $replacement );
             } else {
                 $replacement = apply_filters( 'eme_text', $replacement );
@@ -5875,7 +5875,7 @@ function eme_replace_membership_placeholders( $format, $membership, $target = 'h
             $currency    = $membership['properties']['currency'];
             $replacement = eme_localized_price( $price, $currency );
             if ( $target == 'html' ) {
-                $replacement = eme_esc_html( $replacement );
+                $replacement = esc_html( $replacement );
                 $replacement = apply_filters( 'eme_general', $replacement );
             } else {
                 $replacement = apply_filters( 'eme_text', $replacement );
@@ -5883,7 +5883,7 @@ function eme_replace_membership_placeholders( $format, $membership, $target = 'h
         } elseif ( preg_match( '/#_PRICE_VAT_PCT/', $result ) ) {
             $replacement = $membership['properties']['vat_pct'];
             if ( $target == 'html' ) {
-                $replacement = eme_esc_html( $replacement );
+                $replacement = esc_html( $replacement );
                 $replacement = apply_filters( 'eme_general', $replacement );
             } else {
                 $replacement = apply_filters( 'eme_text', $replacement );
@@ -5894,7 +5894,7 @@ function eme_replace_membership_placeholders( $format, $membership, $target = 'h
             $charge = eme_payment_gateway_extra_charge( $price, $matches[1] );
             $replacement = eme_localized_price( $price+$charge, $currency );
             if ( $target == 'html' ) {
-                $replacement = eme_esc_html( $replacement );
+                $replacement = esc_html( $replacement );
                 $replacement = apply_filters( 'eme_general', $replacement );
             } else {
                 $replacement = apply_filters( 'eme_text', $replacement );
@@ -5904,7 +5904,7 @@ function eme_replace_membership_placeholders( $format, $membership, $target = 'h
             $charge = eme_payment_gateway_extra_charge( $price, $matches[1] );
             $replacement = eme_localized_price( $charge, $currency );
             if ( $target == 'html' ) {
-                $replacement = eme_esc_html( $replacement );
+                $replacement = esc_html( $replacement );
                 $replacement = apply_filters( 'eme_general', $replacement );
             } else {
                 $replacement = apply_filters( 'eme_text', $replacement );
@@ -6087,7 +6087,7 @@ function eme_import_csv_members() {
             // if email empty: at least lastname is needed
             if (empty($line['email'] ) && !isset( $line['lastname'] ) ) {
                 ++$errors;
-                $error_msg .= '<br>' . eme_esc_html( sprintf( __( 'Not imported (both email and lastname are empty): %s', 'events-made-easy' ), implode( ',', $row ) ) );
+                $error_msg .= '<br>' . esc_html( sprintf( __( 'Not imported (both email and lastname are empty): %s', 'events-made-easy' ), implode( ',', $row ) ) );
                 continue;
             }
             // also allow empty firstname
@@ -6099,27 +6099,27 @@ function eme_import_csv_members() {
             }
             if ( ! isset( $line['membership'] ) || ! isset( $line['start_date'] ) ) {
                 ++$errors;
-                $error_msg .= '<br>' . eme_esc_html( sprintf( __( 'Not imported (not all required fields are present): %s', 'events-made-easy' ), print_r( $line, true ) ) );
+                $error_msg .= '<br>' . esc_html( sprintf( __( 'Not imported (not all required fields are present): %s', 'events-made-easy' ), print_r( $line, true ) ) );
                 continue;
             }
             if ( ! empty( $line['email'] ) && ! eme_is_email( $line['email'] ) ) {
                 ++$errors;
-                $error_msg .= '<br>' . eme_esc_html( sprintf( __( 'Not imported (field %s not valid): %s', 'events-made-easy' ), 'email', implode( ',', $row ) ) );
+                $error_msg .= '<br>' . esc_html( sprintf( __( 'Not imported (field %s not valid): %s', 'events-made-easy' ), 'email', implode( ',', $row ) ) );
                 continue;
             }
             if ( isset( $line['start_date'] ) && ! eme_is_date( $line['start_date'] ) ) {
                 ++$errors;
-                $error_msg .= '<br>' . eme_esc_html( sprintf( __( 'Not imported (field %s not valid): %s', 'events-made-easy' ), 'start_date', implode( ',', $row ) ) );
+                $error_msg .= '<br>' . esc_html( sprintf( __( 'Not imported (field %s not valid): %s', 'events-made-easy' ), 'start_date', implode( ',', $row ) ) );
                 continue;
             }
             if ( isset( $line['end_date'] ) && ! eme_is_date( $line['end_date'] ) ) {
                 ++$errors;
-                $error_msg .= '<br>' . eme_esc_html( sprintf( __( 'Not imported (field %s not valid): %s', 'events-made-easy' ), 'end_date', implode( ',', $row ) ) );
+                $error_msg .= '<br>' . esc_html( sprintf( __( 'Not imported (field %s not valid): %s', 'events-made-easy' ), 'end_date', implode( ',', $row ) ) );
                 continue;
             }
             if ( isset( $line['creation_date'] ) && ! ( eme_is_date( $line['creation_date'] ) || eme_is_datetime( $line['creation_date'] ) ) ) {
                 ++$errors;
-                $error_msg .= '<br>' . eme_esc_html( sprintf( __( 'Not imported (field %s not valid): %s', 'events-made-easy' ), 'creation_date', implode( ',', $row ) ) );
+                $error_msg .= '<br>' . esc_html( sprintf( __( 'Not imported (field %s not valid): %s', 'events-made-easy' ), 'creation_date', implode( ',', $row ) ) );
                 continue;
             }
 
@@ -6142,13 +6142,13 @@ function eme_import_csv_members() {
                     $person_id = eme_db_insert_person( $person );
                     if ( ! $person_id ) {
                         ++$errors;
-                        $error_msg .= '<br>' . eme_esc_html( sprintf( __( 'Not imported (problem updating the person in the db): %s', 'events-made-easy' ), implode( ',', $row ) ) );
+                        $error_msg .= '<br>' . esc_html( sprintf( __( 'Not imported (problem updating the person in the db): %s', 'events-made-easy' ), implode( ',', $row ) ) );
                     }
                 }
             } else {
                 // if membership doesn't exist
                 ++$errors;
-                $error_msg .= '<br>' . eme_esc_html( sprintf( __( 'Not imported (membership does not exist): %s', 'events-made-easy' ), implode( ',', $row ) ) );
+                $error_msg .= '<br>' . esc_html( sprintf( __( 'Not imported (membership does not exist): %s', 'events-made-easy' ), implode( ',', $row ) ) );
             }
             if ( $membership && $person_id ) {
                 if ( isset( $line['start_date'] ) ) {
@@ -6198,7 +6198,7 @@ function eme_import_csv_members() {
                     }
                 } else {
                     ++$errors;
-                    $error_msg .= '<br>' . eme_esc_html( sprintf( __( 'Not imported (problem inserting the member in the db): %s', 'events-made-easy' ), implode( ',', $row ) ) );
+                    $error_msg .= '<br>' . esc_html( sprintf( __( 'Not imported (problem inserting the member in the db): %s', 'events-made-easy' ), implode( ',', $row ) ) );
                 }
             }
         }
@@ -6275,7 +6275,7 @@ function eme_import_csv_member_dynamic_answers() {
             // if email empty: at least lastname is needed
             if (empty($line['email'] ) && !isset( $line['lastname'] ) ) {
                 ++$errors;
-                $error_msg .= '<br>' . eme_esc_html( sprintf( __( 'Not imported (both email and lastname are empty): %s', 'events-made-easy' ), implode( ',', $row ) ) );
+                $error_msg .= '<br>' . esc_html( sprintf( __( 'Not imported (both email and lastname are empty): %s', 'events-made-easy' ), implode( ',', $row ) ) );
                 continue;
             }
             // also allow empty firstname
@@ -6287,7 +6287,7 @@ function eme_import_csv_member_dynamic_answers() {
             }
             if ( !isset( $line['membership'] ) ) {
                 ++$errors;
-                $error_msg .= '<br>' . eme_esc_html( sprintf( __( 'Not imported (not all required fields are present): %s', 'events-made-easy' ), implode( ',', $row ) ) );
+                $error_msg .= '<br>' . esc_html( sprintf( __( 'Not imported (not all required fields are present): %s', 'events-made-easy' ), implode( ',', $row ) ) );
                 continue;
             }
 
@@ -6299,12 +6299,12 @@ function eme_import_csv_member_dynamic_answers() {
                     $person_id = $person['person_id'];
                 } else {
                     ++$errors;
-                    $error_msg .= '<br>' . eme_esc_html( sprintf( __( 'Not imported (person does not exist): %s', 'events-made-easy' ), implode( ',', $row ) ) );
+                    $error_msg .= '<br>' . esc_html( sprintf( __( 'Not imported (person does not exist): %s', 'events-made-easy' ), implode( ',', $row ) ) );
                     continue;
                 }
             } else {
                 ++$errors;
-                $error_msg .= '<br>' . eme_esc_html( sprintf( __( 'Not imported (membership does not exist): %s', 'events-made-easy' ), implode( ',', $row ) ) );
+                $error_msg .= '<br>' . esc_html( sprintf( __( 'Not imported (membership does not exist): %s', 'events-made-easy' ), implode( ',', $row ) ) );
                 continue;
             }
             if ( $person_id ) {
@@ -6349,11 +6349,11 @@ function eme_import_csv_member_dynamic_answers() {
                     }
                 } else {
                     ++$errors;
-                    $error_msg .= '<br>' . eme_esc_html( sprintf( __( 'Not imported (member does not exist): %s', 'events-made-easy' ), implode( ',', $row ) ) );
+                    $error_msg .= '<br>' . esc_html( sprintf( __( 'Not imported (member does not exist): %s', 'events-made-easy' ), implode( ',', $row ) ) );
                 }
             } else {
                 ++$errors;
-                $error_msg .= '<br>' . eme_esc_html( sprintf( __( 'Not imported (no matching person found): %s', 'events-made-easy' ), implode( ',', $row ) ) );
+                $error_msg .= '<br>' . esc_html( sprintf( __( 'Not imported (no matching person found): %s', 'events-made-easy' ), implode( ',', $row ) ) );
             }
         }
     }
@@ -6534,9 +6534,9 @@ function eme_ajax_memberships_list() {
             $record['name'] = "<s>";
         }
         if ( current_user_can( get_option( 'eme_cap_edit_members' ) ) ) {
-            $record['name'] .= "<a href='" . esc_url( admin_url( 'admin.php?page=eme-memberships&eme_admin_action=edit_membership&membership_id=' . $item['membership_id'] ) ) . "' title='" . esc_attr__( 'Edit membership', 'events-made-easy' ) . "'>" . eme_esc_html( $item['name'] ) . '</a>';
+            $record['name'] .= "<a href='" . esc_url( admin_url( 'admin.php?page=eme-memberships&eme_admin_action=edit_membership&membership_id=' . $item['membership_id'] ) ) . "' title='" . esc_attr__( 'Edit membership', 'events-made-easy' ) . "'>" . esc_html( $item['name'] ) . '</a>';
         } else {
-            $record['name'] .= eme_esc_html( $item['name'] );
+            $record['name'] .= esc_html( $item['name'] );
         }
         if ($item['status']==0) {
             $record['name'] .= "</s>";
@@ -6546,8 +6546,8 @@ function eme_ajax_memberships_list() {
             $record['name'] .= "&nbsp;<img style='vertical-align: middle;' src='" . esc_url(EME_PLUGIN_URL) . "images/warning.png' alt='warning' title='" . esc_attr__( 'No membership form has been defined for this membership, a simple default will be used.', 'events-made-easy' ) . "'>";
         }
 
-        $record['description'] = eme_esc_html( $item['description'] );
-        $record['status'] = eme_esc_html( $membership_status_array[$item['status']] );
+        $record['description'] = esc_html( $item['description'] );
+        $record['status'] = esc_html( $membership_status_array[$item['status']] );
         if ( ! isset( $familymembercount[ $item['membership_id'] ] ) ) {
             $familymembercount[ $item['membership_id'] ] = 0;
         }
@@ -6560,7 +6560,7 @@ function eme_ajax_memberships_list() {
         } else {
             $record['membercount'] = $total;
         }
-        $record['contact'] = eme_esc_html( "$contact_name ($contact_email)" );
+        $record['contact'] = esc_html( "$contact_name ($contact_email)" );
         $answers           = eme_get_membership_answers( $item['membership_id'] );
         foreach ( $formfields as $formfield ) {
             foreach ( $answers as $val ) {
@@ -6628,11 +6628,11 @@ function eme_ajax_members_list( ) {
         $record['members.member_id'] = $item['member_id'];
         $record['related_member_id'] = '';
         if ( $item['related_member_id'] ) {
-            $familytext     = eme_esc_html( __( '(family member)', 'events-made-easy' ) );
+            $familytext     = esc_html( __( '(family member)', 'events-made-easy' ) );
             $related_member = eme_get_member( $item['related_member_id'] );
             if ( $related_member ) {
                 $related_person              = eme_get_person( $related_member['person_id'] );
-                $record['related_member_id'] = "<a href='" . esc_url( admin_url( 'admin.php?page=eme-members&eme_admin_action=edit_member&member_id=' . $item['related_member_id'] ) ) . "' title='" . esc_attr__( 'Edit member', 'events-made-easy' ) . "'>" . eme_esc_html( eme_format_full_name( $related_person['firstname'], $related_person['lastname'], $related_person['email'] ) ) . '</a>';
+                $record['related_member_id'] = "<a href='" . esc_url( admin_url( 'admin.php?page=eme-members&eme_admin_action=edit_member&member_id=' . $item['related_member_id'] ) ) . "' title='" . esc_attr__( 'Edit member', 'events-made-easy' ) . "'>" . esc_html( eme_format_full_name( $related_person['firstname'], $related_person['lastname'], $related_person['email'] ) ) . '</a>';
                 $familytext                 .= '<br>' . esc_html__( 'Head of the family: ', 'events-made-easy' ) . $record['related_member_id'];
             }
         } elseif ( ! empty( $membership['properties']['family_membership'] ) ) {
@@ -6641,27 +6641,27 @@ function eme_ajax_members_list( ) {
             $familytext = '';
         }
 
-        $record['lastname']   = "<a href='" . esc_url( admin_url( 'admin.php?page=eme-members&eme_admin_action=edit_member&member_id=' . $item['member_id'] ) ) . "' title='" . esc_attr__( 'Edit member', 'events-made-easy' ) . "'>" . eme_esc_html( $item['lastname'] ) . '</a> ' . $familytext;
-        $record['firstname']  = "<a href='" . esc_url( admin_url( 'admin.php?page=eme-members&eme_admin_action=edit_member&member_id=' . $item['member_id'] ) ) . "' title='" . esc_attr__( 'Edit member', 'events-made-easy' ) . "'>" . eme_esc_html( $item['firstname'] ) . '</a> ' . $familytext;
-        $record['email']      = "<a href='" . esc_url( admin_url( 'admin.php?page=eme-members&eme_admin_action=edit_member&member_id=' . $item['member_id'] ) ) . "' title='" . esc_attr__( 'Edit member', 'events-made-easy' ) . "'>" . eme_esc_html( $item['email'] ) . '</a> ' . $familytext;
+        $record['lastname']   = "<a href='" . esc_url( admin_url( 'admin.php?page=eme-members&eme_admin_action=edit_member&member_id=' . $item['member_id'] ) ) . "' title='" . esc_attr__( 'Edit member', 'events-made-easy' ) . "'>" . esc_html( $item['lastname'] ) . '</a> ' . $familytext;
+        $record['firstname']  = "<a href='" . esc_url( admin_url( 'admin.php?page=eme-members&eme_admin_action=edit_member&member_id=' . $item['member_id'] ) ) . "' title='" . esc_attr__( 'Edit member', 'events-made-easy' ) . "'>" . esc_html( $item['firstname'] ) . '</a> ' . $familytext;
+        $record['email']      = "<a href='" . esc_url( admin_url( 'admin.php?page=eme-members&eme_admin_action=edit_member&member_id=' . $item['member_id'] ) ) . "' title='" . esc_attr__( 'Edit member', 'events-made-easy' ) . "'>" . esc_html( $item['email'] ) . '</a> ' . $familytext;
         $record['birthdate']  = eme_localized_date( $item['birthdate'], EME_TIMEZONE, 1 );
-        $record['birthplace'] = eme_esc_html( $item['birthplace'] );
-        $record['address1']   = eme_esc_html( $item['address1'] );
-        $record['address2']   = eme_esc_html( $item['address2'] );
-        $record['city']       = eme_esc_html( $item['city'] );
-        $record['zip']        = eme_esc_html( $item['zip'] );
+        $record['birthplace'] = esc_html( $item['birthplace'] );
+        $record['address1']   = esc_html( $item['address1'] );
+        $record['address2']   = esc_html( $item['address2'] );
+        $record['city']       = esc_html( $item['city'] );
+        $record['zip']        = esc_html( $item['zip'] );
         if ( ! empty( $item['state_code'] ) ) {
-            $record['state'] = eme_esc_html( eme_get_state_name( $item['state_code'], $item['country_code'] ) );
+            $record['state'] = esc_html( eme_get_state_name( $item['state_code'], $item['country_code'] ) );
         } else {
             $record['state'] = '';
         }
         if ( ! empty( $item['country_code'] ) ) {
-            $record['country'] = eme_esc_html( eme_get_country_name( $item['country_code'] ) );
+            $record['country'] = esc_html( eme_get_country_name( $item['country_code'] ) );
         } else {
             $record['country'] = '';
         }
         if ( $membership ) {
-            $record['membership_name'] = eme_esc_html( $membership['name'] );
+            $record['membership_name'] = esc_html( $membership['name'] );
         } else {
             $record['membership_name'] = '';
         }
@@ -6680,29 +6680,29 @@ function eme_ajax_members_list( ) {
         $record['dcodes_used']   = eme_esc_html( eme_unserialize( $item['dcodes_used'] ) );
         $record['renewal_count'] = intval( $item['renewal_count'] );
         $record['paid']          = ( $item['paid'] == 1 ) ? esc_html__( 'Yes', 'events-made-easy' ) : esc_html__( 'No', 'events-made-easy' );
-        $record['payment_id']    = eme_esc_html( $item['payment_id'] );
-        $record['unique_nbr']    = "<span title='" . esc_attr( sprintf( __( 'This is based on the payment ID of the member: %d', 'events-made-easy' ), $item['payment_id'] ) ) . "'>" . eme_esc_html( eme_unique_nbr_formatted( $item['unique_nbr'] ) ) . '</span>';
+        $record['payment_id']    = esc_html( $item['payment_id'] );
+        $record['unique_nbr']    = "<span title='" . esc_attr( sprintf( __( 'This is based on the payment ID of the member: %d', 'events-made-easy' ), $item['payment_id'] ) ) . "'>" . esc_html( eme_unique_nbr_formatted( $item['unique_nbr'] ) ) . '</span>';
         $record['status']        = $eme_member_status_array[ $item['status'] ];
-        $record['wp_id']         = eme_esc_html( $item['wp_id'] );
+        $record['wp_id']         = esc_html( $item['wp_id'] );
         if ( $item['wp_id'] && isset( $wp_users[ $record['wp_id'] ] ) ) {
-            $record['wp_user'] = eme_esc_html( $wp_users[ $record['wp_id'] ] );
+            $record['wp_user'] = esc_html( $wp_users[ $record['wp_id'] ] );
         } else {
             $record['wp_user'] = '';
         }
 
         if ( ! empty( $item['pg'] ) ) {
             if ( isset( $pgs[ $item['pg'] ] ) ) {
-                $record['pg'] = eme_esc_html( $pgs[ $item['pg'] ] );
+                $record['pg'] = esc_html( $pgs[ $item['pg'] ] );
             } else {
                 $record['pg'] = 'UNKNOWN';
             }
             if ( ($item['pg'] == 'payconiq'||$item['pg'] == 'bancontactwero') && ! empty( $item['pg_pid'] ) ) {
-                $record['pg'] .= "<br><button id='button_".$item['payment_id']."' class='button action eme_iban_button norowselectonclick' data-pg_pid='".$item['pg_pid']."'>".esc_html__('Get IBAN')."</button><span id='bancontactwero_".$item['payment_id']."'></span>";
+                $record['pg'] .= "<br><button id='button_".$item['payment_id']."' class='button action eme_iban_button norowselectonclick' data-pg_pid='".$item['pg_pid']."'>".esc_html__('Get IBAN', 'events-made-easy')."</button><span id='bancontactwero_".$item['payment_id']."'></span>";
             }
         } else {
             $record['pg'] = '';
         }
-        $record['pg_pid'] = eme_esc_html( $item['pg_pid'] );
+        $record['pg_pid'] = esc_html( $item['pg_pid'] );
         $answers          = eme_get_member_answers( $item['member_id'] );
         foreach ( $formfields as $formfield ) {
             foreach ( $answers as $val ) {

--- a/eme-payments.php
+++ b/eme-payments.php
@@ -15,7 +15,7 @@ function eme_payment_gateways() {
         'payconiq'     => __( 'Bancontact Pay - Wero', 'events-made-easy' ),
         'bancontactwero' => __( 'Bancontact Pay - Wero', 'events-made-easy' ),
         'worldpay'     => __( 'Worldpay', 'events-made-easy' ),
-        'opayo'        => __( 'Opayo', 'events_made_easy' ),
+        'opayo'        => __( 'Opayo', 'events-made-easy' ),
         'sumup'        => __( 'SumUp', 'events-made-easy' ),
         'stripe'       => __( 'Stripe', 'events-made-easy' ),
         'braintree'    => __( 'Braintree', 'events-made-easy' ),
@@ -630,7 +630,7 @@ function eme_payment_form_webmoney( $item_name, $payment, $baseprice, $cur, $mul
 
     $description = eme_get_payment_desc( $item_name, $payment, $gateway, $multi_booking );
 
-    $description = eme_esc_html( $description );
+    $description = esc_html( $description );
 
     $button_above = get_option( 'eme_' . $gateway . '_button_above' );
     $button_label = get_option( 'eme_' . $gateway . '_button_label' );
@@ -684,7 +684,7 @@ function eme_payment_form_2co( $item_name, $payment, $baseprice, $cur, $multi_bo
     $notification_link = add_query_arg( [ 'eme_eventAction' => "{$gateway}_notification" ], $events_page_link );
 
     $description = eme_get_payment_desc( $item_name, $payment, $gateway, $multi_booking );
-    $description = eme_esc_html( $description );
+    $description = esc_html( $description );
 
     $button_above = get_option( 'eme_' . $gateway . '_button_above' );
     $button_label = get_option( 'eme_' . $gateway . '_button_label' );
@@ -738,7 +738,7 @@ function eme_payment_form_worldpay( $item_name, $payment, $baseprice, $cur, $mul
     }
     $quantity = 1;
 
-    $description = eme_esc_html( $description );
+    $description = esc_html( $description );
 
     $button_above = get_option( 'eme_' . $gateway . '_button_above' );
     $button_label = get_option( 'eme_' . $gateway . '_button_label' );
@@ -939,7 +939,7 @@ function eme_payment_form_braintree( $item_name, $payment, $baseprice, $cur, $mu
             script.src = "https://js.braintreegateway.com/web/dropin/1.33.0/js/dropin.min.js";
             script.async = true;
             script.onload = function () {
-                const clientToken = "' . eme_esc_html($clientToken) . '";
+                const clientToken = "' . esc_html($clientToken) . '";
                 const container = document.getElementById("braintree-payment-form-div");
     
                 if (!container) {
@@ -1013,7 +1013,7 @@ function eme_payment_form_sumup( $item_name, $payment, $baseprice, $cur, $multi_
 
     $description = eme_get_payment_desc( $item_name, $payment, $gateway, $multi_booking );
 
-    $description = eme_esc_html( $description );
+    $description = esc_html( $description );
 
     $button_above = get_option( 'eme_' . $gateway . '_button_above' );
     $button_label = get_option( 'eme_' . $gateway . '_button_label' );
@@ -1095,7 +1095,7 @@ function eme_payment_form_stripe( $item_name, $payment, $baseprice, $cur, $multi
 
     // gateway doesn't like the single quotes
     $description = str_replace( "'", '', $description );
-    $description = eme_esc_html( $description );
+    $description = esc_html( $description );
 
     $price            = eme_payment_gateway_total( $baseprice, $cur, $gateway );
     $events_page_link = eme_get_events_page();
@@ -1145,7 +1145,7 @@ function eme_payment_form_fdgg( $item_name, $payment, $baseprice, $cur, $multi_b
 
     // we add the next lines to be conform with the others, but fdgg ignores the description
     $description = eme_get_payment_desc( $item_name, $payment, $gateway, $multi_booking );
-    $description = eme_esc_html( $description );
+    $description = esc_html( $description );
 
     // the live or sandbox url
     $mode = get_option( 'eme_fdgg_url' );
@@ -1214,7 +1214,7 @@ function eme_payment_form_instamojo( $item_name, $payment, $baseprice, $cur, $mu
     $notification_link = add_query_arg( [ 'eme_eventAction' => "{$gateway}_notification" ], $events_page_link );
 
     $description = eme_get_payment_desc( $item_name, $payment, $gateway, $multi_booking );
-    $description = eme_esc_html( $description );
+    $description = esc_html( $description );
 
     $button_above = get_option( 'eme_' . $gateway . '_button_above' );
     $button_label = get_option( 'eme_' . $gateway . '_button_label' );
@@ -1255,7 +1255,7 @@ function eme_payment_form_mollie( $item_name, $payment, $baseprice, $cur, $multi
 
     // gateway doesn't like the single quotes
     $description = str_replace( "'", '', $description );
-    $description = eme_esc_html( $description );
+    $description = esc_html( $description );
 
     $price            = eme_payment_gateway_total( $baseprice, $cur, $gateway );
     $events_page_link = eme_get_events_page();
@@ -1303,7 +1303,7 @@ function eme_payment_form_bancontactwero( $item_name, $payment, $baseprice, $cur
 
     // gateway doesn't like the single quotes
     $description = str_replace( "'", '', $description );
-    $description = eme_esc_html( $description );
+    $description = esc_html( $description );
 
     $price            = eme_payment_gateway_total( $baseprice, $cur, $gateway );
     $events_page_link = eme_get_events_page();
@@ -1354,7 +1354,7 @@ function eme_payment_form_paypal( $item_name, $payment, $baseprice, $cur, $multi
 
     $description = eme_get_payment_desc( $item_name, $payment, $gateway, $multi_booking );
 
-    $description = eme_esc_html( $description );
+    $description = esc_html( $description );
 
     $button_above = get_option( 'eme_' . $gateway . '_button_above' );
     $button_label = get_option( 'eme_' . $gateway . '_button_label' );
@@ -1401,7 +1401,7 @@ function eme_payment_form_legacypaypal( $item_name, $payment, $baseprice, $cur, 
 
     $description = eme_get_payment_desc( $item_name, $payment, $gateway, $multi_booking );
 
-    $description = eme_esc_html( $description );
+    $description = esc_html( $description );
 
     $button_above = get_option( 'eme_' . $gateway . '_button_above' );
     $button_label = get_option( 'eme_' . $gateway . '_button_label' );
@@ -1491,8 +1491,8 @@ function eme_payment_form_mercadopago( $item_name, $payment, $baseprice, $cur, $
         $item_name = $description;
     }
 
-    $description = eme_esc_html( $description );
-    $item_name   = eme_esc_html( $item_name );
+    $description = esc_html( $description );
+    $item_name   = esc_html( $item_name );
 
     $price            = eme_payment_gateway_total( $baseprice, $cur, $gateway );
     $quantity         = 1;
@@ -1514,7 +1514,7 @@ function eme_payment_form_mercadopago( $item_name, $payment, $baseprice, $cur, $
     $locale_code             = determine_locale();
     $locale_code             = str_replace( '_', '-', $locale_code );
     $button_price            = eme_localized_price( $price, $cur );
-    $button_text_inside_form = eme_esc_html( sprintf( __( 'Pay %s', 'events-made-easy' ), $button_price ) );
+    $button_text_inside_form = esc_html( sprintf( __( 'Pay %s', 'events-made-easy' ), $button_price ) );
     $form_html               = $button_above;
 
     // Create a preference object
@@ -1535,7 +1535,7 @@ function eme_payment_form_mercadopago( $item_name, $payment, $baseprice, $cur, $
     $res                            = $preference->save();
 
     if ( ! $res ) {
-        $form_html .= '<br>' . __( 'Mercado Pago API returned an error: ', 'events-made-easy' ) . eme_esc_html( $preference->Error() );
+        $form_html .= '<br>' . __( 'Mercado Pago API returned an error: ', 'events-made-easy' ) . esc_html( $preference->Error() );
     } else {
         $form_html .= "<form action='' method='post' name='eme_{$gateway}_form' id='eme_{$gateway}_form'>
            <script src='https://www.mercadopago.com.ar/integrations/v1/web-payment-checkout.js' data-preference-id='" . $preference->id . "' data-button-label='$button_label'></script>
@@ -1561,7 +1561,7 @@ function eme_payment_form_fondy( $item_name, $payment, $baseprice, $cur, $multi_
 
     // gateway doesn't like the single quotes
     $description = str_replace( "'", '', $description );
-    $description = eme_esc_html( $description );
+    $description = esc_html( $description );
 
     $price      = eme_payment_gateway_total( $baseprice, $cur, $gateway );
 
@@ -3930,7 +3930,7 @@ function eme_replace_payment_gateway_placeholders( $format, $pg, $total_price, $
         }
         if ( $found ) {
             if ( $need_escape ) {
-                $replacement = eme_esc_html( preg_replace( '/\n|\r/', '', $replacement ) );
+                $replacement = esc_html( preg_replace( '/\n|\r/', '', $replacement ) );
             }
             $format         = substr_replace( $format, $replacement, $orig_result_needle, $orig_result_length );
             $needle_offset += $orig_result_length - strlen( $replacement );

--- a/eme-people.php
+++ b/eme-people.php
@@ -368,7 +368,7 @@ function eme_replace_people_placeholders( $format, $person, $target = 'html', $l
         } elseif ( preg_match( '/#_FULLNAME/', $result ) ) {
             $replacement = eme_format_full_name( $person['firstname'], $person['lastname'] );
             if ( $target == 'html' ) {
-                $replacement = eme_esc_html( $replacement );
+                $replacement = esc_html( $replacement );
                 $replacement = apply_filters( 'eme_general', $replacement );
             } else {
                 $replacement = apply_filters( 'eme_text', $replacement );
@@ -384,7 +384,7 @@ function eme_replace_people_placeholders( $format, $person, $target = 'html', $l
             }
             $replacement = $person[ $field ];
             if ( $target == 'html' ) {
-                $replacement = eme_esc_html( $replacement );
+                $replacement = esc_html( $replacement );
                 $replacement = apply_filters( 'eme_general', $replacement );
             } else {
                 $replacement = apply_filters( 'eme_text', $replacement );
@@ -410,7 +410,7 @@ function eme_replace_people_placeholders( $format, $person, $target = 'html', $l
             // add trailing '.'
             $replacement .= ( substr( $replacement, -1 ) == '.' ? '' : '.' );
             if ( $target == 'html' ) {
-                $replacement = eme_esc_html( $replacement );
+                $replacement = esc_html( $replacement );
                 $replacement = apply_filters( 'eme_general', $replacement );
             } else {
                 $replacement = apply_filters( 'eme_text', $replacement );
@@ -419,7 +419,7 @@ function eme_replace_people_placeholders( $format, $person, $target = 'html', $l
             $length      = intval( $matches[1] );
             $replacement = substr( $person['lastname'], 0, $length );
             if ( $target == 'html' ) {
-                $replacement = eme_esc_html( $replacement );
+                $replacement = esc_html( $replacement );
                 $replacement = apply_filters( 'eme_general', $replacement );
             } else {
                 $replacement = apply_filters( 'eme_text', $replacement );
@@ -428,7 +428,7 @@ function eme_replace_people_placeholders( $format, $person, $target = 'html', $l
             $fullname    = eme_format_full_name( $person['firstname'], $person['lastname'] );
             $replacement = eme_get_initials( $fullname );
             if ( $target == 'html' ) {
-                $replacement = eme_esc_html( $replacement );
+                $replacement = esc_html( $replacement );
                 $replacement = apply_filters( 'eme_general', $replacement );
             } else {
                 $replacement = apply_filters( 'eme_text', $replacement );
@@ -436,7 +436,7 @@ function eme_replace_people_placeholders( $format, $person, $target = 'html', $l
         } elseif ( preg_match( '/#_LASTNAME_INITIALS/', $result ) ) {
             $replacement = eme_get_initials( $person['lastname'] );
             if ( $target == 'html' ) {
-                $replacement = eme_esc_html( $replacement );
+                $replacement = esc_html( $replacement );
                 $replacement = apply_filters( 'eme_general', $replacement );
             } else {
                 $replacement = apply_filters( 'eme_text', $replacement );
@@ -444,7 +444,7 @@ function eme_replace_people_placeholders( $format, $person, $target = 'html', $l
         } elseif ( preg_match( '/#_COUNTRY/', $result ) ) {
             $replacement = eme_get_country_name( $person['country_code'], $lang );
             if ( $target == 'html' ) {
-                $replacement = eme_esc_html( $replacement );
+                $replacement = esc_html( $replacement );
                 $replacement = apply_filters( 'eme_general', $replacement );
             } else {
                 $replacement = apply_filters( 'eme_text', $replacement );
@@ -452,7 +452,7 @@ function eme_replace_people_placeholders( $format, $person, $target = 'html', $l
         } elseif ( preg_match( '/#_STATE/', $result ) ) {
             $replacement = eme_get_state_name( $person['state_code'], $person['country_code'], $lang );
             if ( $target == 'html' ) {
-                $replacement = eme_esc_html( $replacement );
+                $replacement = esc_html( $replacement );
                 $replacement = apply_filters( 'eme_general', $replacement );
             } else {
                 $replacement = apply_filters( 'eme_text', $replacement );
@@ -461,7 +461,7 @@ function eme_replace_people_placeholders( $format, $person, $target = 'html', $l
             if (!empty($person['person_id']))
                 $replacement = join( ', ', eme_get_persongroup_names( $person['person_id'] ) );
             if ( $target == 'html' ) {
-                $replacement = eme_esc_html( $replacement );
+                $replacement = esc_html( $replacement );
                 $replacement = apply_filters( 'eme_general', $replacement );
             } else {
                 $replacement = apply_filters( 'eme_text', $replacement );
@@ -470,7 +470,7 @@ function eme_replace_people_placeholders( $format, $person, $target = 'html', $l
             if (!empty($person['person_id']))
                 $replacement = eme_get_activemembership_names_by_personid( $person['person_id'] );
             if ( $target == 'html' ) {
-                $replacement = eme_esc_html( $replacement );
+                $replacement = esc_html( $replacement );
                 $replacement = apply_filters( 'eme_general', $replacement );
             } else {
                 $replacement = apply_filters( 'eme_text', $replacement );
@@ -513,7 +513,7 @@ function eme_replace_people_placeholders( $format, $person, $target = 'html', $l
         } elseif ( preg_match( '/#_BIRTHDAY_EMAIL/', $result ) ) {
             $replacement = $person['bd_email'] ? __( 'Yes', 'events-made-easy' ) : __( 'No', 'events-made-easy' );
             if ( $target == 'html' ) {
-                $replacement = eme_esc_html( $replacement );
+                $replacement = esc_html( $replacement );
                 $replacement = apply_filters( 'eme_general', $replacement );
             } else {
                 $replacement = apply_filters( 'eme_text', $replacement );
@@ -521,7 +521,7 @@ function eme_replace_people_placeholders( $format, $person, $target = 'html', $l
         } elseif ( preg_match( '/#_MASSMAIL|#_OPT_IN|#_OPT_OUT/', $result ) ) {
             $replacement = $person['massmail'] ? __( 'Yes', 'events-made-easy' ) : __( 'No', 'events-made-easy' );
             if ( $target == 'html' ) {
-                $replacement = eme_esc_html( $replacement );
+                $replacement = esc_html( $replacement );
                 $replacement = apply_filters( 'eme_general', $replacement );
             } else {
                 $replacement = apply_filters( 'eme_text', $replacement );
@@ -529,7 +529,7 @@ function eme_replace_people_placeholders( $format, $person, $target = 'html', $l
         } elseif ( preg_match( '/#_GDPR|#_CONSENT/', $result ) ) {
             $replacement = $person['gdpr'] ? __( 'Yes', 'events-made-easy' ) : __( 'No', 'events-made-easy' );
             if ( $target == 'html' ) {
-                $replacement = eme_esc_html( $replacement );
+                $replacement = esc_html( $replacement );
                 $replacement = apply_filters( 'eme_general', $replacement );
             } else {
                 $replacement = apply_filters( 'eme_text', $replacement );
@@ -758,7 +758,7 @@ function eme_replace_people_placeholders( $format, $person, $target = 'html', $l
                     $replacement = $user->user_nicename;
                 }
                 if ( $target == 'html' ) {
-                    $replacement = eme_esc_html( $replacement );
+                    $replacement = esc_html( $replacement );
                     $replacement = apply_filters( 'eme_general', $replacement );
                 } else {
                     $replacement = apply_filters( 'eme_text', $replacement );
@@ -771,7 +771,7 @@ function eme_replace_people_placeholders( $format, $person, $target = 'html', $l
                     $replacement = $user->display_name;
                 }
                 if ( $target == 'html' ) {
-                    $replacement = eme_esc_html( $replacement );
+                    $replacement = esc_html( $replacement );
                     $replacement = apply_filters( 'eme_general', $replacement );
                 } else {
                     $replacement = apply_filters( 'eme_text', $replacement );
@@ -786,7 +786,7 @@ function eme_replace_people_placeholders( $format, $person, $target = 'html', $l
             $my_nonce = wp_create_nonce( 'eme_frontend' );
             $replacement = $person['random_id']."&eme_frontend_nonce=$my_nonce";
             if ( $target == 'html' ) {
-                $replacement = eme_esc_html( $replacement );
+                $replacement = esc_html( $replacement );
                 $replacement = apply_filters( 'eme_general', $replacement );
             } else {
                 $replacement = apply_filters( 'eme_text', $replacement );
@@ -808,7 +808,7 @@ function eme_replace_people_placeholders( $format, $person, $target = 'html', $l
                     foreach ( $familymember_person_ids as $familymember_person_id ) {
                         $related_person = eme_get_person( $familymember_person_id );
                         if ( $related_person ) {
-                            $replacement .= "<tr class='eme_dyndata_row'><td style='border: 1px solid black;padding: 5px;' class='eme_dyndata_column_left'>" . eme_esc_html( eme_format_full_name( $related_person['firstname'], $related_person['lastname'], $related_person['email'] ) ) . "</td><td style='border: 1px solid black;padding: 5px;' class='eme_dyndata_column_right'>" . eme_esc_html( $related_person['email'] ) . '</td></tr>';
+                            $replacement .= "<tr class='eme_dyndata_row'><td style='border: 1px solid black;padding: 5px;' class='eme_dyndata_column_left'>" . esc_html( eme_format_full_name( $related_person['firstname'], $related_person['lastname'], $related_person['email'] ) ) . "</td><td style='border: 1px solid black;padding: 5px;' class='eme_dyndata_column_right'>" . esc_html( $related_person['email'] ) . '</td></tr>';
                         }
                     }
                     $replacement .= '</table>';
@@ -824,7 +824,7 @@ function eme_replace_people_placeholders( $format, $person, $target = 'html', $l
                 $replacement = "";
             }
             if ( $need_escape ) {
-                $replacement = eme_esc_html( preg_replace( '/\n|\r/', '', $replacement ) );
+                $replacement = esc_html( preg_replace( '/\n|\r/', '', $replacement ) );
             }
             if ( $need_urlencode ) {
                 $replacement = rawurlencode( $replacement );
@@ -911,7 +911,7 @@ function eme_import_csv_people() {
             // if email empty: at least lastname is needed
             if ( empty($line['email'] ) && !isset( $line['lastname'] ) ) {
                 ++$errors;
-                $error_msg .= '<br>' . eme_esc_html( sprintf( __( 'Not imported (both email and lastname are empty): %s', 'events-made-easy' ), implode( ',', $row ) ) );
+                $error_msg .= '<br>' . esc_html( sprintf( __( 'Not imported (both email and lastname are empty): %s', 'events-made-easy' ), implode( ',', $row ) ) );
                 continue;
             }
             // also allow empty firstname
@@ -923,7 +923,7 @@ function eme_import_csv_people() {
             }
             if ( ! empty( $line['email'] ) && ! eme_is_email( $line['email'] ) ) {
                 ++$errors;
-                $error_msg .= '<br>' . eme_esc_html( sprintf( __( 'Not imported (field %s not valid): %s', 'events-made-easy' ), 'email', implode( ',', $row ) ) );
+                $error_msg .= '<br>' . esc_html( sprintf( __( 'Not imported (field %s not valid): %s', 'events-made-easy' ), 'email', implode( ',', $row ) ) );
                 continue;
             }
 
@@ -949,10 +949,10 @@ function eme_import_csv_people() {
                 $person_id = eme_db_update_person( $person['person_id'], $line );
                 if ( $person_id ) {
                     ++$updated;
-                    $updated_msg .= '<br>' . eme_esc_html( sprintf( __( 'Updated person %d: %s', 'events-made-easy' ), $person_id, implode( ',', $row ) ) );
+                    $updated_msg .= '<br>' . esc_html( sprintf( __( 'Updated person %d: %s', 'events-made-easy' ), $person_id, implode( ',', $row ) ) );
                 } else {
                     ++$errors;
-                    $error_msg .= '<br>' . eme_esc_html( sprintf( __( 'Not imported (problem updating the person in the db): %s', 'events-made-easy' ), implode( ',', $row ) ) );
+                    $error_msg .= '<br>' . esc_html( sprintf( __( 'Not imported (problem updating the person in the db): %s', 'events-made-easy' ), implode( ',', $row ) ) );
                 }
             } else {
                 $person_id = eme_db_insert_person( $line );
@@ -960,7 +960,7 @@ function eme_import_csv_people() {
                     ++$inserted;
                 } else {
                     ++$errors;
-                    $error_msg .= '<br>' . eme_esc_html( sprintf( __( 'Not imported (problem inserting the person in the db): %s', 'events-made-easy' ), implode( ',', $row ) ) );
+                    $error_msg .= '<br>' . esc_html( sprintf( __( 'Not imported (problem inserting the person in the db): %s', 'events-made-easy' ), implode( ',', $row ) ) );
                 }
             }
             if ( $person_id ) {
@@ -1390,7 +1390,7 @@ function eme_csv_booking_report( $event_id ) {
         }
         if ( ! empty( $booking['pg'] ) ) {
             if ( isset( $pgs[ $booking['pg'] ] ) ) {
-                $line[] = eme_esc_html( $pgs[ $booking['pg'] ] );
+                $line[] = esc_html( $pgs[ $booking['pg'] ] );
             } else {
                 $line[]  = '';
             }
@@ -1868,9 +1868,9 @@ function eme_person_verify_layout() {
                 print '<td>' . $membership_names . '</td>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- pre-escaped HTML from eme_get_linked_activemembership_names_by_personid()
                 $future_bookings = eme_get_bookings_by_person_id( $person_id, "future" );
                 if (!empty($future_bookings)) {
-                    print "<td>".esc_html__('Yes','events_made_easy')."</td>";
+                    print "<td>".esc_html__('Yes','events-made-easy')."</td>";
                 } else {
-                    print "<td>".esc_html__('No','events_made_easy')."</td>";
+                    print "<td>".esc_html__('No','events-made-easy')."</td>";
                 }
                 print '</tr>';
             }
@@ -1911,9 +1911,9 @@ function eme_person_verify_layout() {
                 print '<td>' . $membership_names . '</td>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- pre-escaped HTML from eme_get_linked_activemembership_names_by_personid()
                 $future_bookings = eme_get_bookings_by_person_id( $person_id, "future" );
                 if (!empty($future_bookings)) {
-                    print "<td>".esc_html__('Yes','events_made_easy')."</td>";
+                    print "<td>".esc_html__('Yes','events-made-easy')."</td>";
                 } else {
-                    print "<td>".esc_html__('No','events_made_easy')."</td>";
+                    print "<td>".esc_html__('No','events-made-easy')."</td>";
                 }
                 print '</tr>';
             }
@@ -1954,9 +1954,9 @@ function eme_person_verify_layout() {
                 print '<td>' . $membership_names . '</td>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- pre-escaped HTML from eme_get_linked_activemembership_names_by_personid()
                 $future_bookings = eme_get_bookings_by_person_id( $person_id, "future" );
                 if (!empty($future_bookings)) {
-                    print "<td>".esc_html__('Yes','events_made_easy')."</td>";
+                    print "<td>".esc_html__('Yes','events-made-easy')."</td>";
                 } else {
-                    print "<td>".esc_html__('No','events_made_easy')."</td>";
+                    print "<td>".esc_html__('No','events-made-easy')."</td>";
                 }
                 print '</tr>';
             }
@@ -2174,7 +2174,7 @@ function eme_render_people_searchfields( $limit_to_group = 0, $group_to_edit = [
             $value = '';
         }
         $label = __( 'Custom fields to filter on', 'events-made-easy' );
-        $extra_attributes = 'aria-label="' . eme_esc_html( $label ) . '" data-placeholder="' . eme_esc_html( $label ) . '"';
+        $extra_attributes = 'aria-label="' . esc_html( $label ) . '" data-placeholder="' . esc_html( $label ) . '"';
         echo eme_ui_multiselect_key_value( $value, 'search_customfieldids', $formfields_searchable, 'field_id', 'field_name', 5, '', 0, 'eme_snapselect', $extra_attributes, 1, id_prefix: $id_prefix ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_multiselect_key_value()
         if ( $edit_group ) {
             echo '</td></tr><tr><td>' . esc_html__( 'Exact custom field search match', 'events-made-easy' ) . '</td><td>';
@@ -2522,7 +2522,7 @@ function eme_person_edit_layout( $person_id = 0, $message = '' ) {
 <?php
     $preselected_option = '';
     if ( ! empty( $related_person ) ) {
-        $preselected_text   = eme_esc_html( eme_format_full_name( $related_person['firstname'], $related_person['lastname'], $related_person['email'] ) );
+        $preselected_text   = esc_html( eme_format_full_name( $related_person['firstname'], $related_person['lastname'], $related_person['email'] ) );
         $preselected_option = '<option value="' . intval( $person['related_person_id'] ) . '" selected>' . $preselected_text . '</option>';
     }
 ?>
@@ -5228,16 +5228,16 @@ function eme_ajax_people_autocomplete( $no_wp_die = 0, $wp_membership_required =
         $persons = eme_get_persons( '', $search );
         foreach ( $persons as $item ) {
             $record              = [];
-            $record['lastname']  = eme_esc_html( $item['lastname'] );
-            $record['firstname'] = eme_esc_html( $item['firstname'] );
-            $record['address1']  = eme_esc_html( $item['address1'] );
-            $record['address2']  = eme_esc_html( $item['address2'] );
-            $record['city']      = eme_esc_html( $item['city'] );
-            $record['zip']       = eme_esc_html( $item['zip'] );
-            $record['state']     = eme_esc_html( eme_get_state_name( $item['state_code'], $item['country_code'] ) );
-            $record['country']   = eme_esc_html( eme_get_country_name( $item['country_code'] ) );
-            $record['email']     = eme_esc_html( $item['email'] );
-            $record['phone']     = eme_esc_html( $item['phone'] );
+            $record['lastname']  = esc_html( $item['lastname'] );
+            $record['firstname'] = esc_html( $item['firstname'] );
+            $record['address1']  = esc_html( $item['address1'] );
+            $record['address2']  = esc_html( $item['address2'] );
+            $record['city']      = esc_html( $item['city'] );
+            $record['zip']       = esc_html( $item['zip'] );
+            $record['state']     = esc_html( eme_get_state_name( $item['state_code'], $item['country_code'] ) );
+            $record['country']   = esc_html( eme_get_country_name( $item['country_code'] ) );
+            $record['email']     = esc_html( $item['email'] );
+            $record['phone']     = esc_html( $item['phone'] );
             $record['person_id'] = intval( $item['person_id'] );
             $record['wp_id']     = intval( $item['wp_id'] );
             $record['massmail']  = intval( $item['massmail'] );
@@ -5254,20 +5254,20 @@ function eme_ajax_people_autocomplete( $no_wp_die = 0, $wp_membership_required =
         $wp_users = eme_get_wp_users( search: $lastname, wp_ids_to_exclude: $wp_ids_seen );
         foreach ( $wp_users as $wp_user ) {
             $record             = [];
-            $phone              = eme_esc_html( eme_get_user_phone( $wp_user->ID ) );
-            $record['lastname'] = eme_esc_html( $wp_user->user_lastname );
+            $phone              = esc_html( eme_get_user_phone( $wp_user->ID ) );
+            $record['lastname'] = esc_html( $wp_user->user_lastname );
             if ( empty( $record['lastname'] ) ) {
-                $record['lastname'] = eme_esc_html( $wp_user->display_name );
+                $record['lastname'] = esc_html( $wp_user->display_name );
             }
-            $record['firstname'] = eme_esc_html( $wp_user->user_firstname );
-            $record['email']     = eme_esc_html( $wp_user->user_email );
+            $record['firstname'] = esc_html( $wp_user->user_firstname );
+            $record['email']     = esc_html( $wp_user->user_email );
             $record['address1']  = '';
             $record['address2']  = '';
             $record['city']      = '';
             $record['zip']       = '';
             $record['state']     = '';
             $record['country']   = '';
-            $record['phone']     = eme_esc_html( $phone );
+            $record['phone']     = esc_html( $phone );
             $record['wp_id']     = intval( $wp_user->ID );
             $record['massmail']  = 1;
             $record['gdpr']      = 1;
@@ -5320,7 +5320,7 @@ function eme_ajax_people_list( ) {
         $record['people.person_id'] = $item['person_id'];
         if ( $item['related_person_id'] ) {
             $related_person              = eme_get_person( $item['related_person_id'] );
-            $record['people.related_to'] = "<a href='" . esc_url( admin_url( 'admin.php?page=eme-people&eme_admin_action=edit_person&person_id=' . $item['related_person_id'] ) ) . "' title='" . esc_attr__( 'Edit person', 'events-made-easy' ) . "'>" . eme_esc_html( $related_person['lastname'] . ' ' . $related_person['firstname'] ) . '</a>';
+            $record['people.related_to'] = "<a href='" . esc_url( admin_url( 'admin.php?page=eme-people&eme_admin_action=edit_person&person_id=' . $item['related_person_id'] ) ) . "' title='" . esc_attr__( 'Edit person', 'events-made-easy' ) . "'>" . esc_html( $related_person['lastname'] . ' ' . $related_person['firstname'] ) . '</a>';
             $familytext                  = esc_html__( '(family member)', 'events-made-easy' );
         } else {
             $record['people.related_to'] = '';
@@ -5328,40 +5328,40 @@ function eme_ajax_people_list( ) {
         }
 
         //$owner_user_info = get_userdata($item['wp_id']);
-        //$record['people.wp_id'] = eme_esc_html($owner_user_info->display_name);
+        //$record['people.wp_id'] = esc_html($owner_user_info->display_name);
         if ( $item['wp_id'] && isset( $wp_users[ $item['wp_id'] ] ) ) {
-            $record['people.wp_user'] = eme_esc_html( $wp_users[ $item['wp_id'] ] );
+            $record['people.wp_user'] = esc_html( $wp_users[ $item['wp_id'] ] );
         } else {
             $record['people.wp_user'] = '';
         }
-        $record['people.lastname']   = "<a href='" . esc_url( admin_url( 'admin.php?page=eme-people&eme_admin_action=edit_person&person_id=' . $item['person_id'] ) ) . "' title='" . esc_attr__( 'Edit person', 'events-made-easy' ) . "'>" . eme_esc_html( $item['lastname'] ) . '</a> ' . $familytext;
-        $record['people.firstname']  = "<a href='" . esc_url( admin_url( 'admin.php?page=eme-people&eme_admin_action=edit_person&person_id=' . $item['person_id'] ) ) . "' title='" . esc_attr__( 'Edit person', 'events-made-easy' ) . "'>" . eme_esc_html( $item['firstname'] ) . '</a> ' . $familytext;
-        $record['people.email']      = "<a href='" . esc_url( admin_url( 'admin.php?page=eme-people&eme_admin_action=edit_person&person_id=' . $item['person_id'] ) ) . "' title='" . esc_attr__( 'Edit person', 'events-made-easy' ) . "'>" . eme_esc_html( $item['email'] ) . '</a> ' . $familytext;
-        $record['people.phone']      = eme_esc_html( $item['phone'] );
+        $record['people.lastname']   = "<a href='" . esc_url( admin_url( 'admin.php?page=eme-people&eme_admin_action=edit_person&person_id=' . $item['person_id'] ) ) . "' title='" . esc_attr__( 'Edit person', 'events-made-easy' ) . "'>" . esc_html( $item['lastname'] ) . '</a> ' . $familytext;
+        $record['people.firstname']  = "<a href='" . esc_url( admin_url( 'admin.php?page=eme-people&eme_admin_action=edit_person&person_id=' . $item['person_id'] ) ) . "' title='" . esc_attr__( 'Edit person', 'events-made-easy' ) . "'>" . esc_html( $item['firstname'] ) . '</a> ' . $familytext;
+        $record['people.email']      = "<a href='" . esc_url( admin_url( 'admin.php?page=eme-people&eme_admin_action=edit_person&person_id=' . $item['person_id'] ) ) . "' title='" . esc_attr__( 'Edit person', 'events-made-easy' ) . "'>" . esc_html( $item['email'] ) . '</a> ' . $familytext;
+        $record['people.phone']      = esc_html( $item['phone'] );
         $record['people.birthdate']  = eme_localized_date( $item['birthdate'], EME_TIMEZONE, 1 );
         $record['people.bd_email']   = $item['bd_email'] ? esc_html__( 'Yes', 'events-made-easy' ) : esc_html__( 'No', 'events-made-easy' );
-        $record['people.birthplace'] = eme_esc_html( $item['birthplace'] );
-        $record['people.address1']   = eme_esc_html( $item['address1'] );
-        $record['people.address2']   = eme_esc_html( $item['address2'] );
-        $record['people.city']       = eme_esc_html( $item['city'] );
-        $record['people.zip']        = eme_esc_html( $item['zip'] );
-        $record['people.lang']       = eme_esc_html( $item['lang'] );
+        $record['people.birthplace'] = esc_html( $item['birthplace'] );
+        $record['people.address1']   = esc_html( $item['address1'] );
+        $record['people.address2']   = esc_html( $item['address2'] );
+        $record['people.city']       = esc_html( $item['city'] );
+        $record['people.zip']        = esc_html( $item['zip'] );
+        $record['people.lang']       = esc_html( $item['lang'] );
         if ( $item['state_code'] ) {
-            $record['people.state'] = eme_esc_html( eme_get_state_name( $item['state_code'], $item['country_code'] ) );
+            $record['people.state'] = esc_html( eme_get_state_name( $item['state_code'], $item['country_code'] ) );
         } elseif ( isset( $item['state'] ) ) {
-            $record['people.state'] = eme_esc_html( $item['state'] );
+            $record['people.state'] = esc_html( $item['state'] );
         }
         if ( $item['country_code'] ) {
-            $record['people.country'] = eme_esc_html( eme_get_country_name( $item['country_code'] ) );
+            $record['people.country'] = esc_html( eme_get_country_name( $item['country_code'] ) );
         } elseif ( isset( $item['country'] ) ) {
-            $record['people.country'] = eme_esc_html( $item['country'] );
+            $record['people.country'] = esc_html( $item['country'] );
         }
         $record['people.massmail']      = $item['massmail'] ? esc_html__( 'Yes', 'events-made-easy' ) : esc_html__( 'No', 'events-made-easy' );
         $record['people.gdpr']          = $item['gdpr'] ? esc_html__( 'Yes', 'events-made-easy' ) : esc_html__( 'No', 'events-made-easy' );
-        $record['people.gdpr_date']     = eme_esc_html( $item['gdpr_date'] );
+        $record['people.gdpr_date']     = esc_html( $item['gdpr_date'] );
         $record['people.creation_date'] = eme_localized_datetime( $item['creation_date'], EME_TIMEZONE, 1 );
         $record['people.modif_date']    = eme_localized_datetime( $item['modif_date'], EME_TIMEZONE, 1 );
-        $record['people.groups']        = join( ', ', eme_esc_html( eme_get_persongroup_names( $item['person_id'] ) ) );
+        $record['people.groups']        = join( ', ', array_map( 'esc_html', eme_get_persongroup_names( $item['person_id'] ) ) );
         $record['people.memberships']   = eme_get_activemembership_names_by_personid( $item['person_id'] );
         $answers = eme_get_person_answers( $item['person_id'] );
         foreach ( $formfields as $formfield ) {
@@ -5429,11 +5429,11 @@ function eme_ajax_groups_list() {
         $record['group_id'] = $group['group_id'];
         $record['public']   = $group['public'] ? esc_html__( 'Yes', 'events-made-easy' ) : esc_html__( 'No', 'events-made-easy' );
         if ( current_user_can( get_option( 'eme_cap_edit_people' ) ) ) {
-            $record['name'] = "<a href='" . esc_url( admin_url( 'admin.php?page=eme-groups&eme_admin_action=edit_group&group_id=' . $group['group_id'] ) ) . "' title='" . esc_attr__( 'Edit group', 'events-made-easy' ) . "'>" . eme_esc_html( $group['name'] ) . '</a>';
+            $record['name'] = "<a href='" . esc_url( admin_url( 'admin.php?page=eme-groups&eme_admin_action=edit_group&group_id=' . $group['group_id'] ) ) . "' title='" . esc_attr__( 'Edit group', 'events-made-easy' ) . "'>" . esc_html( $group['name'] ) . '</a>';
         } else {
-            $record['name'] = eme_esc_html( $group['name'] );
+            $record['name'] = esc_html( $group['name'] );
         }
-        $record['description'] = eme_esc_html( $group['description'] );
+        $record['description'] = esc_html( $group['description'] );
         if ( $group['type'] == 'dynamic_people' ) {
             $record['groupcount'] = esc_html__( 'Dynamic group of people', 'events-made-easy' );
             if ( ! empty( $group['search_terms'] ) ) {
@@ -5506,9 +5506,9 @@ function eme_ajax_chooseperson_snapselect() {
         $records[] = [
             'id'        => intval( $person['person_id'] ),
             'text'      => eme_format_full_name( $person['firstname'], $person['lastname'], $person['email'] ) . ' (' . $person['email'] . ')',
-            'firstname' => eme_esc_html( $person['firstname'] ),
-            'lastname'  => eme_esc_html( $person['lastname'] ),
-            'email'     => eme_esc_html( $person['email'] ),
+            'firstname' => esc_html( $person['firstname'] ),
+            'lastname'  => esc_html( $person['lastname'] ),
+            'email'     => esc_html( $person['email'] ),
             'wpid'      => intval( $person['wp_id'] ),
         ];
     }

--- a/eme-rsvp.php
+++ b/eme-rsvp.php
@@ -244,7 +244,7 @@ function eme_add_multibooking_form( $events, $template_id_header = 0, $template_
             if ( $is_multibooking && $only_one_event ) {
                 if ( $simple ) {
                     $value      = eme_replace_event_placeholders( $event_booking_format_entry, $tmp_event );
-                    $form_html .= "<input type='radio' id='eme_event_{$event_id}' name='eme_event_ids[]' value='$event_id'> <label for='eme_event_{$event_id}'>" . eme_esc_html( $value ) . '</label>';
+                    $form_html .= "<input type='radio' id='eme_event_{$event_id}' name='eme_event_ids[]' value='$event_id'> <label for='eme_event_{$event_id}'>" . esc_html( $value ) . '</label>';
                 } else {
                     $form_html .= "<option value='$event_id'>" . eme_replace_event_placeholders( $event_booking_format_entry, $tmp_event ) . '</option>';
                 }
@@ -253,7 +253,7 @@ function eme_add_multibooking_form( $events, $template_id_header = 0, $template_
                     $form_html .= "<input type='hidden' name='eme_event_ids[]' value='$event_id'>";
                 } else {
                     $value      = eme_replace_event_placeholders( $event_booking_format_entry, $tmp_event );
-                    $form_html .= "<input type='checkbox' name='eme_event_ids[]' id='eme_event_ids_{$event_id}' value='$event_id'> <label for='eme_event_ids_{$event_id}'>" . eme_esc_html( $value ) . '</label>';
+                    $form_html .= "<input type='checkbox' name='eme_event_ids[]' id='eme_event_ids_{$event_id}' value='$event_id'> <label for='eme_event_ids_{$event_id}'>" . esc_html( $value ) . '</label>';
                 }
             } else {
                 $form_html .= "<input type='hidden' name='eme_event_ids[]' value='$event_id'>";
@@ -3569,7 +3569,7 @@ function eme_replace_booking_placeholders( $format, $event, $booking, $is_multib
         if ( preg_match( '/#_(RESP)?COMMENT/', $result ) ) {
             $replacement = $booking['booking_comment'];
             if ( $target == 'html' ) {
-                $replacement = eme_esc_html( $replacement );
+                $replacement = esc_html( $replacement );
                 $replacement = apply_filters( 'eme_general', $replacement );
             } else {
                 $replacement = apply_filters( 'eme_text', $replacement );
@@ -3579,7 +3579,7 @@ function eme_replace_booking_placeholders( $format, $event, $booking, $is_multib
                 $replacement = eme_sanitize_request( $_POST['eme_cancelcomment'] );
             }
             if ( $target == 'html' ) {
-                $replacement = eme_esc_html( $replacement );
+                $replacement = esc_html( $replacement );
                 $replacement = apply_filters( 'eme_general', $replacement );
             } else {
                 $replacement = apply_filters( 'eme_text', $replacement );
@@ -3634,7 +3634,7 @@ function eme_replace_booking_placeholders( $format, $event, $booking, $is_multib
                                 $old_grouping  = $grouping;
                                 $old_occurence = $occurence;
                             }
-                            $replacement .= "<tr class='eme_dyndata_row'><td style='border: 1px solid black;padding: 5px;' class='eme_dyndata_column_left'>" . eme_esc_html( $tmp_formfield['field_name'] ) . "</td><td style='border: 1px solid black;padding: 5px;' class='eme_dyndata_column_right'> " . eme_answer2readable( $answer['answer'], $tmp_formfield, 1, '<br>', $target ) . '</td></tr>';
+                            $replacement .= "<tr class='eme_dyndata_row'><td style='border: 1px solid black;padding: 5px;' class='eme_dyndata_column_left'>" . esc_html( $tmp_formfield['field_name'] ) . "</td><td style='border: 1px solid black;padding: 5px;' class='eme_dyndata_column_right'> " . eme_answer2readable( $answer['answer'], $tmp_formfield, 1, '<br>', $target ) . '</td></tr>';
                         } else {
                             $replacement .= $tmp_formfield['field_name'] . ': ' . eme_answer2readable( $answer['answer'], $tmp_formfield, 1, '||', $target ) . "\n";
                         }
@@ -3725,7 +3725,7 @@ function eme_replace_booking_placeholders( $format, $event, $booking, $is_multib
                 foreach ( $applied_discountids as $discount_id ) {
                     $discount = eme_get_discount( $discount_id );
                     if ( $discount && isset( $discount['name'] ) ) {
-                        $discount_names[] = eme_esc_html( $discount['name'] );
+                        $discount_names[] = esc_html( $discount['name'] );
                     } else {
                         $discount_names[] = sprintf( __( 'Applied discount %d no longer exists', 'events-made-easy' ), $discount_id );
                     }
@@ -4104,7 +4104,7 @@ function eme_replace_booking_placeholders( $format, $event, $booking, $is_multib
 
         if ( $found ) {
             if ( $need_escape ) {
-                $replacement = eme_esc_html( preg_replace( '/\n|\r/', '', $replacement ) );
+                $replacement = esc_html( preg_replace( '/\n|\r/', '', $replacement ) );
             }
             $format         = substr_replace( $format, $replacement, $orig_result_needle, $orig_result_length );
             $needle_offset += $orig_result_length - strlen( $replacement );
@@ -4170,7 +4170,7 @@ function eme_replace_attendees_placeholders( $format, $event, $person, $target =
         }
         if ( $found ) {
             if ( $need_escape ) {
-                $replacement = eme_esc_html( preg_replace( '/\n|\r/', '', $replacement ) );
+                $replacement = esc_html( preg_replace( '/\n|\r/', '', $replacement ) );
             }
             $format         = substr_replace( $format, $replacement, $orig_result_needle, $orig_result_length );
             $needle_offset += $orig_result_length - strlen( $replacement );
@@ -5204,24 +5204,24 @@ function eme_import_csv_payments() {
 
             if ( empty( $payment_id ) ) {
                 ++$ignored;
-                $ignored_msg .= '<br>' . eme_esc_html( sprintf( __( 'No linked payment found: %s', 'events-made-easy' ), implode( $delimiter, $row ) ) );
+                $ignored_msg .= '<br>' . esc_html( sprintf( __( 'No linked payment found: %s', 'events-made-easy' ), implode( $delimiter, $row ) ) );
             } elseif ( ! eme_is_date( $payment_date ) ) {
                 ++$errors;
-                $error_msg .= '<br>' . eme_esc_html( sprintf( __( 'Field %s not valid: %s', 'events-made-easy' ), 'payment_date', implode( $delimiter, $row ) ) );
+                $error_msg .= '<br>' . esc_html( sprintf( __( 'Field %s not valid: %s', 'events-made-easy' ), 'payment_date', implode( $delimiter, $row ) ) );
             } elseif ( empty( $amount ) ) {
                 ++$errors;
-                $error_msg .= '<br>' . eme_esc_html( sprintf( __( 'Field %s not valid: %s', 'events-made-easy' ), 'amount', implode( $delimiter, $row ) ) );
+                $error_msg .= '<br>' . esc_html( sprintf( __( 'Field %s not valid: %s', 'events-made-easy' ), 'amount', implode( $delimiter, $row ) ) );
             } else {
                 $to_pay = eme_get_payment_price( $payment_id );
                 if ( $to_pay == 0 ) {
                     ++$ignored;
-                    $ignored_msg .= '<br>' . eme_esc_html( sprintf( __( 'Already paid in full: %s', 'events-made-easy' ), implode( $delimiter, $row ) ) );
+                    $ignored_msg .= '<br>' . esc_html( sprintf( __( 'Already paid in full: %s', 'events-made-easy' ), implode( $delimiter, $row ) ) );
                 } elseif ( $to_pay == $amount ) {
                     ++$updated;
                     eme_mark_payment_paid( $payment_id, 0 );
                 } else {
                     ++$errors;
-                    $error_msg .= '<br>' . eme_esc_html( sprintf( __( 'Amount paid (%s) is not equal to the expected amount (%s): %s', 'events-made-easy' ), $amount, $to_pay, implode( $delimiter, $row ) ) );
+                    $error_msg .= '<br>' . esc_html( sprintf( __( 'Amount paid (%s) is not equal to the expected amount (%s): %s', 'events-made-easy' ), $amount, $to_pay, implode( $delimiter, $row ) ) );
                 }
             }
         }
@@ -5451,7 +5451,7 @@ function eme_registration_seats_form_table( $pending = 0 ) {
     <span id="span_partialpayment" class="eme-hidden">
 <?php
     esc_html_e( 'Partial payment amount', 'events-made-easy' );
-    $label = eme_esc_html('Partial payment amount', 'events-made-easy' );
+    $label = esc_html__('Partial payment amount', 'events-made-easy' );
     echo eme_ui_number( 0, 'partial_amount', 0, '', 'aria-label="' . $label . '"' ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML from eme_ui_number()
 ?>
     </span>
@@ -5930,14 +5930,14 @@ function eme_ajax_bookings_list() {
             if ( empty( $person ) ) {
                 $person = eme_new_person();
             }
-            $person_info_shown  = eme_esc_html( eme_format_full_name( $person['firstname'], $person['lastname'], $person['email'] ) );
-            $person_info_shown .= ' (' . eme_esc_html( $person['email'] ) . ')';
+            $person_info_shown  = esc_html( eme_format_full_name( $person['firstname'], $person['lastname'], $person['email'] ) );
+            $person_info_shown .= ' (' . esc_html( $person['email'] ) . ')';
             if ( ! empty( $person['wp_id'] ) && isset( $wp_users[ $person['wp_id'] ] ) ) {
-                $line['wp_user'] = eme_esc_html( $wp_users[ $person['wp_id'] ] );
+                $line['wp_user'] = esc_html( $wp_users[ $person['wp_id'] ] );
             } else {
                 $line['wp_user'] = '';
             }
-            $line['booker'] = "<a href='" . esc_url( admin_url( 'admin.php?page=eme-people&eme_admin_action=edit_person&person_id=' . $person['person_id'] ) ) . "' title='" . esc_attr__( 'Click the name of the booker in order to see and/or edit the details of the booker.', 'events-made-easy' ) . "'>" . eme_esc_html( $person_info_shown ) . '</a>';
+            $line['booker'] = "<a href='" . esc_url( admin_url( 'admin.php?page=eme-people&eme_admin_action=edit_person&person_id=' . $person['person_id'] ) ) . "' title='" . esc_attr__( 'Click the name of the booker in order to see and/or edit the details of the booker.', 'events-made-easy' ) . "'>" . $person_info_shown . '</a>';
             $line['person_id'] = $booking['person_id'];
         } else {
             $line['booker']  = __( 'Anonymous', 'events-made-easy' );
@@ -6111,7 +6111,7 @@ function eme_ajax_bookings_list() {
         }
 
         $line['creation_date'] = esc_html($localized_booking_datetime);
-        $line['payment_id']    = eme_esc_html( $booking['payment_id'] );
+        $line['payment_id']    = esc_html( $booking['payment_id'] );
         if ( !eme_is_empty_datetime( $booking['payment_date'] ) ) {
             $line['payment_date'] = esc_html($localized_payment_datetime);
         } else {
@@ -6138,7 +6138,7 @@ function eme_ajax_bookings_list() {
         $line['discount']   = eme_localized_price( $booking['discount'], $event['currency'] );
         // dcodes_used is still eme_serialized here
         $line['dcodes_used']  = eme_esc_html( eme_unserialize( $booking['dcodes_used'] ) );
-        $line['unique_nbr']   = "<span title='" . esc_attr( sprintf( __( 'This is based on the payment ID of the booking: %d', 'events-made-easy' ), $booking ['payment_id'] ) ) . "'>" . eme_esc_html( eme_unique_nbr_formatted( $booking['unique_nbr'] ) ) . '</span>';
+        $line['unique_nbr']   = "<span title='" . esc_attr( sprintf( __( 'This is based on the payment ID of the booking: %d', 'events-made-easy' ), $booking ['payment_id'] ) ) . "'>" . esc_html( eme_unique_nbr_formatted( $booking['unique_nbr'] ) ) . '</span>';
         $line['booking_paid'] = $booking['booking_paid'] ? __( 'Yes', 'events-made-easy' ) : __( 'No', 'events-made-easy' );
         if ( empty( $booking['remaining'] ) && empty( $booking['received'] ) ) {
             $line['remaining'] = $line['totalprice'];
@@ -6148,7 +6148,7 @@ function eme_ajax_bookings_list() {
         $line['received'] = eme_convert_multi2br( eme_localized_price( $booking['received'], $event['currency'] ) );
         if ( ! empty( $booking['pg'] ) ) {
             if ( isset( $pgs[ $booking['pg'] ] ) ) {
-                $line['pg'] = eme_esc_html( $pgs[ $booking['pg'] ] );
+                $line['pg'] = esc_html( $pgs[ $booking['pg'] ] );
             } else {
                 $line['pg'] = 'UNKNOWN';
             }
@@ -6159,9 +6159,9 @@ function eme_ajax_bookings_list() {
             $line['pg'] = '';
         }
 
-        $line['pg_pid']          = eme_esc_html( $booking['pg_pid'] );
+        $line['pg_pid']          = esc_html( $booking['pg_pid'] );
         $line['attend_count']    = intval( $booking['attend_count'] );
-        $line['booking_comment'] = eme_esc_html( $booking['booking_comment'] );
+        $line['booking_comment'] = esc_html( $booking['booking_comment'] );
         foreach ( $formfields as $formfield ) {
             foreach ( $answers as $answer ) {
                 if ( $answer['field_id'] == $formfield['field_id'] && $answer['answer'] != '' ) {

--- a/eme-tasks.php
+++ b/eme-tasks.php
@@ -1002,7 +1002,7 @@ function eme_meta_box_div_event_tasks( $event, $edit_recurrence = 0 ) {
 }
 
 function eme_meta_box_div_event_task_settings( $event ) {
-    $eme_prop_task_reminder_days         = eme_esc_html( $event['event_properties']['task_reminder_days'] );
+    $eme_prop_task_reminder_days         = esc_html( $event['event_properties']['task_reminder_days'] );
     $extra_attributes                    = 'data-placeholder="' . esc_attr__( 'Select one or more groups', 'events-made-easy' ) . '"';
     ?>
     <div id='div_event_task_settings'>
@@ -1710,7 +1710,7 @@ function eme_replace_task_placeholders( $format, $task, $event, $target = 'html'
         if ( preg_match( '/#_TASKNAME$/', $result ) ) {
             $replacement = eme_translate( $task['name'], $lang );
             if ( $target == 'html' ) {
-                $replacement = eme_esc_html( $replacement );
+                $replacement = esc_html( $replacement );
                 $replacement = apply_filters( 'eme_general', $replacement );
             } else {
                 $replacement = apply_filters( 'eme_text', $replacement );
@@ -1718,7 +1718,7 @@ function eme_replace_task_placeholders( $format, $task, $event, $target = 'html'
         } elseif ( preg_match( '/#_TASKDESCRIPTION$/', $result ) ) {
             $replacement = eme_translate( $task['description'], $lang );
             if ( $target == 'html' ) {
-                $replacement = eme_esc_html( $replacement );
+                $replacement = esc_html( $replacement );
                 $replacement = apply_filters( 'eme_general', $replacement );
             } else {
                 $replacement = apply_filters( 'eme_text', $replacement );
@@ -1760,7 +1760,7 @@ function eme_replace_task_placeholders( $format, $task, $event, $target = 'html'
 
         if ( $found ) {
             if ( $need_escape ) {
-                $replacement = eme_esc_html( preg_replace( '/\n|\r/', '', $replacement ) );
+                $replacement = esc_html( preg_replace( '/\n|\r/', '', $replacement ) );
             }
             $format         = substr_replace( $format, $replacement, $orig_result_needle, $orig_result_length );
             $needle_offset += $orig_result_length - strlen( $replacement );
@@ -1817,7 +1817,7 @@ function eme_replace_tasksignup_placeholders( $format, $signup, $person, $event,
         } elseif ( preg_match( '/#_(TASK)?COMMENT/', $result ) ) {
             $replacement = $signup['comment'];
             if ( $target == 'html' ) {
-                $replacement = eme_esc_html( $replacement );
+                $replacement = esc_html( $replacement );
                 $replacement = apply_filters( 'eme_general', $replacement );
             } else {
                 $replacement = apply_filters( 'eme_text', $replacement );
@@ -2153,8 +2153,8 @@ function eme_ajax_task_signups_list() {
             $row['event_name']  = "<strong><a href='" . esc_url( admin_url( 'admin.php?page=eme-manager&eme_admin_action=edit_event&event_id=' . $row['event_id'] ) ) . "' title='" . esc_attr__( 'Edit event', 'events-made-easy' ) . "'>" . esc_html( eme_translate( $row['event_name'] ) ) . '</a></strong><br>' . $localized_start_date . ' - ' . $localized_end_date;
             $csv_address = esc_url( admin_url( 'admin.php?page=eme-people&eme_admin_action=tasksignups_csv&event_id=' . $row['event_id'] ) );
             $row['event_name'] .= " (<a id='tasksignups_csv_" . $row['event_id'] . "' href='".esc_url($csv_address)."'>" . esc_html__( 'CSV export', 'events-made-easy' ) . '</a>)';
-            $row['task_name']   = eme_esc_html( $row['task_name'] );
-            $row['comment']     = nl2br(eme_esc_html( $row['comment'] ));
+            $row['task_name']   = esc_html( $row['task_name'] );
+            $row['comment']     = nl2br(esc_html( $row['comment'] ));
             $row['task_start']  = $localized_taskstart_date;
             $row['task_end']    = $localized_taskend_date;
             $row['signup_date'] = $localized_signup_date;
@@ -2163,7 +2163,7 @@ function eme_ajax_task_signups_list() {
             } else {
                 $row['signup_status'] = __('Pending', 'events-made-easy');
             }
-            $row['person_info'] = "<a href='" . esc_url( admin_url( 'admin.php?page=eme-people&eme_admin_action=edit_person&person_id=' . $row['person_id'] ) ) . "' title='" . esc_attr__( 'Edit person', 'events-made-easy' ) . "'>" . eme_esc_html( eme_format_full_name( $row['firstname'], $row['lastname'], $row['email'] ) ) . '</a>' . ' (' . eme_esc_html( $row['email'] ) . ')';
+            $row['person_info'] = "<a href='" . esc_url( admin_url( 'admin.php?page=eme-people&eme_admin_action=edit_person&person_id=' . $row['person_id'] ) ) . "' title='" . esc_attr__( 'Edit person', 'events-made-easy' ) . "'>" . esc_html( eme_format_full_name( $row['firstname'], $row['lastname'], $row['email'] ) ) . '</a>' . ' (' . esc_html( $row['email'] ) . ')';
 
             foreach ( $formfields as $formfield ) {
                 foreach ( $answers as $answer ) {

--- a/eme-todos.php
+++ b/eme-todos.php
@@ -248,7 +248,7 @@ function eme_email_todo($todo) {
 	$contact_email  = $contact->user_email;
         $contact_name   = $contact->display_name;
 
-	$contact_subject = __('Todo reminder for event #_EVENTNAME: ','events_made_easy').$todo['name'];
+	$contact_subject = __('Todo reminder for event #_EVENTNAME: ','events-made-easy').$todo['name'];
 	$contact_body = $todo['description'];
 	$contact_subject = eme_replace_event_placeholders($contact_subject, $event, 'text');
 	$contact_body = eme_replace_event_placeholders($contact_body, $event);

--- a/eme-translate.php
+++ b/eme-translate.php
@@ -96,7 +96,7 @@ function eme_trans_sanitize_html( $value, $lang = '' ) {
 }
 
 function eme_trans_esc_html( $value, $lang = '' ) {
-	return eme_esc_html( eme_translate( $value, $lang ) );
+	return esc_html( eme_translate( $value, $lang ) );
 }
 
 function eme_translate( $value, $lang = '', $use_wp_trans = 1 ) {

--- a/eme-ui-helpers.php
+++ b/eme-ui-helpers.php
@@ -18,9 +18,9 @@ function eme_option_items( $arr, $saved_value ) {
         } else {
             "$key" == $saved_value ? $selected = "selected='selected' " : $selected = '';
         }
-        $output .= "<option value='" . eme_esc_html( $key ) . "' $selected >" . eme_esc_html( $item ) . "</option>\n";
+        $output .= "<option value='" . esc_html( $key ) . "' $selected >" . esc_html( $item ) . "</option>\n";
     }
-    echo $output; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML built with eme_esc_html() in this function
+    echo $output; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML built with esc_html() in this function
 }
 
 function eme_checkbox_items( $name, $arr, $saved_values, $horizontal = true ) {
@@ -37,14 +37,14 @@ function eme_checkbox_items( $name, $arr, $saved_values, $horizontal = true ) {
             $checked = "checked='checked'";
         }
         $id = esc_attr( eme_get_field_id( $name, $key ));
-        $output .= "<input type='checkbox' name='$name' id='$id' value='" . eme_esc_html( $key ) . "' $checked>&nbsp;<label for='$id'>" . $item . '</label>';
+        $output .= "<input type='checkbox' name='$name' id='$id' value='" . esc_html( $key ) . "' $checked>&nbsp;<label for='$id'>" . $item . '</label>';
         if ( $horizontal ) {
             $output .= "&nbsp;";
         } else {
             $output .= "<br>\n";
         }
     }
-    echo $output; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML built with eme_esc_html() in this function
+    echo $output; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- trusted HTML built with esc_html() in this function
 }
 
 function eme_options_input_type( $title, $name, $description, $type = 'text', $option_value = false ) {
@@ -60,7 +60,7 @@ function eme_options_input_type( $title, $name, $description, $type = 'text', $o
     <tr style='vertical-align:top' id='<?php echo esc_attr( $name ); ?>_row'>
         <th scope="row"><label for='<?php echo esc_attr( $name ); ?>'><?php echo esc_html( $title ); ?></label></th>
         <td>
-<?php echo "<input $autocomplete name='" . esc_attr( $name ) . "' type='" . esc_attr( $type ) . "' id='" . esc_attr( $name ) . "' style='width: 95%;' value='" . eme_esc_html( $option_value ) . "' size='45'>"; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- $autocomplete is hardcoded
+<?php echo "<input $autocomplete name='" . esc_attr( $name ) . "' type='" . esc_attr( $type ) . "' id='" . esc_attr( $name ) . "' style='width: 95%;' value='" . esc_html( $option_value ) . "' size='45'>"; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- $autocomplete is hardcoded
 if ( ! empty( $description ) ) {
     echo '<br>' . wp_kses_post( $description );
 }
@@ -289,16 +289,16 @@ function eme_form_select( $option_value, $name, $id, $list, $add_empty_first = '
     foreach ( $list as $key => $value ) {
         if ( is_array( $value ) ) {
             $t_key   = $value[0];
-            $t_value = eme_esc_html( $value[1] );
+            $t_value = esc_html( $value[1] );
         } else {
             $t_key   = $key;
-            $t_value = eme_esc_html( $value );
+            $t_value = esc_html( $value );
         }
         if ( empty( $t_value ) && $t_value !== '0' ) {
             $t_value = '&nbsp;';
         }
         "$t_key" === "$option_value" ? $selected = "selected='selected' " : $selected = '';
-        $val                                    .= "<option value='" . eme_esc_html( $t_key ) . "' $selected>$t_value</option>";
+        $val                                    .= "<option value='" . esc_html( $t_key ) . "' $selected>$t_value</option>";
     }
     $val .= ' </select>';
     return $val;
@@ -325,7 +325,7 @@ function eme_ui_list( $option_value, $name, $list, $required = 0, $class = '', $
     $val = "<input list='$datalist_id' id='$name' name='$name' value='$option_value' $extra_attributes >";
     $val .= "<datalist id='$datalist_id'>";
     foreach ( $list as $key => $value ) {
-        $val .= "<option value='".eme_esc_html( $value )."'>";
+        $val .= "<option value='".esc_html( $value )."'>";
     }
     $val .= "</datalist>";
     return $val;
@@ -354,21 +354,21 @@ function eme_ui_select( $option_value, $name, $list, $add_empty_first = '', $req
     foreach ( $list as $key => $value ) {
         if ( is_array( $value ) ) {
             $t_key   = $value[0];
-            $t_value = eme_esc_html( $value[1] );
+            $t_value = esc_html( $value[1] );
         } else {
             $t_key   = $key;
-            $t_value = eme_esc_html( $value );
+            $t_value = esc_html( $value );
         }
         if ( empty( $t_value ) && $t_value !== '0' ) {
             $t_value = '&nbsp;';
         }
         if ( $t_key == 'BEGINOPTGROUP' ) {
-            $val .= "<optgroup label='" . eme_esc_html( $t_value ) . "'>";
+            $val .= "<optgroup label='" . esc_html( $t_value ) . "'>";
         } elseif ( $t_key == 'ENDOPTGROUP' ) {
             $val .= "</optgroup>";
         } else {
             "$t_key" === "$option_value" ? $selected = "selected='selected' " : $selected = '';
-            $val .= "<option value='" . eme_esc_html( $t_key ) . "' $selected>$t_value</option>";
+            $val .= "<option value='" . esc_html( $t_key ) . "' $selected>$t_value</option>";
         }
     }
     $val .= ' </select>';
@@ -396,12 +396,12 @@ function eme_ui_select_inverted( $option_value, $name, $list, $add_empty_first =
         $val .= "<option value=''>$add_empty_first</option>";
     }
     foreach ( $list as $value => $key ) {
-        $t_value = eme_esc_html( $value );
+        $t_value = esc_html( $value );
         if ( empty( $t_value ) ) {
             $t_value = '&nbsp;';
         }
         "$key" === "$option_value" ? $selected = "selected='selected' " : $selected = '';
-        $val                                  .= "<option value='" . eme_esc_html( $key ) . "' $selected>$t_value</option>";
+        $val                                  .= "<option value='" . esc_html( $key ) . "' $selected>$t_value</option>";
     }
     $val .= ' </select>';
     return $val;
@@ -425,16 +425,16 @@ function eme_ui_select_key_value( $option_value, $name, $list, $key, $value, $ad
 
     $val = "<select id='$name' name='$name' $extra_attributes >";
     if ( $add_empty_first != '' ) {
-        $val .= "<option value=''>" . eme_esc_html( $add_empty_first ) . '</option>';
+        $val .= "<option value=''>" . esc_html( $add_empty_first ) . '</option>';
     }
     foreach ( $list as $line ) {
         $t_key   = $line[ $key ];
-        $t_value = eme_esc_html( $line[ $value ] );
+        $t_value = esc_html( $line[ $value ] );
         if ( empty( $t_value ) && $t_value !== '0' ) {
             $t_value = '&nbsp;';
         }
         "$t_key" == $option_value ? $selected = "selected='selected' " : $selected = '';
-        $val .= "<option value='" . eme_esc_html( $t_key ) . "' $selected>$t_value</option>";
+        $val .= "<option value='" . esc_html( $t_key ) . "' $selected>$t_value</option>";
     }
     $val .= ' </select>';
     return $val;
@@ -458,19 +458,19 @@ function eme_ui_multiselect( $option_value, $name, $list, $size = 5, $add_empty_
     $val = "<select $extra_attributes multiple='multiple' name='{$name}[]' id='{$id_prefix}{$name}' size='$size'>";
     if ( $add_empty_first != '' ) {
         if ($disable_first_option) {
-            $val .= "<option disabled='disabled' value=''>" . eme_esc_html( $add_empty_first ) . '</option>';
+            $val .= "<option disabled='disabled' value=''>" . esc_html( $add_empty_first ) . '</option>';
         } else {
-            $val .= "<option value=''>" . eme_esc_html( $add_empty_first ) . '</option>';
+            $val .= "<option value=''>" . esc_html( $add_empty_first ) . '</option>';
         }
     }
     foreach ( $list as $key => $value ) {
         $selected = '';
         if ( is_array( $value ) ) {
             $t_key   = $value[0];
-            $t_value = eme_esc_html( $value[1] );
+            $t_value = esc_html( $value[1] );
         } else {
             $t_key   = $key;
-            $t_value = eme_esc_html( $value );
+            $t_value = esc_html( $value );
         }
         if ( ! empty( $t_key ) ) {
             if ( is_array( $option_value ) ) {
@@ -480,11 +480,11 @@ function eme_ui_multiselect( $option_value, $name, $list, $size = 5, $add_empty_
             }
         }
         if ( $t_key == 'BEGINOPTGROUP' ) {
-            $val .= "<optgroup label='" . eme_esc_html( $t_value ) . "'>";
+            $val .= "<optgroup label='" . esc_html( $t_value ) . "'>";
         } elseif ( $t_key == 'ENDOPTGROUP' ) {
             $val .= "</optgroup>";
         } else {
-            $val .= "<option value='" . eme_esc_html( $t_key ) . "' $selected>$t_value</option>";
+            $val .= "<option value='" . esc_html( $t_key ) . "' $selected>$t_value</option>";
         }
     }
     $val .= ' </select>';
@@ -510,15 +510,15 @@ function eme_ui_multiselect_key_value( $option_value, $name, $list, $key, $value
     $val = "<select $extra_attributes multiple='multiple' name='{$name}[]' id='{$id_prefix}{$name}' size='$size'>";
     if ( ! empty( $add_empty_first ) ) {
         if ($disable_first_option) {
-            $val .= "<option disabled='disabled' value=''>" . eme_esc_html( $add_empty_first ) . '</option>';
+            $val .= "<option disabled='disabled' value=''>" . esc_html( $add_empty_first ) . '</option>';
         } else {
-            $val .= "<option value=''>" . eme_esc_html( $add_empty_first ) . '</option>';
+            $val .= "<option value=''>" . esc_html( $add_empty_first ) . '</option>';
         }
     }
     foreach ( $list as $line ) {
         $selected = '';
         $t_key   = $line[ $key ];
-        $t_value = eme_esc_html( $line[ $value ] );
+        $t_value = esc_html( $line[ $value ] );
         if ( ! empty( $t_key ) ) {
             if ( is_array( $option_value ) ) {
                 if (in_array( $t_key, $option_value )) $selected = "selected='selected' ";
@@ -529,7 +529,7 @@ function eme_ui_multiselect_key_value( $option_value, $name, $list, $key, $value
         if ( empty( $t_value ) ) {
             $t_value = '&nbsp;';
         }
-        $val .= "<option value='" . eme_esc_html( $t_key ) . "' $selected>$t_value</option>";
+        $val .= "<option value='" . esc_html( $t_key ) . "' $selected>$t_value</option>";
     }
     $val .= ' </select>';
     return $val;
@@ -558,7 +558,7 @@ function eme_ui_radio( $option_value, $name, $list, $horizontal = true, $require
             $t_value = $value;
         }
         "$t_key" == $option_value ? $selected = "checked='checked' " : $selected = '';
-        $val                                 .= "<input type='radio' id='{$name}_{$counter}' name='$name' value='" . eme_esc_html( $t_key ) . "' $selected $extra_attributes>&nbsp;<label for='{$name}_{$counter}'>" . $t_value . '</label>';
+        $val                                 .= "<input type='radio' id='{$name}_{$counter}' name='$name' value='" . esc_html( $t_key ) . "' $selected $extra_attributes>&nbsp;<label for='{$name}_{$counter}'>" . $t_value . '</label>';
         if (  $horizontal ) {
             $val .= "&nbsp;";
         } else {
@@ -616,7 +616,7 @@ function eme_ui_checkbox( $option_value, $name, $list, $horizontal = true, $requ
         } else {
             "$key" == $option_value ? $selected = "checked='checked' " : $selected = '';
         }
-        $val .= "<input type='checkbox' name='{$name}[]' id='{$name}_{$counter}' value='" . eme_esc_html( $key ) . "' $selected $extra_attributes> <label for='{$name}_{$counter}'>" . $value . '</label>';
+        $val .= "<input type='checkbox' name='{$name}[]' id='{$name}_{$counter}' value='" . esc_html( $key ) . "' $selected $extra_attributes> <label for='{$name}_{$counter}'>" . $value . '</label>';
         if ( $horizontal ) {
             $val .= "&nbsp;";
         } else {

--- a/eme-widgets.php
+++ b/eme-widgets.php
@@ -114,20 +114,20 @@ class WP_Widget_eme_list extends WP_Widget {
 		$title      = isset( $instance['title'] ) ? esc_attr( $instance['title'] ) : '';
 		$format_tpl = isset( $instance['format_tpl'] ) ? intval( $instance['format_tpl'] ) : 0;
 		$limit      = isset( $instance['limit'] ) ? intval( $instance['limit'] ) : 5;
-		$scope      = empty( $instance['scope'] ) ? 'future' : eme_esc_html( $instance['scope'] );
-		$showperiod = empty( $instance['showperiod'] ) ? '' : eme_esc_html( $instance['showperiod'] );
+		$scope      = empty( $instance['scope'] ) ? 'future' : esc_html( $instance['scope'] );
+		$showperiod = empty( $instance['showperiod'] ) ? '' : esc_html( $instance['showperiod'] );
 		if ( isset( $instance['show_ongoing'] ) && ( $instance['show_ongoing'] != false ) ) {
 			$show_ongoing = true;
 		} else {
 			$show_ongoing = false;
 		}
-		$order                = empty( $instance['order'] ) ? 'ASC' : eme_esc_html( $instance['order'] );
-		$header               = empty( $instance['header'] ) ? '<ul>' : eme_esc_html( $instance['header'] );
-		$footer               = empty( $instance['footer'] ) ? '</ul>' : eme_esc_html( $instance['footer'] );
-		$category             = empty( $instance['category'] ) ? '' : eme_esc_html( $instance['category'] );
-		$notcategory          = empty( $instance['notcategory'] ) ? '' : eme_esc_html( $instance['notcategory'] );
-		$recurrence_only_once = empty( $instance['recurrence_only_once'] ) ? '' : eme_esc_html( $instance['recurrence_only_once'] );
-		$authorid             = empty( $instance['authorid'] ) ? '' : eme_esc_html( $instance['authorid'] );
+		$order                = empty( $instance['order'] ) ? 'ASC' : esc_html( $instance['order'] );
+		$header               = empty( $instance['header'] ) ? '<ul>' : esc_html( $instance['header'] );
+		$footer               = empty( $instance['footer'] ) ? '</ul>' : esc_html( $instance['footer'] );
+		$category             = empty( $instance['category'] ) ? '' : esc_html( $instance['category'] );
+		$notcategory          = empty( $instance['notcategory'] ) ? '' : esc_html( $instance['notcategory'] );
+		$recurrence_only_once = empty( $instance['recurrence_only_once'] ) ? '' : esc_html( $instance['recurrence_only_once'] );
+		$authorid             = empty( $instance['authorid'] ) ? '' : esc_html( $instance['authorid'] );
 		$categories           = eme_get_categories();
 		$option_categories    = [];
 		foreach ( $categories as $cat ) {
@@ -135,9 +135,9 @@ class WP_Widget_eme_list extends WP_Widget {
 			$option_categories[ $id ] = $cat['category_name'];
 		}
 		if ( empty( $instance['format_tpl'] ) && eme_is_empty_string( $instance['format'] ) ) {
-			$format = eme_esc_html( DEFAULT_WIDGET_EVENT_LIST_ITEM_FORMAT );
+			$format = esc_html( DEFAULT_WIDGET_EVENT_LIST_ITEM_FORMAT );
 		} elseif ( empty( $instance['format_tpl'] ) && ! eme_is_empty_string( $instance['format'] ) ) {
-			$format = eme_esc_html( $instance['format'] );
+			$format = esc_html( $instance['format'] );
 		} else {
 			$format = '';
 		}
@@ -154,7 +154,7 @@ class WP_Widget_eme_list extends WP_Widget {
 	</p>
 	<p>
 	<label for="<?php echo esc_attr( $this->get_field_id( 'scope' ) ); ?>"><?php esc_html_e( 'Scope of the events', 'events-made-easy' ); ?><br><?php esc_html_e( '(See the doc for &#91;eme_events] for all possible values)', 'events-made-easy' ); ?>:</label><br>
-	<input type="text" id="<?php echo esc_attr( $this->get_field_id( 'scope' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'scope' ) ); ?>" value="<?php echo $scope; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- already eme_esc_html() on line 117 ?>">
+	<input type="text" id="<?php echo esc_attr( $this->get_field_id( 'scope' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'scope' ) ); ?>" value="<?php echo $scope; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- already esc_html() on line 117 ?>">
 	</p>
 	<p>
 	<label for="<?php echo esc_attr( $this->get_field_id( 'showperiod' ) ); ?>"><?php esc_html_e( 'Show events per period', 'events-made-easy' ); ?>:</label><br>
@@ -217,7 +217,7 @@ class WP_Widget_eme_list extends WP_Widget {
 	</p>
 	<p>
 	<label for="<?php echo esc_attr( $this->get_field_id( 'header' ) ); ?>"><?php esc_html_e( 'List header format<br>(if empty &lt;ul&gt; is used)', 'events-made-easy' ); ?>: </label>
-	<input type="text" id="<?php echo esc_attr( $this->get_field_id( 'header' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'header' ) ); ?>" value="<?php echo $header; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- already eme_esc_html() on line 125 ?>">
+	<input type="text" id="<?php echo esc_attr( $this->get_field_id( 'header' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'header' ) ); ?>" value="<?php echo $header; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- already esc_html() on line 125 ?>">
 	</p>
 	<p>
 	<label for="<?php echo esc_attr( $this->get_field_id( 'format_tpl' ) ); ?>"><?php esc_html_e( 'List item format', 'events-made-easy' ); ?>:</label>
@@ -228,11 +228,11 @@ class WP_Widget_eme_list extends WP_Widget {
 	</p> 
 	<p>
 	<label for="<?php echo esc_attr( $this->get_field_id( 'format' ) ); ?>"><?php esc_html_e( 'Or enter your own (if anything is entered here, it takes precedence over the selected template): ', 'events-made-easy' ); ?>:</label>
-	<textarea id="<?php echo esc_attr( $this->get_field_id( 'format' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'format' ) ); ?>" rows="5" cols="24"><?php echo $format; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- already eme_esc_html() on lines 138/140 ?></textarea>
+	<textarea id="<?php echo esc_attr( $this->get_field_id( 'format' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'format' ) ); ?>" rows="5" cols="24"><?php echo $format; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- already esc_html() on lines 138/140 ?></textarea>
 	</p> 
 	<p>
 	<label for="<?php echo esc_attr( $this->get_field_id( 'footer' ) ); ?>"><?php esc_html_e( 'List footer format<br>(if empty &lt;/ul&gt; is used)', 'events-made-easy' ); ?>: </label>
-	<input type="text" id="<?php echo esc_attr( $this->get_field_id( 'footer' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'footer' ) ); ?>" value="<?php echo $footer; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- already eme_esc_html() on line 126 ?>">
+	<input type="text" id="<?php echo esc_attr( $this->get_field_id( 'footer' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'footer' ) ); ?>" value="<?php echo $footer; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- already esc_html() on line 126 ?>">
 	</p>
 		<?php
 	}
@@ -315,10 +315,10 @@ class WP_Widget_eme_calendar extends WP_Widget {
 		//Defaults
 		$instance             = wp_parse_args( (array) $instance, [ 'long_events' => 0 ] );
 		$title                = isset( $instance['title'] ) ? esc_attr( $instance['title'] ) : '';
-		$category             = empty( $instance['category'] ) ? '' : eme_esc_html( $instance['category'] );
-		$notcategory          = empty( $instance['notcategory'] ) ? '' : eme_esc_html( $instance['notcategory'] );
-		$long_events          = isset( $instance['long_events'] ) ? eme_esc_html( $instance['long_events'] ) : false;
-		$authorid             = isset( $instance['authorid'] ) ? eme_esc_html( $instance['authorid'] ) : '';
+		$category             = empty( $instance['category'] ) ? '' : esc_html( $instance['category'] );
+		$notcategory          = empty( $instance['notcategory'] ) ? '' : esc_html( $instance['notcategory'] );
+		$long_events          = isset( $instance['long_events'] ) ? esc_html( $instance['long_events'] ) : false;
+		$authorid             = isset( $instance['authorid'] ) ? esc_html( $instance['authorid'] ) : '';
 		$holiday_id           = isset( $instance['holiday_id'] ) ? intval( $instance['holiday_id'] ) : 0;
 		$categories           = eme_get_categories();
 		$holidays_array_by_id = eme_get_holidays_array_by_id();


### PR DESCRIPTION
## Summary

Addresses two items from the [issue #919 priorities](https://github.com/liedekef/events-made-easy/issues/919#issuecomment-4004679921):

1. **Fix MissingArgDomain + TextDomainMismatch PCP warnings** (18 fixes across 7 files)
2. **Replace eme_esc_html() with esc_html()** where safe (455 of 461 calls across 22 files)

### Text domain fixes

- 8x `'events_made_easy'` (underscore) changed to `'events-made-easy'`
- 4x `'event-made-easy'` (missing 's') changed to `'events-made-easy'`
- 3x missing text domain argument added
- 3x `phpcs:ignore` for intentional WP core weekday translations (`$wp_locale`)

### eme_esc_html() cleanup

`eme_esc_html()` is a wrapper around `esc_html()` with extra null/array handling. PHPCS doesn't recognize it as an escaping function.

- **455 calls replaced** with `esc_html()` (scalar strings) or `array_map('esc_html', ...)` (arrays)
- **Bug fix**: 12 calls used `eme_esc_html('text', 'events-made-easy')` where the text domain was silently ignored (function only takes 1 param). Changed to `esc_html__()` for correct translation + escaping
- **1 double-escaping fix**: removed redundant escape in eme-rsvp.php
- **6 calls kept**: 4 function definitions + 2 `eme_unserialize()` calls (returns mixed types)
- Function definition preserved in eme-functions.php

## Test plan

- [x] `php -l` on all 23 files (passed)
- [x] 76/76 runtime tests pass
- [x] PCP: 0 errors
- [ ] Verify admin pages render correctly (events, members, people, mailer)
- [ ] Verify GDPR export/erase names show correctly
- [ ] Verify mailer form labels are translated