### PR TITLE
Pilot: use %i identifier placeholder in eme-cleanup.php (#919)

### DIFF
--- a/events-manager.php
+++ b/events-manager.php
@@ -14,6 +14,7 @@ Author: Franky Van Liedekerke
 Author URI: https://www.e-dynamics.be/
 Text Domain: events-made-easy
 Domain Path: /langs
+Requires at least: 6.2
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 */

--- a/includes/eme-cleanup.php
+++ b/includes/eme-cleanup.php
@@ -47,7 +47,7 @@ function eme_cleanup_trashed_people( $eme_number, $eme_period ) {
         break;
     }
     $datetime   = $eme_date_obj->getDateTime();
-    $prepared_sql = $wpdb->prepare( "SELECT person_id FROM $people_table WHERE modif_date < %s AND status = %d", $datetime, EME_PEOPLE_STATUS_TRASH ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+    $prepared_sql = $wpdb->prepare( 'SELECT person_id FROM %i WHERE modif_date < %s AND status = %d', $people_table, $datetime, EME_PEOPLE_STATUS_TRASH );
     $person_ids   = $wpdb->get_col( $prepared_sql ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
     $count      = count( $person_ids );
     $tmp_ids    = join( ',', $person_ids );
@@ -181,11 +181,11 @@ function eme_cleanup_events( $eme_number, $eme_period ) {
     }
     $end_datetime = $eme_date_obj->getDateTime();
     $end_date     = $eme_date_obj->getDate();
-    $wpdb->query( $wpdb->prepare( "DELETE FROM $bookings_table WHERE event_id IN (SELECT event_id FROM $events_table WHERE event_end<%s)", $end_datetime ) ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-    $wpdb->query( $wpdb->prepare( "DELETE FROM $answers_table WHERE type='event' AND related_id IN (SELECT event_id FROM $events_table WHERE event_end<%s)", $end_datetime ) ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-    $wpdb->query( $wpdb->prepare( "DELETE FROM $attendances_table WHERE type='event' AND related_id in (SELECT event_id FROM $events_table WHERE event_end<%s)", $end_datetime ) ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-    $wpdb->query( $wpdb->prepare( "DELETE FROM $events_table WHERE event_end<%s", $end_datetime ) ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-    $wpdb->query( $wpdb->prepare( "DELETE FROM $recurrence_table where recurrence_freq <> 'specific' AND recurrence_end_date<%s", $end_date ) ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+    $wpdb->query( $wpdb->prepare( 'DELETE FROM %i WHERE event_id IN (SELECT event_id FROM %i WHERE event_end<%s)', $bookings_table, $events_table, $end_datetime ) );
+    $wpdb->query( $wpdb->prepare( "DELETE FROM %i WHERE type='event' AND related_id IN (SELECT event_id FROM %i WHERE event_end<%s)", $answers_table, $events_table, $end_datetime ) );
+    $wpdb->query( $wpdb->prepare( "DELETE FROM %i WHERE type='event' AND related_id in (SELECT event_id FROM %i WHERE event_end<%s)", $attendances_table, $events_table, $end_datetime ) );
+    $wpdb->query( $wpdb->prepare( 'DELETE FROM %i WHERE event_end<%s', $events_table, $end_datetime ) );
+    $wpdb->query( $wpdb->prepare( "DELETE FROM %i where recurrence_freq <> 'specific' AND recurrence_end_date<%s", $recurrence_table, $end_date ) );
 }
 
 function eme_cleanup_all_event_related_data( $other_data ) {
@@ -197,7 +197,7 @@ function eme_cleanup_all_event_related_data( $other_data ) {
         $tables  = array_merge( $tables, $tables2 );
     }
     foreach ( $tables as $table ) {
-        $wpdb->query( 'DELETE FROM ' . EME_DB_PREFIX . $table ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- table name is a safe variable
+        $wpdb->query( $wpdb->prepare( 'DELETE FROM %i', EME_DB_PREFIX . $table ) );
     }
 }
 


### PR DESCRIPTION
## Pilot for issue #919 — `%i` identifier placeholder migration

Per your reopened comment on #919: WP 6.2's `%i` placeholder for table/field names. Pilot file `includes/eme-cleanup.php` so you can sanity-check the conversion pattern before we roll it out across the rest of the codebase.

### Changes

**`events-manager.php`** — added `Requires at least: 6.2` to the plugin header. Required prerequisite: PCP/WPCS reads the minimum WP version from the plugin file header (since WP 5.8, not from readme.txt), and without it the sniff defaults below 6.2 and flags every `%i` as `UnsupportedIdentifierPlaceholder`. Tested: with header present, all 10 `%i` errors disappear.

**`includes/eme-cleanup.php`** — 7 `phpcs:ignore` comments removed:

- 6× `\$wpdb->prepare("... FROM \$table_var ...", ...)` → `prepare("... FROM %i ...", \$table_var, ...)` — removes `InterpolatedNotPrepared` ignores (lines 50, 184–188).
- 1× `\$wpdb->query('DELETE FROM ' . EME_DB_PREFIX . \$table)` → `\$wpdb->query(\$wpdb->prepare('DELETE FROM %i', EME_DB_PREFIX . \$table))` — removes the `NotPrepared -- table name is a safe variable` ignore (line 200), now PHPCS-verified rather than "trust me".

### Out of scope (intentionally — pilot)

- Multi-table queries with `\$table.column` notation (lines 14, 104, 119, 145) — `%i` versions get verbose (`prepare("SELECT %i.col FROM %i ...", \$t, \$t, ...)`); raised in #919 issue comment.
- `NotPrepared` ignores on `\$wpdb->get_*(\$prepared_sql)` cross-line cases — separate PHPCS limitation, not addressed by `%i`.

## Test results

Tested against containerized WordPress 6.7 + PHP 8.2 + MariaDB.

| Suite | Result |
|-------|--------|
| Static analysis (`code-checks.sh`) | 4 passed, 0 failed, 0 warnings |
| PHP lint | clean |
| Plugin Check (PCP) | 497 → 488 errors. All 10 new `UnsupportedIdentifierPlaceholder` resolved by the header line; 7 ignores removed without introducing new errors. |
| Smoke tests | 8/9 passed (1 fail = pre-existing test-script hardcoded DB version mismatch, unrelated) |
| CRUD workflows | 11/11 passed, no new PHP errors |
| Admin / AJAX / Admin Form HTTP tests | skipped due to pre-existing container login session issue, unrelated to this change |
| Functional verification | All 6 cleanup functions executed without fatals; direct `%i` query verified to produce \`\`DELETE FROM \`wp_eme_bookings\` WHERE event_id IN (SELECT event_id FROM \`wp_eme_events\` ...)\`\` (backticks correctly applied) |

<details>
<summary>Full test output</summary>

**Static analysis (`bash code-checks.sh`)**
\`\`\`
=== Events Made Easy — Code Analysis ===

[Nonce Consistency]
  PASS  All GET URLs with eme_admin_action have wp_nonce_url() wrapping
  PASS  No check_admin_referer() in eme_actions_init (GET URLs don't need nonces yet)

[Capability Checks]

[Input Sanitization]
  PASS  No direct superglobal usage in SQL queries found

[ABSPATH Protection]
  PASS  All PHP files have ABSPATH protection

[WP Store Readiness]
  INFO  Unescaped output: ~0 (target: 0)
  INFO  \$wpdb without prepare(): ~0 (target: 0)
  INFO  Unsanitized superglobals: ~0 (target: 0)
  INFO  Files with inline <script>: 0 / <style>: 0 (target: 0)
  INFO  Text domain issues: ~0 (target: 0)
  INFO  Unescaped translations in attributes: ~0 (target: 0)
  INFO  Unescaped translations in link text: ~0 (target: 0)
  INFO  eme_ui_* echo without phpcs:ignore: ~0 (target: 0)
  INFO  wp_nonce_field echo without phpcs:ignore: ~0 (target: 0)
  INFO  esc_html in placeholder attributes: ~0 (target: 0)
  INFO  Unprefixed functions: 0 (target: 0)

=== Results: 4 passed, 0 failed, 0 warnings ===
\`\`\`

**Runtime tests (`bash run-tests.sh`)**
\`\`\`
=== Events Made Easy — Runtime Test Suite (6 layers) ===

[1/6] Smoke Tests
  PASS  Plugin is active
  PASS  No PHP fatal errors in debug.log
  PASS  PHP syntax check (39 files)
  FAIL  DB version = 423 (expected 421)
  PASS  25 database tables exist
  PASS  10/10 core shortcodes registered
  PASS  2/2 widgets registered
  PASS  REST route registered
  PASS  Events page created

[2/6] Admin Page HTTP Tests
  FAIL  Could not login via HTTP — skipping admin page tests

[3/6] AJAX Endpoint Tests
  FAIL  Could not login via HTTP — skipping AJAX tests

[4/6] Plugin Check — WP Store Readiness
  INFO  PCP errors: 488 / warnings: 6546

  Top errors by code:
        160 WordPress.Security.EscapeOutput.OutputNotEscaped
         99 WordPress.Security.EscapeOutput.ExceptionNotEscaped
         62 missing_direct_file_access_protection
         29 Generic.PHP.DisallowShortOpenTag.EchoFound
         21 WordPress.WP.AlternativeFunctions.curl_curl_setopt
         14 WordPress.DB.PreparedSQL.NotPrepared
          ...

[5/6] CRUD Workflow Tests
  PASS  Location create → read → delete
  PASS  Category create → read → delete
  PASS  Person create → read → trash → cleanup
  PASS  Discount create → read → delete
  PASS  Template create → read → delete
  PASS  Holiday create → read → parse → delete
  PASS  Event create → read → verify → delete
  PASS  Booking workflow
  PASS  Membership workflow
  PASS  Group workflow
  PASS  Recurrence (weekly → 5 events)
  PASS  No new PHP errors during CRUD operations

[6/6] Admin Form CRUD Tests
  FAIL  Could not login via HTTP — skipping admin form CRUD tests

=== Results: 20 passed, 4 failed ===
\`\`\`

(The 4 failures are pre-existing test infrastructure issues, not introduced by this PR — the test script has a hardcoded expected DB version that's older than the current plugin, and the containerized WP installation has a stale admin session for the HTTP login. Neither relates to the `%i` conversion.)

</details>

See issue #919 for the open scope question before the bigger batch PR.