### PR TITLE
Fix license mismatch in readme.txt (issue #919)

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -6,8 +6,8 @@ Requires at least: 6.0
 Tested up to: 6.9
 Stable tag: 3.0.50
 Requires PHP: 8.0
-License: GPLv3 or later
-License URI: https://www.gnu.org/licenses/gpl.html
+License: GPLv2 or later
+License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
 Manage and display events, memberships, recurring events, locations and maps, volunteers, widgets, RSVP, ICAL and RSS feeds, payment gateways support. SEO compatible.
              


### PR DESCRIPTION
## Summary

- readme.txt declared `GPLv3 or later` while the plugin header (events-manager.php) and LICENSE file both declare GPLv2
- Aligned readme.txt to `GPLv2 or later` with version-specific URI, matching WordPress itself
- Per liedekef's confirmation on issue #919

## Changes

| File | Change |
|---|---|
| readme.txt | `License: GPLv3 or later` -> `GPLv2 or later` |
| readme.txt | `License URI:` -> `https://www.gnu.org/licenses/gpl-2.0.html` |

## Test plan

- [x] 76/76 tests pass
- [x] PCP 0 errors / 0 warnings
- [x] License now consistent across readme.txt, plugin header, and LICENSE file