### PR TITLE
Fix own-code PCP errors: singular placeholders, translators comment, license header (Batch B)

### DIFF
--- a/eme-options.php
+++ b/eme-options.php
@@ -2745,8 +2745,8 @@ if (!empty($webhook_id)) {
 } else {
     $err_txt = get_option('eme_paypal_webhook_error');
     if (!empty($err_txt)) {
-        // translators: %s is the error reason
         echo "<tr><td colspan='2' class='notice notice-warning'>" .
+            // translators: %s is the error reason
             sprintf( esc_html__( 'WARNING: webhook has not been created. Reason: %s', 'events-made-easy' ), esc_html($err_txt) ) .
             '</td></tr>';
     } else {

--- a/eme-people.php
+++ b/eme-people.php
@@ -5458,7 +5458,7 @@ function eme_ajax_groups_list() {
                 $count        = $wpdb->get_var( $count_sql ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
                 if ( $count > 0 ) {
                     // translators: %d is the number of persons in the group
-                    $record['groupcount'] .= '&nbsp;' . sprintf( _n( '(1 person)', '(%d persons)', $count, 'events-made-easy' ), $count );
+                    $record['groupcount'] .= '&nbsp;' . sprintf( _n( '(%d person)', '(%d persons)', $count, 'events-made-easy' ), $count );
                 }
             }
         } elseif ( $group['type'] == 'dynamic_members' ) {
@@ -5469,7 +5469,7 @@ function eme_ajax_groups_list() {
                 $count        = $wpdb->get_var( $count_sql ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
                 if ( $count > 0 ) {
                     // translators: %d is the number of members in the group
-                    $record['groupcount'] .= '&nbsp;' . sprintf( _n( '(1 member)', '(%d members)', $count, 'events-made-easy' ), $count );
+                    $record['groupcount'] .= '&nbsp;' . sprintf( _n( '(%d member)', '(%d members)', $count, 'events-made-easy' ), $count );
                 }
             }
         } else {

--- a/eme-tasks.php
+++ b/eme-tasks.php
@@ -943,7 +943,7 @@ function eme_meta_box_div_event_tasks( $event, $edit_recurrence = 0 ) {
                     if ($count_signups>0) {
                         echo "<span name='eme_tasks[" . intval($count) . "][signup_count]' id='eme_tasks[" . intval($count) . "][signup_count]'><br>";
                         // translators: %d is the number of persons signed up
-                        echo esc_html(sprintf( _n( 'One person already signed up for this task','%d persons already signed up for this task', $count_signups, 'events-made-easy' ), $count_signups ));
+                        echo esc_html(sprintf( _n( '%d person already signed up for this task','%d persons already signed up for this task', $count_signups, 'events-made-easy' ), $count_signups ));
                         echo "</span>";
                     }
                 }

--- a/events-manager.php
+++ b/events-manager.php
@@ -14,6 +14,8 @@ Author: Franky Van Liedekerke
 Author URI: https://www.e-dynamics.be/
 Text Domain: events-made-easy
 Domain Path: /langs
+License: GPLv2 or later
+License URI: https://www.gnu.org/licenses/gpl-2.0.html
 */
 
 /*

--- a/langs/events-made-easy-de_DE.po
+++ b/langs/events-made-easy-de_DE.po
@@ -12500,9 +12500,9 @@ msgstr "Dynamische Gruppe von Personen"
 
 #. translators: %d is the number of persons in the group
 #: eme-people.php:5461
-msgid "(1 person)"
+msgid "(%d person)"
 msgid_plural "(%d persons)"
-msgstr[0] "(1 Person)"
+msgstr[0] "(%d Person)"
 msgstr[1] "(%d Personen)"
 
 #: eme-people.php:5465
@@ -12511,9 +12511,9 @@ msgstr "Dynamische Gruppe von Mitgliedern"
 
 #. translators: %d is the number of members in the group
 #: eme-people.php:5472
-msgid "(1 member)"
+msgid "(%d member)"
 msgid_plural "(%d members)"
-msgstr[0] "(1 Mitglied)"
+msgstr[0] "(%d Mitglied)"
 msgstr[1] "(%d Mitglieder)"
 
 #: eme-people.php:5732
@@ -14362,9 +14362,9 @@ msgstr "Eine maximale Kapazität für den Standort ist festgelegt. Wenn das Maxi
 
 #. translators: %d is the number of persons signed up
 #: eme-tasks.php:946
-msgid "One person already signed up for this task"
+msgid "%d person already signed up for this task"
 msgid_plural "%d persons already signed up for this task"
-msgstr[0] "Eine Person hat sich bereits für diese Aufgabe angemeldet"
+msgstr[0] "%d Person hat sich bereits für diese Aufgabe angemeldet"
 msgstr[1] "%d Personen haben sich bereits für diese Aufgabe angemeldet"
 
 #: eme-functions.php:1477

--- a/langs/events-made-easy-fr_FR.po
+++ b/langs/events-made-easy-fr_FR.po
@@ -12491,9 +12491,9 @@ msgstr "Groupe dynamique de personnes"
 
 #. translators: %d is the number of persons in the group
 #: eme-people.php:5461
-msgid "(1 person)"
+msgid "(%d person)"
 msgid_plural "(%d persons)"
-msgstr[0] "(1 personne)"
+msgstr[0] "(%d personne)"
 msgstr[1] "(%d personnes)"
 
 #: eme-people.php:5465
@@ -12502,9 +12502,9 @@ msgstr "Groupe dynamique de membres"
 
 #. translators: %d is the number of members in the group
 #: eme-people.php:5472
-msgid "(1 member)"
+msgid "(%d member)"
 msgid_plural "(%d members)"
-msgstr[0] "(1 membre)"
+msgstr[0] "(%d membre)"
 msgstr[1] "(%d membres)"
 
 #: eme-people.php:5732
@@ -14335,9 +14335,9 @@ msgstr "Une capacité maximale de lieu est définie. Si le maximum de votre év�
 
 #. translators: %d is the number of persons signed up
 #: eme-tasks.php:946
-msgid "One person already signed up for this task"
+msgid "%d person already signed up for this task"
 msgid_plural "%d persons already signed up for this task"
-msgstr[0] "Une personne s'est déjà inscrite pour cette tâche"
+msgstr[0] "%d personne s'est déjà inscrite pour cette tâche"
 msgstr[1] "%d personnes se sont déjà inscrites pour cette tâche"
 
 #: eme-functions.php:4313

--- a/langs/events-made-easy-nl_BE.po
+++ b/langs/events-made-easy-nl_BE.po
@@ -12493,9 +12493,9 @@ msgstr "Dynamische groep van personen"
 
 #. translators: %d is the number of persons in the group
 #: eme-people.php:5461
-msgid "(1 person)"
+msgid "(%d person)"
 msgid_plural "(%d persons)"
-msgstr[0] "(1 persoon)"
+msgstr[0] "(%d persoon)"
 msgstr[1] "(%d personen)"
 
 #: eme-people.php:5465
@@ -12504,9 +12504,9 @@ msgstr "Dynamische groep van leden"
 
 #. translators: %d is the number of members in the group
 #: eme-people.php:5472
-msgid "(1 member)"
+msgid "(%d member)"
 msgid_plural "(%d members)"
-msgstr[0] "(1 lid)"
+msgstr[0] "(%d lid)"
 msgstr[1] "(%d leden)"
 
 #: eme-people.php:5732
@@ -14337,9 +14337,9 @@ msgstr ""
 
 #. translators: %d is the number of persons signed up
 #: eme-tasks.php:946
-msgid "One person already signed up for this task"
+msgid "%d person already signed up for this task"
 msgid_plural "%d persons already signed up for this task"
-msgstr[0] "Eén persoon heeft zich al aangemeld voor deze taak"
+msgstr[0] "%d persoon heeft zich al aangemeld voor deze taak"
 msgstr[1] "%d personen hebben zich al aangemeld voor deze taak"
 
 #: eme-functions.php:4313

--- a/langs/events-made-easy-nl_NL.po
+++ b/langs/events-made-easy-nl_NL.po
@@ -12493,9 +12493,9 @@ msgstr "Dynamische groep van personen"
 
 #. translators: %d is the number of persons in the group
 #: eme-people.php:5461
-msgid "(1 person)"
+msgid "(%d person)"
 msgid_plural "(%d persons)"
-msgstr[0] "(1 persoon)"
+msgstr[0] "(%d persoon)"
 msgstr[1] "(%d personen)"
 
 #: eme-people.php:5465
@@ -12504,9 +12504,9 @@ msgstr "Dynamische groep van leden"
 
 #. translators: %d is the number of members in the group
 #: eme-people.php:5472
-msgid "(1 member)"
+msgid "(%d member)"
 msgid_plural "(%d members)"
-msgstr[0] "(1 lid)"
+msgstr[0] "(%d lid)"
 msgstr[1] "(%d leden)"
 
 #: eme-people.php:5732
@@ -14337,9 +14337,9 @@ msgstr ""
 
 #. translators: %d is the number of persons signed up
 #: eme-tasks.php:946
-msgid "One person already signed up for this task"
+msgid "%d person already signed up for this task"
 msgid_plural "%d persons already signed up for this task"
-msgstr[0] "Eén persoon heeft zich al aangemeld voor deze taak"
+msgstr[0] "%d persoon heeft zich al aangemeld voor deze taak"
 msgstr[1] "%d personen hebben zich al aangemeld voor deze taak"
 
 #: eme-functions.php:4313

--- a/langs/events-made-easy-sk_SK.po
+++ b/langs/events-made-easy-sk_SK.po
@@ -13028,9 +13028,9 @@ msgstr "Dynamická skupina ľudí"
 
 #. translators: %d is the number of persons in the group
 #: eme-people.php:5461
-msgid "(1 person)"
+msgid "(%d person)"
 msgid_plural "(%d persons)"
-msgstr[0] "(1 osoba)"
+msgstr[0] "(%d osoba)"
 msgstr[1] "(%d osoby)"
 msgstr[2] "(%d osôb)"
 
@@ -13040,9 +13040,9 @@ msgstr "Dynamická skupina členov"
 
 #. translators: %d is the number of members in the group
 #: eme-people.php:5472
-msgid "(1 member)"
+msgid "(%d member)"
 msgid_plural "(%d members)"
-msgstr[0] "(1 člen)"
+msgstr[0] "(%d člen)"
 msgstr[1] "(%d členovia)"
 msgstr[2] "(%d členov)"
 
@@ -14343,7 +14343,7 @@ msgstr ""
 
 #. translators: %d is the number of persons signed up
 #: eme-tasks.php:946
-msgid "One person already signed up for this task"
+msgid "%d person already signed up for this task"
 msgid_plural "%d persons already signed up for this task"
 msgstr[0] ""
 msgstr[1] ""

--- a/langs/events-made-easy-sv_SE.po
+++ b/langs/events-made-easy-sv_SE.po
@@ -12535,7 +12535,7 @@ msgstr "Dynamisk grupp av personer"
 
 #. translators: %d is the number of persons in the group
 #: eme-people.php:5461
-msgid "(1 person)"
+msgid "(%d person)"
 msgid_plural "(%d persons)"
 msgstr[0] ""
 msgstr[1] ""
@@ -12546,7 +12546,7 @@ msgstr "Medlemmar i dynamisk grupp"
 
 #. translators: %d is the number of members in the group
 #: eme-people.php:5472
-msgid "(1 member)"
+msgid "(%d member)"
 msgid_plural "(%d members)"
 msgstr[0] ""
 msgstr[1] ""
@@ -14404,7 +14404,7 @@ msgstr ""
 
 #. translators: %d is the number of persons signed up
 #: eme-tasks.php:946
-msgid "One person already signed up for this task"
+msgid "%d person already signed up for this task"
 msgid_plural "%d persons already signed up for this task"
 msgstr[0] ""
 msgstr[1] ""

--- a/langs/events-made-easy-zh_CN.po
+++ b/langs/events-made-easy-zh_CN.po
@@ -12542,7 +12542,7 @@ msgstr "动态的人们群组"
 
 #. translators: %d is the number of persons in the group
 #: eme-people.php:5461
-msgid "(1 person)"
+msgid "(%d person)"
 msgid_plural "(%d persons)"
 msgstr[0] "（%d 个人）"
 
@@ -12552,7 +12552,7 @@ msgstr "动态的会员群组"
 
 #. translators: %d is the number of members in the group
 #: eme-people.php:5472
-msgid "(1 member)"
+msgid "(%d member)"
 msgid_plural "(%d members)"
 msgstr[0] "（%d 名成员）"
 
@@ -14409,7 +14409,7 @@ msgstr ""
 
 #. translators: %d is the number of persons signed up
 #: eme-tasks.php:946
-msgid "One person already signed up for this task"
+msgid "%d person already signed up for this task"
 msgid_plural "%d persons already signed up for this task"
 msgstr[0] ""
 

--- a/langs/events-made-easy.pot
+++ b/langs/events-made-easy.pot
@@ -14003,7 +14003,7 @@ msgstr ""
 
 #. translators: %d is the number of persons in the group
 #: eme-people.php:5461
-msgid "(1 person)"
+msgid "(%d person)"
 msgid_plural "(%d persons)"
 msgstr[0] ""
 msgstr[1] ""
@@ -14014,7 +14014,7 @@ msgstr ""
 
 #. translators: %d is the number of members in the group
 #: eme-people.php:5472
-msgid "(1 member)"
+msgid "(%d member)"
 msgid_plural "(%d members)"
 msgstr[0] ""
 msgstr[1] ""
@@ -14653,7 +14653,7 @@ msgstr ""
 
 #. translators: %d is the number of persons signed up
 #: eme-tasks.php:946
-msgid "One person already signed up for this task"
+msgid "%d person already signed up for this task"
 msgid_plural "%d persons already signed up for this task"
 msgstr[0] ""
 msgstr[1] ""

--- a/payment_gateways/paypal/class_eme_paypal.php
+++ b/payment_gateways/paypal/class_eme_paypal.php
@@ -25,11 +25,13 @@ class EME_PayPal_Client {
         ]);
 
         if ( is_wp_error( $response ) ) {
+            // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped
             throw new Exception( 'PayPal auth error: ' . $response->get_error_message() );
         }
 
         $data = json_decode( wp_remote_retrieve_body( $response ), true );
         if ( empty( $data['access_token'] ) ) {
+            // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped
             throw new Exception( 'PayPal: failed to obtain access token' );
         }
 
@@ -55,6 +57,7 @@ class EME_PayPal_Client {
         $response = wp_remote_request( $url, $args );
 
         if ( is_wp_error( $response ) ) {
+            // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped
             throw new Exception( "PayPal API error ({$endpoint}): " . $response->get_error_message() );
         }
 
@@ -63,6 +66,7 @@ class EME_PayPal_Client {
 
         $code = wp_remote_retrieve_response_code( $response );
         if ( $code < 200 || $code >= 300 ) {
+            // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped
             throw new Exception( "PayPal API error ({$endpoint}): HTTP {$code}, " . print_r( $data, true ) );
         }
 
@@ -137,12 +141,14 @@ class EME_PayPal_Client {
         $required = ['Paypal-Transmission-Id', 'Paypal-Transmission-Time', 'Paypal-Transmission-Sig', 'Paypal-Cert-Url', 'Paypal-Auth-Algo'];
         foreach ( $required as $h ) {
             if ( ! isset( $headers[ $h ] ) ) {
+                // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped
                 throw new Exception( "Missing header: $h" );
             }
         }
 
         $webhook_id = get_option( 'eme_paypal_webhook_id' );
         if ( ! $webhook_id ) {
+            // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped
             throw new Exception( 'Webhook ID not configured' );
         }
 


### PR DESCRIPTION
## Summary

- Fix MissingSingularPlaceholder in `_n()` calls (eme-people.php 2x, eme-tasks.php 1x)
- Fix MissingTranslatorsComment placement in eme-options.php
- Add `phpcs:ignore` for ExceptionNotEscaped in class_eme_paypal.php (6x)
- Add License header to events-manager.php plugin header
- Update 7 .po + 1 .pot translation files for changed `_n()` singular forms
- Reduces PCP error count from 673 to 662 (-11)

## Details

**MissingSingularPlaceholder (3x):** `_n()` singular forms used hardcoded "1" or "One" instead of `%d`. Translators need the placeholder to position the number correctly in different languages.

**MissingTranslatorsComment (1x):** Comment was on wrong line (above `echo` instead of directly above the `sprintf(esc_html__())` call).

**ExceptionNotEscaped (6x):** EME's own PayPal wrapper throws exceptions with internal error messages. Added `phpcs:ignore` since exception messages are not rendered to end users.

**License header (1x):** Added `License: GPLv2 or later` + `License URI` to the plugin header docblock.

## Files changed (13)

5 own code + 8 translation files

## Test results

- PHP lint: clean on all 5 own code files
- Tests: 76/76 pass
- PCP: 673 -> 662 errors (-11)
- Controleslag: 8/8 checks pass

## Batch plan context

This is **Batch B** of the PCP error reduction plan (see issue #919):
- [x] Batch A: MissingTranslatorsComment + UnorderedPlaceholders (-339 errors) -- PR #957
- [x] Batch B: Own code fixes (-11 errors) -- this PR
- [ ] Batch C: AlternativeFunctions + date (~100 errors)
- [ ] Batch D: OutputNotEscaped + PreparedSQL (~200 errors)

Note: ~230 PCP errors in third-party payment gateway SDKs are left as-is per maintainer preference (PR #958 feedback). These can be addressed via the release sync script or accepted as vendor code limitations.